### PR TITLE
Add namespace creation to apply output

### DIFF
--- a/internal/flags/package.go
+++ b/internal/flags/package.go
@@ -1,9 +1,5 @@
 package flags
 
-import (
-	"fmt"
-)
-
 type Package string
 
 func (f *Package) String() string {
@@ -31,5 +27,5 @@ func (f *Package) Shorthand() string {
 }
 
 func (f *Package) Description() string {
-	return fmt.Sprintf("The name of the module's package used for building the templates. (default \"%s\")", f.Default())
+	return "The name of the module's package used for building the templates."
 }

--- a/internal/runtime/storage.go
+++ b/internal/runtime/storage.go
@@ -159,6 +159,29 @@ func (s *StorageManager) GetStaleObjects(ctx context.Context, i *apiv1.Instance)
 	return objects, nil
 }
 
+// NamespaceExists returns false if the namespace is not found.
+func (s *StorageManager) NamespaceExists(ctx context.Context, name string) (bool, error) {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := s.resManager.Client().Get(ctx, client.ObjectKeyFromObject(ns), ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
 // getOwnerLabels returns a label selector matching the storage owner.
 func (s *StorageManager) getOwnerLabels() client.MatchingLabels {
 	return client.MatchingLabels{


### PR DESCRIPTION
When the instance namespace does not exist, log its creation in the `timoni apply` output.