### PR TITLE
Introduce annotations for prune and force behaviour

### DIFF
--- a/api/v1alpha1/actions.go
+++ b/api/v1alpha1/actions.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "fmt"
+
+const (
+	EnabledValue  = "enabled"
+	DisabledValue = "disabled"
+)
+
+var (
+	// PruneAction is the annotation that defines if a Kubernetes resource should be garbage collected.
+	PruneAction = fmt.Sprintf("action.%s/prune", GroupVersion.Group)
+
+	// ForceAction is the annotation that defines if a Kubernetes resource should be recreated.
+	ForceAction = fmt.Sprintf("action.%s/force", GroupVersion.Group)
+)

--- a/cmd/timoni/delete_test.go
+++ b/cmd/timoni/delete_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+func TestDelete(t *testing.T) {
+	modPath := "testdata/cs"
+	name := rnd("my-instance", 5)
+	namespace := rnd("my-namespace", 5)
+
+	t.Run("sets prune disabled annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -f %s -p main --wait",
+			namespace,
+			name,
+			modPath,
+			modPath+"-values/skip-prune.cue",
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		clientCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-client", name),
+				Namespace: namespace,
+			},
+		}
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(clientCM.GetAnnotations()).To(HaveKeyWithValue(apiv1.PruneAction, apiv1.DisabledValue))
+	})
+
+	t.Run("skips annotated resources on uninstall", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"delete -n %s %s --wait",
+			namespace,
+			name,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		clientCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-client", name),
+				Namespace: namespace,
+			},
+		}
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}

--- a/cmd/timoni/inspect_test.go
+++ b/cmd/timoni/inspect_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func Test_Inspect(t *testing.T) {
+func TestInspect(t *testing.T) {
 	g := NewWithT(t)
 	modPath := "testdata/cs"
 	modURL := fmt.Sprintf("oci://%s/%s", dockerRegistry, rnd("my-mod", 5))

--- a/cmd/timoni/testdata/cs-values/force-apply.cue
+++ b/cmd/timoni/testdata/cs-values/force-apply.cue
@@ -1,0 +1,3 @@
+values: {
+	metadata: annotations: "action.timoni.sh/force": "enabled"
+}

--- a/cmd/timoni/testdata/cs-values/skip-prune.cue
+++ b/cmd/timoni/testdata/cs-values/skip-prune.cue
@@ -1,0 +1,3 @@
+values: {
+	metadata: annotations: "action.timoni.sh/prune": "disabled"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,16 +91,24 @@ The `install` and `upgrade` commands are aliases of `timoni apply`.
 To apply the Kubernetes resources belonging to a module instance,
 Timoni uses Kubernetes server-side apply and
 [Flux](https://fluxcd.io)'s drift detection.
+
 The apply command validates all resources with a dry-run apply,
 and reconciles only the ones with changes to the cluster state.
+
+To recreate immutable resources such as Kubernetes Jobs,
+these resources can be annotated with `action.timoni.sh/force: "enabled"`.
 
 Timoni's garbage collector keeps track of the applied resources
 and prunes the Kubernetes objects that were previously applied
 but are missing from the current revision.
 
-After an install or upgrade operation, Timoni waits for the
+To prevent Timoni's garbage collector from deleting certain
+resources such as Kubernetes Persistent Volumes,
+these resources can be annotated with `action.timoni.sh/prune: "disabled"`.
+
+After an installation or upgrade, Timoni waits for the
 applied resources to be fully reconciled by checking the ready status
-of deployments, services, ingresses, and Kubernetes custom resources.
+of deployments, jobs, services, ingresses, and Kubernetes custom resources.
 
 ## License
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,8 @@
-# Install
+# Installation Guide
 
 Timoni is available as a binary executable for Linux, macOS and Windows.
-The binaries can be downloaded from GitHub [releases](https://github.com/stefanprodan/timoni/releases).
+The AMD64 and ARM64 binaries can be downloaded from GitHub [releases](https://github.com/stefanprodan/timoni/releases).
+Each release comes with a Software Bill of Materials (SBOM) in SPDX format.
 
 === "Install with brew"
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,4 @@
-# Get Started
+# Quickstart Guide
 
 This guide shows you the basics of Timoni.
 You'll deploy a demo application on Kubernetes using a Timoni module

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,8 +38,8 @@ markdown_extensions:
 
 nav:
   - Introduction: index.md
-  - Install: install.md
-  - Get started: quickstart.md
+  - Installation: install.md
+  - Quickstart: quickstart.md
   - Command Reference:
       - Modules:
           - Build: cmd/timoni_build.md


### PR DESCRIPTION
This PR introduces annotations that allow changing the default behaviour for pruning and force apply operations: 
- `action.timoni.sh/force: "enabled"` recreates immutable resources such as Kubernetes Jobs
- `action.timoni.sh/prune: "disabled"` prevents Timoni's garbage collector from deleting certain resources such as Kubernetes PV & PVC