### PR TITLE
Add GitHub Action and workflow examples

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,10 @@ jobs:
         run: make test
       - name: Run linter
         run: make lint-samples
+      - name: Run setup action
+        uses: ./actions/setup
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check if working tree is dirty
         run: |
           if [[ $(git diff --stat) != '' ]]; then

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -1,0 +1,51 @@
+name: Setup Timoni
+description: A GitHub Action for running Timoni commands
+author: Stefan Prodan
+branding:
+  color: blue
+  icon: command
+inputs:
+  version:
+    description: "Timoni version e.g. 0.0.2 (defaults to latest stable release)"
+    default: "latest"
+    required: true
+  arch:
+    description: "Arch can be amd64 or arm64"
+    required: true
+    default: "amd64"
+  token:
+    description: "GitHub Token used to query the GitHub API for the latest version"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: "Download the binary to the runner's cache dir"
+      shell: bash
+      run: |
+        ARCH=${{ inputs.arch }}
+        VERSION=${{ inputs.version }}
+        TOKEN=${{ inputs.token }}
+
+        # Find the latest version
+        if [ "${VERSION}" == "latest" ]; then
+          VERSION_SLUG=$(curl -sL -H "Authorization: token ${TOKEN}" https://api.github.com/repos/stefanprodan/timoni/releases/latest  | grep tag_name)
+          VERSION=$(echo "${VERSION_SLUG}" | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
+        fi
+
+        TIMONI_URL="https://github.com/stefanprodan/timoni/releases/download/v${VERSION}/timoni_${VERSION}_linux_${ARCH}.tar.gz"
+        TIMONI_DIR="$RUNNER_TOOL_CACHE/timoni/$VERSION/$ARCH/timoni/bin"
+        
+        # If the requested version is not cached, download the binary and add it to the PATH
+        if [[ ! -x "${TIMONI_DIR}/timoni" ]]; then
+          curl -sLf "${TIMONI_URL}" --output /tmp/timoni.tar.gz
+          mkdir -p /tmp/timoni
+          tar -C /tmp/timoni/ -zxvf /tmp/timoni.tar.gz
+          mkdir -p "${TIMONI_DIR}"
+          cp /tmp/timoni/timoni "${TIMONI_DIR}/"
+          echo "${TIMONI_DIR}" >> "$GITHUB_PATH"
+          rm -rf /tmp/timoni/ /tmp/timoni.tar.gz
+        fi
+    - name: "Print the version"
+      shell: bash
+      run: |
+        timoni version

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,63 @@
+# GitHub Actions
+
+Timoni can be used in GitHub workflows to perform actions
+such as build, test and push modules to container registries.
+
+## Usage
+
+To run Timoni commands on GitHub Linux runners,
+add the following steps to your GitHub workflow:
+
+```yaml
+steps:
+  - name: Setup Timoni
+    uses: stefanprodan/timoni/actions/setup@main
+    with:
+      version: latest # latest or exact version e.g. 0.0.2
+      arch: amd64 # can be amd64 or arm64
+      token: ${{ secrets.GITHUB_TOKEN }}
+  - name: Run Timoni
+    run: timoni version
+```
+
+## Examples
+
+### Push workflow
+
+Example workflow for linting, testing and pushing a module to GitHub Container Registry:
+
+```yaml
+name: Release module
+on:
+  push:
+    tag: ['*'] # semver format
+
+permissions:
+  contents: read # needed for checkout
+  packages: write # needed for GHCR access
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@main
+      - name: Setup Timoni
+        uses: stefanprodan/timoni/actions/setup@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint
+        run: |
+          timoni lint ./modules/my-module
+      - name: Test build
+        run: |
+          timoni build -n testing test ./modules/my-module
+      - name: Push
+        run: |
+          timoni push ./modules/my-module \
+            oci://ghcr.io/${{ github.repository_owner }}/modules/my-module \
+          	--version ${ {github.ref_name }} \
+            --creds ${{ github.actor }}:${ {secrets.GITHUB_TOKEN }}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ Timoni produces artifacts compatible with Docker Hub, GitHub Container Registry,
 Azure Container Registry, Amazon Elastic Container Registry, Google Artifact Registry,
 self-hosted Docker Registry and others.
 
-### Timoni instances
+### Timoni Instances
 
 A Timoni instance represent the unit of deploy on Kubernetes. A module instance
 can be installed, upgraded and uninstalled from a cluster.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - Introduction: index.md
   - Installation: install.md
   - Quickstart: quickstart.md
+  - GitHub Actions: github-actions.md
   - Command Reference:
       - Modules:
           - Build: cmd/timoni_build.md


### PR DESCRIPTION
This PR adds a  composite GitHub Action for running Timoni commands in GitHub workflows. And adds workflow examples to docs on how to push and apply modules in CI.