### PR TITLE
Add status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Commands for working with instances:
 - `timoni apply <name> oci://<module-url> -v <semver> -f <path/to/values.cue>`
 - `timoni delete <name> -n <namespace>`
 - `timoni list -n <namespace>`
-- `timoni inspect [module|values|resources] <name>`
+- `timoni inspect [module|values|resources] <name> -n <namespace>`
+- `timoni status <name> -n <namespace>`
 
 To learn more about instances, please read the [docs](https://timoni.sh/#timoni-instances).
 

--- a/cmd/timoni/status.go
+++ b/cmd/timoni/status.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluxcd/pkg/ssa"
+	"github.com/spf13/cobra"
+	"github.com/stefanprodan/timoni/internal/runtime"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status [INSTANCE NAME]",
+	Short: "Displays the current status of Kubernetes resources managed by an instance",
+	Example: `  # Show the current status of the managed resources
+  timoni status -n apps app
+`,
+	RunE: runstatusCmd,
+}
+
+type statusFlags struct {
+	name string
+}
+
+var statusArgs statusFlags
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}
+
+func runstatusCmd(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("instance name is required")
+	}
+
+	statusArgs.name = args[0]
+
+	rm, err := runtime.NewResourceManager(kubeconfigArgs)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	st := runtime.NewStorageManager(rm)
+	inst, err := st.Get(ctx, statusArgs.name, *kubeconfigArgs.Namespace)
+	if err != nil {
+		return err
+	}
+
+	tm := runtime.InstanceManager{Instance: apiv1.Instance{Inventory: inst.Inventory}}
+
+	objects, err := tm.ListObjects()
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range objects {
+		err = rm.Client().Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.Printf("%s NotFound", ssa.FmtUnstructured(obj))
+				continue
+			}
+			logger.Printf("%s %s", ssa.FmtUnstructured(obj), err.Error())
+			continue
+		}
+
+		res, err := status.Compute(obj)
+		if err != nil {
+			logger.Printf("%s %s", ssa.FmtUnstructured(obj), err.Error())
+			continue
+		}
+		logger.Printf("%s %s %s", ssa.FmtUnstructured(obj), res.Status, res.Message)
+	}
+
+	return nil
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,8 @@ Commands for working with module instances:
 - `timoni upgrade <name> oci://<module-url> -v <semver> -f <path/to/values.cue>`
 - `timoni uninstall <name> -n <namespace>`
 - `timoni list -n <namespace>`
-- `timoni inspect [module|values|resources] <name>`
+- `timoni inspect [module|values|resources] <name> -n <namespace>`
+- `timoni status <name> -n <namespace>`
 
 The `install` and `upgrade` commands are aliases of `timoni apply`.
 To apply the Kubernetes resources belonging to a module instance,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
           - Inspect Module: cmd/timoni_inspect_module.md
           - Inspect Values: cmd/timoni_inspect_values.md
           - Inspect Resources: cmd/timoni_inspect_resources.md
+          - Status: cmd/timoni_status.md
       - Completion:
           - Bash: cmd/timoni_completion_bash.md
           - Fish: cmd/timoni_completion_fish.md


### PR DESCRIPTION
The `timoni status <instance-name>` displays the current status of all Kubernetes resources managed by an instance.