### PR TITLE
Introduce the concept of latest stable version for modules

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,17 +15,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Restore Go cache
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.20.x
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
       - name: Setup CUE
         uses: cue-lang/setup-cue@main
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,17 +16,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Restore Go cache
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.20.x
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
       - name: Generate cmd docs
         run: make docs
       - name: Run mkdocs

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,17 +20,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Restore Go cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.20.x
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
       - name: Setup Kubernetes
         uses: helm/kind-action@v1.5.0
         with:
@@ -42,7 +39,8 @@ jobs:
       - name: Push
         run: |
           timoni mod push ./examples/podinfo oci://localhost:5000/podinfo \
-            --version 1.0.0
+            --version 1.0.0 \
+            --latest
       - name: Template
         run: |
           timoni template podinfo oci://localhost:5000/podinfo \
@@ -51,23 +49,20 @@ jobs:
       - name: Install
         run: |
           timoni install podinfo oci://localhost:5000/podinfo \
-            -v 1.0.0 \
-            -n test \
+            --namespace test \
             --wait
       - name: Upgrade (enable HPA)
         run: |
           timoni upgrade podinfo oci://localhost:5000/podinfo \
             -f ./examples/podinfo-values/ha-values.cue \
-            -v 1.0.0 \
-            -n test \
+            --namespace test \
             --wait
       - name: Upgrade (disable HPA, enable ingress)
         run: |
           timoni apply podinfo oci://localhost:5000/podinfo \
             -f ./examples/podinfo-values/psp-values.cue \
             -f ./examples/podinfo-values/ingress-values.cue \
-            -v 1.0.0 \
-            -n test \
+            --namespace test \
             --wait
       - name: List
         run: |
@@ -77,6 +72,9 @@ jobs:
           timoni inspect resources podinfo -n test
           timoni inspect module podinfo -n test
           timoni inspect values podinfo -n test
+      - name: Status
+        run: |
+          timoni status podinfo -n test
       - name: Uninstall
         run: |
           timoni uninstall podinfo -n test --wait

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.20.x
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
       - name: Setup Syft
         uses: anchore/sbom-action/download-syft@v0
       - name: Run GoReleaser

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ lint-samples: build
 	./bin/timoni mod lint ./internal/engine/testdata/module
 	cue fmt ./internal/engine/testdata/module-values
 
+PODINFO_VER=$(shell cat ./examples/podinfo/templates/config.cue | awk '/tag:/ {print $$2}' | tr -d '*"')
 push-podinfo: build
-	$pv=$(shell cat ./examples/podinfo/templates/config.cue | awk '/tag:/ {print $$2}' | tr -d '*"')
-	./bin/timoni push ./examples/podinfo oci://ghcr.io/stefanprodan/modules/podinfo --version $$pv --source https://github.com/stefanprodan/podinfo
+	./bin/timoni mod push ./examples/podinfo oci://ghcr.io/stefanprodan/modules/podinfo -v $(PODINFO_VER) --latest --source https://github.com/stefanprodan/podinfo
 
 .PHONY: install
 install: ## Build and install the CLI binary.

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -80,6 +80,11 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 	buildArgs.name = args[0]
 	buildArgs.module = args[1]
 
+	version := buildArgs.version.String()
+	if version == "" {
+		version = engine.LatestTag
+	}
+
 	ctx := cuecontext.New()
 
 	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
@@ -94,7 +99,7 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 	fetcher := engine.NewFetcher(
 		ctxPull,
 		buildArgs.module,
-		buildArgs.version.String(),
+		version,
 		tmpDir,
 		buildArgs.creds.String(),
 	)

--- a/cmd/timoni/mod_init.go
+++ b/cmd/timoni/mod_init.go
@@ -51,8 +51,9 @@ func init() {
 }
 
 const (
-	modTemplateURL  = "ghcr.io/stefanprodan/modules/podinfo:6.3.4"
-	modTemplateName = "podinfo"
+	modTemplateName      = "podinfo"
+	modTemplateURL       = "ghcr.io/stefanprodan/modules/podinfo"
+	modTemplateImageRepo = "ghcr.io/stefanprodan"
 )
 
 func runInitModCmd(cmd *cobra.Command, args []string) error {
@@ -107,7 +108,7 @@ func copyModuleFile(mName, mTmpl, src, dst string) (err error) {
 		}
 	}()
 
-	if filepath.Base(in.Name()) == "values.cue" {
+	if filepath.Base(in.Name()) == "README.md" {
 		_, err = io.Copy(out, in)
 		if err != nil {
 			return
@@ -118,6 +119,14 @@ func copyModuleFile(mName, mTmpl, src, dst string) (err error) {
 			return err
 		}
 		txt := strings.Replace(string(data), mTmpl, mName, -1)
+
+		// TODO: find a better way to preserve the container image original name
+		txt = strings.Replace(
+			txt,
+			fmt.Sprintf("%s/%s", modTemplateImageRepo, mName),
+			fmt.Sprintf("%s/%s", modTemplateImageRepo, mTmpl),
+			-1,
+		)
 		_, err = io.WriteString(out, txt)
 		if err != nil {
 			return err

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -24,6 +24,7 @@ import (
 	oci "github.com/fluxcd/pkg/oci/client"
 	"github.com/spf13/cobra"
 
+	"github.com/stefanprodan/timoni/internal/engine"
 	"github.com/stefanprodan/timoni/internal/flags"
 )
 
@@ -32,7 +33,11 @@ var pullModCmd = &cobra.Command{
 	Short: "Pull a module version from a container registry",
 	Long: `The pull command downloads the module from a container registry and
 extract its contents the specified directory.`,
-	Example: `  # Pull a module version from GitHub Container Registry
+	Example: `  # Pull the latest stable version of a module
+  timoni mod pull oci://docker.io/org/app \
+	--output ./path/to/module
+
+  # Pull a specific module version from GitHub Container Registry
   timoni mod pull oci://ghcr.io/org/manifests/app --version 1.0.0 \
 	--output ./path/to/module \
 	--creds timoni:$GITHUB_TOKEN
@@ -62,10 +67,10 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("module URL is required")
 	}
 	ociURL := args[0]
-	version := pullModArgs.version.String()
 
+	version := pullModArgs.version.String()
 	if version == "" {
-		return fmt.Errorf("module version is required")
+		version = engine.LatestTag
 	}
 
 	if pullModArgs.output == "" {
@@ -76,7 +81,7 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid output path %s", pullModArgs.output)
 	}
 
-	url, err := oci.ParseArtifactURL(ociURL + ":" + pullModArgs.version.String())
+	url, err := oci.ParseArtifactURL(ociURL + ":" + version)
 	if err != nil {
 		return err
 	}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,13 +32,14 @@ you have to specify the container registry address and the version of a module.
     and a Timoni **instance** is the equivalent of a Helm **release**.
     To learn more about modules and instances, please see the [concepts section](index.md#concepts).
 
-For example, to install [podinfo](https://github.com/stefanprodan/podinfo)
+For example, to install the latest stable version of [podinfo](https://github.com/stefanprodan/podinfo)
 in a new namespace:
 
 ```console
-$ timoni -n test apply podinfo oci://ghcr.io/stefanprodan/modules/podinfo --version 6.3.3
-pulling oci://ghcr.io/stefanprodan/modules/podinfo:6.3.3
-installing podinfo/test
+$ timoni -n test apply podinfo oci://ghcr.io/stefanprodan/modules/podinfo --version latest
+pulling oci://ghcr.io/stefanprodan/modules/podinfo:latest
+using module timoni.sh/podinfo version 6.3.4
+installing podinfo in namespace test
 Namespace/test created
 ServiceAccount/test/podinfo created
 Service/test/podinfo created
@@ -55,10 +56,10 @@ To get more information on an instance, you can use the `timoni inspect` sub-com
 
 ```console
 $ timoni -n test inspect module podinfo
-digest: sha256:a6763971b24afca01176d796657de96055952c0857317a99f0b2e06d43fdb10b
 name: timoni.sh/podinfo
+version: 6.3.4
 repository: oci://ghcr.io/stefanprodan/modules/podinfo
-version: 6.3.3
+digest: sha256:594b6f8c5c316b4a9aec4b5a8afb84e4ccb94ce5236548097ed74792d270683f
 ```
 
 To learn more about the available commands, use `timoni inspect --help`.
@@ -90,7 +91,7 @@ Apply the config to the podinfo module to perform an upgrade:
 
 ```shell
 timoni -n test apply podinfo \
-  oci://ghcr.io/stefanprodan/modules/podinfo -v 6.3.4 \
+  oci://ghcr.io/stefanprodan/modules/podinfo \
   --values qos-values.cue
 ```
 

--- a/examples/podinfo/README.md
+++ b/examples/podinfo/README.md
@@ -13,7 +13,13 @@ This module is available on GitHub Container Registry at
 To create an instance using the default values:
 
 ```shell
-timoni -n default apply podinfo oci://ghcr.io/stefanprodan/modules/podinfo -v 6.3.4
+timoni -n default apply podinfo oci://ghcr.io/stefanprodan/modules/podinfo
+```
+
+To install a specific module version:
+
+```shell
+timoni -n default apply podinfo oci://ghcr.io/stefanprodan/modules/podinfo -v 6.3.0
 ```
 
 To change the [default configuration](#configuration),
@@ -33,7 +39,7 @@ values: {
 And apply the values with:
 
 ```shell
-timoni -n default apply podinfo oci://ghcr.io/stefanprodan/modules/podinfo -v 6.3.4 \
+timoni -n default apply podinfo oci://ghcr.io/stefanprodan/modules/podinfo \
 --values ./my-values.cue
 ```
 
@@ -49,20 +55,20 @@ timoni -n default delete podinfo
 
 ### General values
 
-| Key                      | Type                               | Default                                    | Description                                                                                                                                  |
-|--------------------------|------------------------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| `image: tag:`            | `string`                           | `6.3.4`                                    | Container image tag                                                                                                                          |
-| `image: repository:`     | `string`                           | `ghcr.io/stefanprodan/podinfo`             | Container image repository                                                                                                                   |
-| `image: pullPolicy:`     | `string`                           | `IfNotPresent`                             | [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy)                                     |
-| `metadata: labels:`      | `{[ string]: string}`              | `{"app.kubernetes.io/version": image.tag}` | Common labels for all resources                                                                                                              |
-| `metadata: annotations:` | `{[ string]: string}`              | `{}`                                       | Common annotations for all resources                                                                                                         |
-| `podAnnotations:`        | `{[ string]: string}`              | `{}`                                       | Annotations applied to pods                                                                                                                  |
-| `imagePullSecrets:`      | `[...corev1.LocalObjectReference]` | `[]`                                       | [Kubernetes image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)                 |
-| `tolerations:`           | `[ ...corev1.#Toleration]`         | `[]`                                       | [Kubernetes toleration](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration)                                        |
-| `affinity:`              | `corev1.#Affinity`                 | `{}`                                       | [Kubernetes affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
-| `resources:`             | `corev1.#ResourceRequirements`     | `{}`                                       | [Kubernetes resource requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers)                     |
-| `podSecurityContext:`    | `corev1.#PodSecurityContext`       | `{}`                                       | [Kubernetes pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context)                                 |
-| `securityContext:`       | `corev1.#SecurityContext`          | `{}`                                       | [Kubernetes container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context)                           |
+| Key                      | Type                               | Default                        | Description                                                                                                                                  |
+|--------------------------|------------------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `image: tag:`            | `string`                           | `<latest version>`             | Container image tag                                                                                                                          |
+| `image: repository:`     | `string`                           | `ghcr.io/stefanprodan/podinfo` | Container image repository                                                                                                                   |
+| `image: pullPolicy:`     | `string`                           | `IfNotPresent`                 | [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy)                                     |
+| `metadata: labels:`      | `{[ string]: string}`              | `{}`                           | Common labels for all resources                                                                                                              |
+| `metadata: annotations:` | `{[ string]: string}`              | `{}`                           | Common annotations for all resources                                                                                                         |
+| `podAnnotations:`        | `{[ string]: string}`              | `{}`                           | Annotations applied to pods                                                                                                                  |
+| `imagePullSecrets:`      | `[...corev1.LocalObjectReference]` | `[]`                           | [Kubernetes image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)                 |
+| `tolerations:`           | `[ ...corev1.#Toleration]`         | `[]`                           | [Kubernetes toleration](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration)                                        |
+| `affinity:`              | `corev1.#Affinity`                 | `{}`                           | [Kubernetes affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| `resources:`             | `corev1.#ResourceRequirements`     | `{}`                           | [Kubernetes resource requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers)                     |
+| `podSecurityContext:`    | `corev1.#PodSecurityContext`       | `{}`                           | [Kubernetes pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context)                                 |
+| `securityContext:`       | `corev1.#SecurityContext`          | `{}`                           | [Kubernetes container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context)                           |
 
 ### Autoscaling values
 

--- a/internal/engine/fetcher.go
+++ b/internal/engine/fetcher.go
@@ -30,6 +30,9 @@ import (
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
+// LatestTag is the OCI tag name used to denote the latest stable version of a module.
+const LatestTag = "latest"
+
 // Fetcher downloads a module and extracts it locally.
 type Fetcher struct {
 	ctx     context.Context
@@ -79,7 +82,7 @@ func (f *Fetcher) Fetch() (*apiv1.ModuleReference, error) {
 }
 
 func (f *Fetcher) fetchOCI(dir string) (*apiv1.ModuleReference, error) {
-	if _, err := semver.StrictNewVersion(f.version); err != nil {
+	if _, err := semver.StrictNewVersion(f.version); f.version != LatestTag && err != nil {
 		return nil, fmt.Errorf("version is not in semver format, error: %w", err)
 	}
 
@@ -108,7 +111,7 @@ func (f *Fetcher) fetchOCI(dir string) (*apiv1.ModuleReference, error) {
 
 	mr := apiv1.ModuleReference{
 		Repository: f.src,
-		Version:    f.version,
+		Version:    meta.Revision,
 		Digest:     digest.DigestStr(),
 	}
 

--- a/internal/flags/version.go
+++ b/internal/flags/version.go
@@ -2,7 +2,10 @@ package flags
 
 import (
 	"fmt"
+
 	"github.com/Masterminds/semver/v3"
+
+	"github.com/stefanprodan/timoni/internal/engine"
 )
 
 type Version string
@@ -12,7 +15,7 @@ func (f *Version) String() string {
 }
 
 func (f *Version) Set(str string) error {
-	if str != "" {
+	if str != "" && str != engine.LatestTag {
 		if _, err := semver.StrictNewVersion(str); err != nil {
 			return err
 		}


### PR DESCRIPTION
Changes:
- allow tagging a module version as `latest` with `timoni mon push -v <semver> --latest=true`
- allow pulling the latest stable version with `timoni mod pull --version=latest`
- allow applying the latest stable version with `timoni apply --version=latest`
- print the semver value at apply time so users know what's the exact version being deployed
- make `--version` default to `latest` for all commands
