### PR TITLE
Add auth and caching to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ to offer a better experience of creating, packaging and delivering apps to Kuber
 > **Warning**
 >
 > Note that Timoni in under active development and is still in its infancy.
-> Its APIs and command-line interface may change in a backwards incompatible manner.
+> The APIs and command-line interface may change in a backwards incompatible manner.
 
 ## Get started
 
@@ -50,7 +50,7 @@ Module structure:
 └── values.cue # Timoni values placeholder
 ```
 
-A module example can be found at [examples/podinfo](examples/podinfo).
+Module examples can be found at [examples/podinfo](examples/podinfo) and [examples/redis](examples/redis).
 
 Commands for working with local modules:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ to offer a better experience of creating, packaging and delivering apps to Kuber
 !!! warning "Development phase"
 
     Timoni in under active development and is still in its infancy.
-    Its APIs and interfaces may change in a backwards incompatible manner.
+    The APIs and interfaces may change in a backwards incompatible manner.
 
 ## Concepts
 

--- a/examples/podinfo-values/caching-values.cue
+++ b/examples/podinfo-values/caching-values.cue
@@ -1,0 +1,4 @@
+values: caching: {
+	enabled:  true
+	redisURL: "tcp://:redis@redis:6379"
+}

--- a/examples/podinfo/README.md
+++ b/examples/podinfo/README.md
@@ -120,3 +120,10 @@ values: {
 |-------------------------|----------|---------|-------------------------------------------------------------------------------|
 | `monitoring: enabled:`  | `bool`   | `false` | Enable [Prometheus ServiceMonitor](https://prometheus-operator.dev/) creation |
 | `monitoring: interval:` | `string` | `15s`   | Prometheus scrape interval                                                    |
+
+### Cashing values
+
+| Key                  | Type     | Default | Description                                             |
+|----------------------|----------|---------|---------------------------------------------------------|
+| `caching: enabled:`  | `bool`   | `false` | Enable Redis caching                                    |
+| `caching: redisURL:` | `string` | `""`    | Redis URL in the format `tcp://:[password]@host[:port]` |

--- a/examples/podinfo/templates/config.cue
+++ b/examples/podinfo/templates/config.cue
@@ -1,6 +1,8 @@
 package templates
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -9,11 +11,14 @@ import (
 #Config: {
 	// Metadata (common to all resources)
 	metadata: metav1.#ObjectMeta
-	metadata: name:      *"podinfo" | string
-	metadata: namespace: *"default" | string
+	metadata: name:      *"podinfo" | string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)
+	metadata: namespace: *"default" | string & strings.MaxRunes(63)
 	metadata: labels:    *selectorLabels | {[ string]: string}
 	metadata: labels: "app.kubernetes.io/version": image.tag
 	metadata: annotations?: {[ string]:            string}
+
+	// Redis
+	redis?: string
 
 	// Deployment
 	replicas:       *1 | int & >0
@@ -61,6 +66,12 @@ import (
 	monitoring: {
 		enabled:  *false | bool
 		interval: *"15s" | string
+	}
+
+	// Caching (optional)
+	caching: {
+		enabled:   *false | bool
+		redisURL?: string & =~"^tcp://.*$"
 	}
 }
 

--- a/examples/podinfo/templates/deployment.cue
+++ b/examples/podinfo/templates/deployment.cue
@@ -54,6 +54,13 @@ import (
 						if _config.securityContext != _|_ {
 							securityContext: _config.securityContext
 						}
+						command: [
+							"./podinfo",
+							"--level=info",
+							if _config.caching.enabled {
+								"--cache-server=\(_config.caching.redisURL)"
+							},
+						]
 					},
 				]
 				if _config.podSecurityContext != _|_ {

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -93,6 +93,7 @@ timoni -n default delete redis
 | `persistence: enabled:`      | `bool`   | `true`     | Enable persistent storage for the Redis master node                                                             |
 | `persistence: storageClass:` | `string` | `standard` | The [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) storage class name |
 | `persistence: size:`         | `string` | `8Gi`      | The persistent volume size                                                                                      |
+| `password`                   | `string` | `""`       | When set, it enables auth for both the master and replicas with the specified password                          |
 
 ### General values
 

--- a/examples/redis/templates/config.cue
+++ b/examples/redis/templates/config.cue
@@ -1,6 +1,8 @@
 package templates
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -15,11 +17,12 @@ import (
 		storageClass: *"standard" | string
 		size:         *"8Gi" | string
 	}
+	password?: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
 
 	// Metadata (common to all resources)
 	metadata: metav1.#ObjectMeta
-	metadata: name:      *"redis" | string
-	metadata: namespace: *"default" | string
+	metadata: name:      *"redis" | string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)
+	metadata: namespace: *"default" | string & strings.MaxRunes(63)
 	metadata: labels: {
 		"app.kubernetes.io/version": image.tag
 		"app.kubernetes.io/part-of": metadata.name

--- a/examples/redis/templates/master.deployment.cue
+++ b/examples/redis/templates/master.deployment.cue
@@ -42,7 +42,13 @@ import (
 							containerPort: 6379
 							protocol:      "TCP"
 						}]
-						command: ["redis-server", "/redis-master/redis.conf"]
+						command: [
+							"redis-server",
+							"/redis-master/redis.conf",
+							if _config.password != _|_ {
+								"--requirepass \(_config.password)"
+							},
+						]
 						livenessProbe: {
 							tcpSocket: port: "redis"
 							initialDelaySeconds: 2

--- a/examples/redis/templates/replica.deployment.cue
+++ b/examples/redis/templates/replica.deployment.cue
@@ -50,6 +50,12 @@ import (
 							"\(_config.service.port)",
 							"--include",
 							"/redis-replica/redis.conf",
+							if _config.password != _|_ {
+								"--masterauth \(_config.password)"
+							},
+							if _config.password != _|_ {
+								"--requirepass \(_config.password)"
+							},
 						]
 						livenessProbe: {
 							tcpSocket: port: "redis"

--- a/examples/redis/test_values.cue
+++ b/examples/redis/test_values.cue
@@ -5,4 +5,5 @@ package main
 values: {
 	resources: requests: cpu: "100m"
 	resources: limits: cpu:   "1000m"
+	password: "my-redis_password123"
 }


### PR DESCRIPTION
Changes to module samples:
- Add an optional `password` field to redis module
- Add an optional `redisURL` field to podinfo module