### PR TITLE
Remove deprecated `rand.Seed`

### DIFF
--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -25,10 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 var (
 	envTestClient  client.Client
 	dockerRegistry string


### PR DESCRIPTION
> The math/rand package now automatically seeds the global random
> number generator (used by top-level functions like Float64 and Int)
> with a random value, and the top-level Seed function has been
> deprecated.

From: https://go.dev/doc/go1.20#minor_library_changes (`math/rand`)