### PR TITLE
bundle: Allow modules to be referenced by digest

### DIFF
--- a/api/v1alpha1/bundle.go
+++ b/api/v1alpha1/bundle.go
@@ -29,6 +29,9 @@ const (
 	// BundleModuleVersionSelector is the CUE path for the Timoni's bundle module version.
 	BundleModuleVersionSelector Selector = "module.version"
 
+	// BundleModuleDigestSelector is the CUE path for the Timoni's bundle module digest.
+	BundleModuleDigestSelector Selector = "module.digest"
+
 	// BundleNamespaceSelector is the CUE path for the Timoni's bundle instance namespace.
 	BundleNamespaceSelector Selector = "namespace"
 
@@ -46,7 +49,8 @@ import "strings"
 	instances: [string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
 		module: close({
 			url:     string & =~"^oci://.*$"
-			version: string & strings.MinRunes(3)
+			version: *"latest" | string
+			digest?:  string
 		})
 		namespace: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
 		values: {...}

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -27,9 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
-	"cuelang.org/go/cue/load"
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -102,15 +100,7 @@ func runBundleApplyCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx := cuecontext.New()
-
-	cfg := &load.Config{
-		Package:   "_",
-		DataFiles: true,
-	}
-
 	files := append(bundleApplyArgs.files, bundleSchema.Name())
-
 	for i, file := range files {
 		if file == "-" {
 			path, err := saveReaderToFile(cmd.InOrStdin())
@@ -124,73 +114,22 @@ func runBundleApplyCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	ix := load.Instances(files, cfg)
-	if len(ix) == 0 {
-		return fmt.Errorf("no bundle found")
-	}
+	ctx := cuecontext.New()
+	bm := engine.NewBundleBuilder(ctx, files)
 
-	inst := ix[0]
-	if inst.Err != nil {
-		return fmt.Errorf("bundle error: %w", inst.Err)
-	}
-
-	v := ctx.BuildInstance(inst)
-	if v.Err() != nil {
-		return v.Err()
-	}
-
-	if err := v.Validate(cue.Concrete(true)); err != nil {
+	v, err := bm.Build()
+	if err != nil {
 		return err
 	}
 
-	apiVersion := v.LookupPath(cue.ParsePath(apiv1.BundleAPIVersionSelector.String()))
-	if apiVersion.Err() != nil {
-		return fmt.Errorf("lookup %s failed, error: %w", apiv1.BundleAPIVersionSelector.String(), apiVersion.Err())
+	instances, err := bm.GetInstances(v)
+	if err != nil {
+		return err
 	}
 
-	apiVer, _ := apiVersion.String()
-	if apiVer != apiv1.GroupVersion.Version {
-		return fmt.Errorf("API version %s not supported, must be %s", apiVer, apiv1.GroupVersion.Version)
-	}
-
-	instances := v.LookupPath(cue.ParsePath(apiv1.BundleInstancesSelector.String()))
-	if instances.Err() != nil {
-		return fmt.Errorf("lookup %s failed, error: %w", apiv1.BundleInstancesSelector.String(), instances.Err())
-	}
-
-	iter, _ := instances.Fields(cue.Concrete(true))
-	for iter.Next() {
-		name := iter.Selector().String()
-		expr := iter.Value()
-
-		logger.Printf("applying instance %s", name)
-
-		moduleURL := expr.LookupPath(cue.ParsePath(apiv1.BundleModuleURLSelector.String()))
-		if moduleURL.Err() != nil {
-			return fmt.Errorf("lookup %s failed, error: %w", apiv1.BundleModuleURLSelector.String(), instances.Err())
-		}
-
-		moduleVersion := expr.LookupPath(cue.ParsePath(apiv1.BundleModuleVersionSelector.String()))
-		if moduleVersion.Err() != nil {
-			return fmt.Errorf("lookup %s failed, error: %w", apiv1.BundleModuleVersionSelector.String(), instances.Err())
-		}
-
-		namespace := expr.LookupPath(cue.ParsePath(apiv1.BundleNamespaceSelector.String()))
-		if namespace.Err() != nil {
-			return fmt.Errorf("lookup %s failed, error: %w", apiv1.BundleNamespaceSelector.String(), instances.Err())
-		}
-
-		values := expr.LookupPath(cue.ParsePath(apiv1.BundleValuesSelector.String()))
-		if values.Err() != nil {
-			return fmt.Errorf("lookup %s failed, error: %w", apiv1.BundleValuesSelector.String(), instances.Err())
-		}
-
-		ns, _ := namespace.String()
-		url, _ := moduleURL.String()
-		version, _ := moduleVersion.String()
-
-		err := applyBundleInstance(name, ns, url, version, values)
-		if err != nil {
+	for _, instance := range instances {
+		logger.Printf("applying instance %s", instance.Name)
+		if err := applyBundleInstance(instance); err != nil {
 			return err
 		}
 	}
@@ -198,8 +137,16 @@ func runBundleApplyCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func applyBundleInstance(name, namespace, moduleURL, moduleVersion string, values cue.Value) error {
-	logger.Printf("pulling %s:%s", moduleURL, moduleVersion)
+func applyBundleInstance(instance engine.BundleInstance) error {
+	moduleVersion := instance.Module.Version
+	sourceURL := fmt.Sprintf("%s:%s", instance.Module.Repository, instance.Module.Version)
+
+	if moduleVersion == engine.LatestTag && instance.Module.Digest != "" {
+		sourceURL = fmt.Sprintf("%s@%s", instance.Module.Repository, instance.Module.Digest)
+		moduleVersion = "@" + instance.Module.Digest
+	}
+
+	logger.Printf("pulling %s", sourceURL)
 
 	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
 	if err != nil {
@@ -212,7 +159,7 @@ func applyBundleInstance(name, namespace, moduleURL, moduleVersion string, value
 
 	fetcher := engine.NewFetcher(
 		ctxPull,
-		moduleURL,
+		instance.Module.Repository,
 		moduleVersion,
 		tmpDir,
 		bundleApplyArgs.creds.String(),
@@ -222,11 +169,16 @@ func applyBundleInstance(name, namespace, moduleURL, moduleVersion string, value
 		return err
 	}
 
+	if instance.Module.Digest != "" && mod.Digest != instance.Module.Digest {
+		return fmt.Errorf("the upstream digest of version %s doesn't match the specified digest %s",
+			instance.Module.Version, instance.Module.Digest)
+	}
+
 	cuectx := cuecontext.New()
 	builder := engine.NewModuleBuilder(
 		cuectx,
-		name,
-		namespace,
+		instance.Name,
+		instance.Namespace,
 		fetcher.GetModuleRoot(),
 		bundleApplyArgs.pkg.String(),
 	)
@@ -238,7 +190,7 @@ func applyBundleInstance(name, namespace, moduleURL, moduleVersion string, value
 
 	logger.Printf("using module %s version %s", mod.Name, mod.Version)
 
-	err = builder.WriteValuesFile(values)
+	err = builder.WriteValuesFile(instance.Values)
 	if err != nil {
 		return err
 	}
@@ -277,14 +229,14 @@ func applyBundleInstance(name, namespace, moduleURL, moduleVersion string, value
 		return err
 	}
 
-	rm.SetOwnerLabels(objects, name, namespace)
+	rm.SetOwnerLabels(objects, instance.Name, instance.Namespace)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	exists := false
 	sm := runtime.NewStorageManager(rm)
-	if _, err := sm.Get(ctx, name, namespace); err == nil {
+	if _, err := sm.Get(ctx, instance.Name, instance.Namespace); err == nil {
 		exists = true
 	}
 
@@ -322,20 +274,20 @@ func applyBundleInstance(name, namespace, moduleURL, moduleVersion string, value
 			}
 		}
 
-		logger.Println("bundled applied successfully")
+		logger.Println("bundle applied successfully")
 		return nil
 	}
 
-	im := runtime.NewInstanceManager(name, namespace, finalValues, *mod)
+	im := runtime.NewInstanceManager(instance.Name, instance.Namespace, finalValues, *mod)
 
 	if err := im.AddObjects(objects); err != nil {
 		return fmt.Errorf("adding objects to instance failed, error: %w", err)
 	}
 
 	if !exists {
-		logger.Printf("installing %s in namespace %s", name, namespace)
+		logger.Printf("installing %s in namespace %s", instance.Name, instance.Namespace)
 
-		nsExists, err := sm.NamespaceExists(ctx, namespace)
+		nsExists, err := sm.NamespaceExists(ctx, instance.Namespace)
 		if err != nil {
 			return fmt.Errorf("instance init failed, error: %w", err)
 		}
@@ -345,10 +297,10 @@ func applyBundleInstance(name, namespace, moduleURL, moduleVersion string, value
 		}
 
 		if !nsExists {
-			logger.Printf("Namespace/%s created", namespace)
+			logger.Printf("Namespace/%s created", instance.Namespace)
 		}
 	} else {
-		logger.Printf("upgrading %s in namespace %s", name, namespace)
+		logger.Printf("upgrading %s in namespace %s", instance.Name, instance.Namespace)
 	}
 
 	bundleApplyOpts := runtime.ApplyOptions(bundleApplyArgs.force, time.Minute)
@@ -387,7 +339,7 @@ func applyBundleInstance(name, namespace, moduleURL, moduleVersion string, value
 
 	var deletedObjects []*unstructured.Unstructured
 	if len(staleObjects) > 0 {
-		deleteOpts := runtime.DeleteOptions(name, namespace)
+		deleteOpts := runtime.DeleteOptions(instance.Name, instance.Namespace)
 		changeSet, err := rm.DeleteAll(ctx, staleObjects, deleteOpts)
 		if err != nil {
 			return fmt.Errorf("prunning objects failed, error: %w", err)

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -170,8 +170,8 @@ func applyBundleInstance(instance engine.BundleInstance) error {
 	}
 
 	if instance.Module.Digest != "" && mod.Digest != instance.Module.Digest {
-		return fmt.Errorf("the upstream digest of version %s doesn't match the specified digest %s",
-			instance.Module.Version, instance.Module.Digest)
+		return fmt.Errorf("the upstream digest %s of version %s doesn't match the specified digest %s",
+			mod.Digest, instance.Module.Version, instance.Module.Digest)
 	}
 
 	cuectx := cuecontext.New()

--- a/cmd/timoni/bundle_apply_test.go
+++ b/cmd/timoni/bundle_apply_test.go
@@ -248,4 +248,29 @@ bundle: {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(output).To(ContainSubstring(modVer2))
 	})
+
+	t.Run("creates instance for digest ignoring latest", func(t *testing.T) {
+		g := NewWithT(t)
+
+		bundleData := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	instances: {
+		test5: {
+			module: {
+				url:     "oci://%[1]s"
+				version: "latest"
+				digest:  "%[2]s"
+			}
+			namespace: "%[3]s"
+		}
+	}
+}
+`, modURL, modDigestv1, namespace)
+
+		r := strings.NewReader(bundleData)
+		output, err := executeCommandWithIn("bundle apply -f - -p main --wait", r)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring(modVer1))
+	})
 }

--- a/cmd/timoni/bundle_apply_test.go
+++ b/cmd/timoni/bundle_apply_test.go
@@ -120,7 +120,6 @@ bundle: {
 				g.Expect(err).ToNot(HaveOccurred())
 			})
 		}
-
 	})
 
 }

--- a/cmd/timoni/bundle_lint_test.go
+++ b/cmd/timoni/bundle_lint_test.go
@@ -71,24 +71,6 @@ bundle: {
 `,
 		},
 		{
-			name:     "fails for missing module version",
-			matchErr: "bundle.instances.test.module.version",
-			bundle: `
-bundle: {
-	apiVersion: "v1alpha1"
-	instances: {
-		test: {
-			module: {
-				url:     "oci://docker.io/test"
-			}
-			namespace: "default"
-			values: {}
-		}
-	}
-}
-`,
-		},
-		{
 			name:     "fails for invalid module prop",
 			matchErr: "url2",
 			bundle: `

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,6 +153,17 @@ bundle: {
 }
 ```
 
+For deterministic operations, it is possible to pin a module version by its OCI digest:
+
+```cue
+redis: {
+    module: {
+        url:     "oci://ghcr.io/stefanprodan/modules/redis"
+        digest:  "sha256:e9137d41b0d263bfaf2a43fc862648ad9dc3a976b4b0fc6e27617ea28ee27d45"
+    }
+}
+```
+
 !!! tip "Bundle example"
 
     An example bundle can be found in Timoni's repository at

--- a/examples/bundles/podinfo.cue
+++ b/examples/bundles/podinfo.cue
@@ -9,7 +9,7 @@ bundle: {
 		redis: {
 			module: {
 				url:     "oci://ghcr.io/stefanprodan/modules/redis"
-				version: "7.0.9"
+				digest:  "sha256:e9137d41b0d263bfaf2a43fc862648ad9dc3a976b4b0fc6e27617ea28ee27d45"
 			}
 			namespace: "podinfo"
 			values: {

--- a/internal/engine/bundle_builder.go
+++ b/internal/engine/bundle_builder.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/load"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+// BundleBuilder compiles CUE definitions to Go Bundle objects.
+type BundleBuilder struct {
+	ctx     *cue.Context
+	pkgPath string
+	files   []string
+}
+
+type BundleInstance struct {
+	Name      string
+	Namespace string
+	Module    apiv1.ModuleReference
+	Values    cue.Value
+}
+
+// NewBundleBuilder creates a BundleBuilder for the given module and package.
+func NewBundleBuilder(ctx *cue.Context, files []string) *BundleBuilder {
+	if ctx == nil {
+		ctx = cuecontext.New()
+	}
+	b := &BundleBuilder{
+		ctx:   ctx,
+		files: files,
+	}
+	return b
+}
+
+// Build builds a CUE instance for the specified files and returns the CUE value.
+func (b *BundleBuilder) Build() (cue.Value, error) {
+	var value cue.Value
+	cfg := &load.Config{
+		Package:   "_",
+		DataFiles: true,
+	}
+
+	ix := load.Instances(b.files, cfg)
+	if len(ix) == 0 {
+		return value, fmt.Errorf("no instances found")
+	}
+
+	inst := ix[0]
+	if inst.Err != nil {
+		return value, fmt.Errorf("instance error: %w", inst.Err)
+	}
+
+	v := b.ctx.BuildInstance(inst)
+	if v.Err() != nil {
+		return value, v.Err()
+	}
+
+	if err := v.Validate(cue.Concrete(true)); err != nil {
+		return value, err
+	}
+
+	return v, nil
+}
+
+// GetInstances returns a list of BundleInstance from the bundle CUE value.
+func (b *BundleBuilder) GetInstances(v cue.Value) ([]BundleInstance, error) {
+	instances := v.LookupPath(cue.ParsePath(apiv1.BundleInstancesSelector.String()))
+	if instances.Err() != nil {
+		return nil, fmt.Errorf("lookup %s failed, error: %w", apiv1.BundleInstancesSelector.String(), instances.Err())
+	}
+
+	var list []BundleInstance
+	iter, err := instances.Fields(cue.Concrete(true))
+	if err != nil {
+		return nil, err
+	}
+
+	for iter.Next() {
+		name := iter.Selector().String()
+		expr := iter.Value()
+
+		vURL := expr.LookupPath(cue.ParsePath(apiv1.BundleModuleURLSelector.String()))
+		url, _ := vURL.String()
+
+		vDigest := expr.LookupPath(cue.ParsePath(apiv1.BundleModuleDigestSelector.String()))
+		digest, _ := vDigest.String()
+
+		vVersion := expr.LookupPath(cue.ParsePath(apiv1.BundleModuleVersionSelector.String()))
+		version, _ := vVersion.String()
+
+		vNamespace := expr.LookupPath(cue.ParsePath(apiv1.BundleNamespaceSelector.String()))
+		namespace, _ := vNamespace.String()
+
+		values := expr.LookupPath(cue.ParsePath(apiv1.BundleValuesSelector.String()))
+
+		list = append(list, BundleInstance{
+			Name:      name,
+			Namespace: namespace,
+			Module: apiv1.ModuleReference{
+				Repository: url,
+				Version:    version,
+				Digest:     digest,
+			},
+			Values: values,
+		})
+	}
+
+	return list, nil
+}

--- a/internal/engine/fetcher.go
+++ b/internal/engine/fetcher.go
@@ -84,8 +84,14 @@ func (f *Fetcher) Fetch() (*apiv1.ModuleReference, error) {
 }
 
 func (f *Fetcher) fetchOCI(dir string) (*apiv1.ModuleReference, error) {
-	if _, err := semver.StrictNewVersion(f.version); f.version != LatestTag && err != nil {
-		return nil, fmt.Errorf("version is not in semver format, error: %w", err)
+	ociURL := fmt.Sprintf("%s:%s", f.src, f.version)
+
+	if strings.HasPrefix(f.version, "@") {
+		ociURL = fmt.Sprintf("%s%s", f.src, f.version)
+	} else {
+		if _, err := semver.StrictNewVersion(f.version); f.version != LatestTag && err != nil {
+			return nil, fmt.Errorf("version is not in semver format, error: %w", err)
+		}
 	}
 
 	ociClient := oci.NewClient(nil)
@@ -96,7 +102,7 @@ func (f *Fetcher) fetchOCI(dir string) (*apiv1.ModuleReference, error) {
 		}
 	}
 
-	url, err := oci.ParseArtifactURL(f.src + ":" + f.version)
+	url, err := oci.ParseArtifactURL(ociURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR extends the Bundle API with support for OCI digests, the full specification can be found in #59.  

Example:

```cue
bundle: {
	apiVersion: "v1alpha1"
	instances: {
		redis: {
			module: {
				url:     "oci://<registry>/<org>/modules/redis"
				digest:  "sha256:<hex>"
			}
			namespace: "default"
		}
	}
}
```

Closes: #59