### PR TITLE
Add Arkade install method to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![release](https://img.shields.io/github/release/stefanprodan/timoni/all.svg)](https://github.com/stefanprodan/timoni/releases)
 [![platforms](https://img.shields.io/badge/platforms-linux|macos|windows-9cf.svg)](https://timoni.sh/install)
+[![build](https://github.com/stefanprodan/timoni/workflows/build/badge.svg)](https://github.com/stefanprodan/timoni/actions)
 [![license](https://img.shields.io/github/license/stefanprodan/timoni.svg)](https://github.com/stefanprodan/timoni/blob/main/LICENSE)
 
 [Timoni](https://timoni.sh) is a package manager for Kubernetes,

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,6 +14,16 @@ Each release comes with a Software Bill of Materials (SBOM) in SPDX format.
 
     Note that the Homebrew formula will setup shell autocompletion for Bash, Fish and Zsh.
 
+=== "Install with arkade"
+
+    Install the latest release on Windows, macOS or Linux with:
+    
+    ```shell
+    arkade get tiomni
+    ```
+
+    Note that the [Arkade](https://github.com/alexellis/arkade) version must be 0.9.11 or newer.
+
 === "Install from source"
 
     Using Go >= 1.20:


### PR DESCRIPTION
Add `arkade get tiomni` to install docs for Windows, macOS and Linux.

Ref: https://github.com/alexellis/arkade/pull/888