### PR TITLE
Implement listing command for module versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Commands for working with remote modules:
 
 - `timoni mod push <path/to/module> oci://<module-url> -v <semver>`
 - `timoni mod pull oci://<module-url> -v <semver> -o <path/to/module>`
+- `timoni mod list oci://<module-url>`
 
 To learn more about modules, please read the [docs](https://timoni.sh/#timoni-modules).
 

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -192,7 +192,7 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 		}
 		_, err = cmd.OutOrStdout().Write(b)
 	default:
-		return fmt.Errorf("unkown --output=%s, can be yaml or json", buildArgs.output)
+		return fmt.Errorf("unknown --output=%s, can be yaml or json", buildArgs.output)
 	}
 
 	return err

--- a/cmd/timoni/mod_list.go
+++ b/cmd/timoni/mod_list.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/flags"
+)
+
+var listModCmd = &cobra.Command{
+	Use:     "list [MODULE URL]",
+	Aliases: []string{"ls"},
+	Short:   "List the versions of a module",
+	Long:    `The list command prints a table with the module versions and their digests.`,
+	Example: `  # Print the versions of a module
+  timoni mod list oci://docker.io/org/app 
+
+  # Print the versions of a module from GitHub Container Registry
+  timoni mod list oci://ghcr.io/org/manifests/app \
+	--creds timoni:$GITHUB_TOKEN
+`,
+	RunE: listModCmdRun,
+}
+
+type listModFlags struct {
+	creds flags.Credentials
+}
+
+var listModArgs listModFlags
+
+func init() {
+	listModCmd.Flags().Var(&listModArgs.creds, listModArgs.creds.Type(), listModArgs.creds.Description())
+
+	modCmd.AddCommand(listModCmd)
+}
+
+func listModCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("module URL is required")
+	}
+	ociURL := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	fetcher := engine.NewFetcher(
+		ctx,
+		ociURL,
+		"",
+		"",
+		listModArgs.creds.String(),
+	)
+
+	list, err := fetcher.GetVersions()
+	if err != nil {
+		return err
+	}
+
+	var rows [][]string
+	for _, v := range list {
+		row := []string{
+			v.Number,
+			v.Digest,
+		}
+		rows = append(rows, row)
+	}
+
+	printTable(rootCmd.OutOrStdout(), []string{"version", "digest"}, rows)
+
+	return nil
+}

--- a/cmd/timoni/mod_list_test.go
+++ b/cmd/timoni/mod_list_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/stefanprodan/timoni/internal/engine"
+)
+
+func Test_ListMod(t *testing.T) {
+	g := NewWithT(t)
+	modPath := "testdata/module"
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
+	modVers := []string{"1.0.0", "2.0.0", "1.1.0-rc.1"}
+
+	for _, v := range modVers {
+		_, err := executeCommand(fmt.Sprintf(
+			"mod push %s oci://%s -v %s --latest",
+			modPath,
+			modURL,
+			v,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	output, err := executeCommand(fmt.Sprintf(
+		"mod ls oci://%s",
+		modURL,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(output).To(ContainSubstring(engine.LatestTag))
+	for _, v := range modVers {
+		g.Expect(output).To(ContainSubstring(v))
+	}
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ Commands for working with remote modules:
 
 - `timoni mod push <path/to/module> oci://<module-url> -v <semver>`
 - `timoni mod pull oci://<module-url> -v <semver> -o <path/to/module>`
+- `timoni mod list oci://<module-url>`
 
 Timoni produces artifacts compatible with Docker Hub, GitHub Container Registry,
 Azure Container Registry, Amazon Elastic Container Registry, Google Artifact Registry,

--- a/docs/module-semver.md
+++ b/docs/module-semver.md
@@ -64,3 +64,22 @@ then it will tag the version as `latest` in the container registry.
     some registries allow enforcing immutability for semver tags but this is not guranteed by default.
 
 To automate the publishing of module versions, please see the [Timoni GitHub Actions](github-actions.md).
+
+## Listing module versions
+
+Timoni offer a command for listing all the versions available in a container registry for a particular module.
+
+The `timoni mod list oci://<module-url>` prints a table with the versions order by semver
+and the OCI digest corresponding to each version.
+
+Example:
+
+```console
+$ timoni mod list oci://ghcr.io/stefanprodan/modules/redis
+VERSION DIGEST                                                                  
+latest  sha256:7fcb6f6918902c0dedc2ba4545fbdeca119a04644a53400af15b977e3921c600 
+7.0.10  sha256:7fcb6f6918902c0dedc2ba4545fbdeca119a04644a53400af15b977e3921c600 
+7.0.9   sha256:e9137d41b0d263bfaf2a43fc862648ad9dc3a976b4b0fc6e27617ea28ee27d45 
+7.0.8   sha256:9340d4651f15305e7932c2fd9abf131d88fe77be2f0f3b6a0c3ede9772c3f622 
+7.0.7   sha256:ba83770ce982fb6532a765009ed0429c4729bdeaa7421277618d4fb38c106be8 
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cuelang.org/go v0.4.3
 	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/distribution/distribution/v3 v3.0.0-20230327091844-0c958010ace2
-	github.com/fluxcd/pkg/oci v0.22.0
+	github.com/fluxcd/pkg/oci v0.23.0
 	github.com/fluxcd/pkg/ssa v0.27.0
 	github.com/google/go-containerregistry v0.14.0
 	github.com/mattn/go-shellwords v1.0.12
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.27.6
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/sirupsen/logrus v1.9.0
-	github.com/spf13/cobra v1.6.1
+	github.com/spf13/cobra v1.7.0
 	k8s.io/api v0.26.3
 	k8s.io/apiextensions-apiserver v0.26.3
 	k8s.io/apimachinery v0.26.3

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/fluxcd/go-git/v5 v5.0.0-20221219190809-2e5c9d01cfc4 h1:Gm5sGGk+/Wq6RhX4xpCZ2IqjDp5XkjlhENaAuAlpdKc=
 github.com/fluxcd/go-git/v5 v5.0.0-20221219190809-2e5c9d01cfc4/go.mod h1:raWgfUV7lDQVXp4QXUaeNNJkRVKz97UQuF+0kdY7Vmo=
-github.com/fluxcd/pkg/oci v0.22.0 h1:6QRvCj1YXGEGXHyVkmKiBvYxsE0sEjUrpFknM513MbQ=
-github.com/fluxcd/pkg/oci v0.22.0/go.mod h1:y0jUgMqb6ionfX+8AjhnoG8D6hSSx4elhtrQ7Uo0WzI=
+github.com/fluxcd/pkg/oci v0.23.0 h1:wUIvnGimHLl0pUErq0X6oqXakw9h0fnt7EZrTwueyp0=
+github.com/fluxcd/pkg/oci v0.23.0/go.mod h1:y0jUgMqb6ionfX+8AjhnoG8D6hSSx4elhtrQ7Uo0WzI=
 github.com/fluxcd/pkg/sourceignore v0.3.3 h1:Ue29JAuPECEYdvIqdpXpQaDxpeySn7amarLArp7XoIs=
 github.com/fluxcd/pkg/sourceignore v0.3.3/go.mod h1:yuJzKggph0Bdbk9LgXjJQhvJZSTJV/1vS7mJuB7mPa0=
 github.com/fluxcd/pkg/ssa v0.27.0 h1:BJnWDy3xDtYD2U+sVZPkoh6PfnQKoXsklO0pzojU8XU=
@@ -321,7 +321,6 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
-github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -476,8 +475,8 @@ github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.1.0/go.mod h1:sKFq3RD6/TKZkSWn8boUbDC7Qkgcv+8XXijpFO6roag=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
-github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=

--- a/internal/runtime/instances.go
+++ b/internal/runtime/instances.go
@@ -18,8 +18,9 @@ package runtime
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fluxcd/pkg/ssa"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -70,7 +71,7 @@ func (m *InstanceManager) AddObjects(objects []*unstructured.Unstructured) error
 	if m.Instance.Inventory == nil {
 		m.Instance.Inventory = &apiv1.ResourceInventory{Entries: entries}
 	} else {
-		return fmt.Errorf("inventory already containts objects: %v", m.Instance.Inventory)
+		return fmt.Errorf("inventory already contains objects: %v", m.Instance.Inventory)
 	}
 
 	return nil

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
           - Lint: cmd/timoni_mod_lint.md
           - Push: cmd/timoni_mod_push.md
           - Pull: cmd/timoni_mod_pull.md
+          - List: cmd/timoni_mod_list.md
       - Instances:
           - Apply: cmd/timoni_apply.md
           - Build: cmd/timoni_build.md


### PR DESCRIPTION
Add `timoni mod list oci://<module-url>` command which prints a table with a module's versions and OCI digests ordered by semver.

Example:

```console
$ timoni mod list oci://ghcr.io/stefanprodan/modules/podinfo
VERSION DIGEST                                                                  
latest  sha256:5c3fd5ef3cdc9d742091ddc1e2546084369069ea96a076c33c1f51374a8d6325 
6.3.5   sha256:5c3fd5ef3cdc9d742091ddc1e2546084369069ea96a076c33c1f51374a8d6325 
6.3.4   sha256:f84d9271e26c28c5209f608b11b367b0093065d126cfd39f53ed60e69c991645 
6.3.3   sha256:04edf7c1183d6e42c413cf3aa1f781a5708ef2da5efd0597bcab953648a32002 
6.3.2   sha256:0600b0f4671487f69698fc07aa3d66a0fb8ebdacb3a745fb57dd8e1a91d90df0 
6.3.1   sha256:52f3c9831449b649e820a4c75651f14d52183c8f70cd068e8a0852479edf2b5f 
6.3.0   sha256:9696eba4bf9043bacffcb8ad2940132acae894820aa9d93ffdcd00b8c89c6e54 
```