### PR TITLE
Ensure all CUE build errors are printed

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -192,7 +192,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 
 	buildResult, err := builder.Build()
 	if err != nil {
-		return fmt.Errorf("failed to build instance, error: %w", err)
+		return describeErr(fetcher.GetModuleRoot(), "failed to build instance", err)
 	}
 
 	apiVer, err := builder.GetAPIVersion(buildResult)

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -141,7 +141,7 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 
 	buildResult, err := builder.Build()
 	if err != nil {
-		return fmt.Errorf("build failed, error: %w", err)
+		return describeErr(fetcher.GetModuleRoot(), "build failed", err)
 	}
 
 	apiVer, err := builder.GetAPIVersion(buildResult)

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -197,7 +197,7 @@ func applyBundleInstance(instance engine.BundleInstance) error {
 
 	buildResult, err := builder.Build()
 	if err != nil {
-		return fmt.Errorf("failed to build instance, error: %w", err)
+		return describeErr(fetcher.GetModuleRoot(), "failed to build instance", err)
 	}
 
 	apiVer, err := builder.GetAPIVersion(buildResult)

--- a/cmd/timoni/errors.go
+++ b/cmd/timoni/errors.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+
+	"cuelang.org/go/cue/errors"
+)
+
+func describeErr(moduleRoot, description string, err error) error {
+	return fmt.Errorf("%s:\n%s", description, errors.Details(err, &errors.Config{
+		Cwd: moduleRoot,
+	}))
+}


### PR DESCRIPTION
Before:
```
✗ build failed, error: #Instance._controllerFoo.defaultImage: reference "#config" not found (and 23 more errors)
```

After:
```
✗ build failed:
#Instance._controllerFoo.defaultImage: reference "#config" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:76:35
#Instance._controllerBar.defaultImage.defaultImage: reference "#config" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:86:35
#Instance._workload.spec.template.spec.containers.command: reference "_command" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:110:13
#Instance._workload.spec.template.spec.containers.image: reference "#config" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:111:13
#Instance._workload.spec.template.spec.containers.volumeMounts.mountPath: reference "_configDir" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:119:17
#Instance._workload.spec.template.spec.containers: reference "#config" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:134:8
#Instance: reference "#config" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:144:6
#Instance._workload.spec.selector.matchLabels.name: reference "constants" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:148:34
#Instance._workload.spec.template.metadata.labels.name: reference "constants" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:150:30
#Instance._command: reference "constants" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:159:27
#Instance: reference "#config" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:162:5
#Instance._command: reference "constants" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/operator.cue:179:12
_serviceAccount.metadata.name: reference "constants" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/rbac.cue:14:9
_serviceAccount.metadata.labels.name: reference "constants" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/rbac.cue:15:17
_serviceAccount.metadata.namespace: reference "parameters" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/rbac.cue:16:14
let[]: reference "parameters" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/rbac.cue:186:21
_#clusterRole.metadata.labels.name: reference "constants" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/rbac.cue:191:26
_#clusterRoleBinding.metadata.labels.name: reference "constants" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/rbac.cue:214:26
_#clusterRoleBinding.subjects.name: reference "constants" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/rbac.cue:217:14
_#clusterRoleBinding.subjects.namespace: reference "parameters" not found:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/config/operator/rbac.cue:218:14
cannot use _ as label:
    /var/folders/gm/dnc405js6nlb275l4v2gh_b40000gn/T/timoni121902745/module/timoni.cue:13:1

```
