### PR TITLE
feat: enable name-oriented bundle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A Timoni bundle is a CUE file for defining a group of instances together with th
 ```cue
 bundle: {
 	apiVersion: "v1alpha1"
+	name: "podinfo"
 	instances: {
 		redis: {
 			module: {

--- a/api/v1alpha1/bundle.go
+++ b/api/v1alpha1/bundle.go
@@ -20,6 +20,9 @@ const (
 	// BundleAPIVersionSelector is the CUE path for the Timoni's bundle API version.
 	BundleAPIVersionSelector Selector = "bundle.apiVersion"
 
+	// BundleName is the CUE path for the Timoni's bundle name.
+	BundleName Selector = "bundle.name"
+
 	// BundleInstancesSelector is the CUE path for the Timoni's bundle instances.
 	BundleInstancesSelector Selector = "bundle.instances"
 
@@ -37,6 +40,9 @@ const (
 
 	// BundleValuesSelector is the CUE path for the Timoni's bundle instance values.
 	BundleValuesSelector Selector = "values"
+
+	// BundleNameLabelKey is the Kubernetes label key for tracking Timoni's bundle by name.
+	BundleNameLabelKey = "bundle.timoni.sh/name"
 )
 
 // BundleSchema defines the v1alpha1 CUE schema for Timoni's bundle API.
@@ -46,6 +52,7 @@ import "strings"
 
 #Bundle: {
 	apiVersion: string & =~"^v1alpha1$"
+	name: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
 	instances: [string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
 		module: close({
 			url:     string & =~"^oci://.*$"

--- a/cmd/timoni/bundle_delete_test.go
+++ b/cmd/timoni/bundle_delete_test.go
@@ -32,6 +32,7 @@ import (
 func Test_BundleDelete(t *testing.T) {
 	g := NewWithT(t)
 
+	bundleName := "my-bundle"
 	modPath := "testdata/module"
 	namespace := rnd("my-namespace", 5)
 	modName := rnd("my-mod", 5)
@@ -49,26 +50,27 @@ func Test_BundleDelete(t *testing.T) {
 	bundleData := fmt.Sprintf(`
 bundle: {
 	apiVersion: "v1alpha1"
+	name: "%[1]s"
 	instances: {
 		frontend: {
 			module: {
-				url:     "oci://%[1]s"
-				version: "%[2]s"
+				url:     "oci://%[2]s"
+				version: "%[3]s"
 			}
-			namespace: "%[3]s"
+			namespace: "%[4]s"
 			values: server: enabled: false
 		}
 		backend: {
 			module: {
-				url:     "oci://%[1]s"
-				version: "%[2]s"
+				url:     "oci://%[2]s"
+				version: "%[3]s"
 			}
-			namespace: "%[3]s"
+			namespace: "%[4]s"
 			values: client: enabled: false
 		}
 	}
 }
-`, modURL, modVer, namespace)
+`, bundleName, modURL, modVer, namespace)
 
 	t.Run("deletes instances from bundle", func(t *testing.T) {
 		g := NewWithT(t)
@@ -92,6 +94,197 @@ bundle: {
 		g.Expect(output).To(ContainSubstring("backend"))
 
 		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	t.Run("deletes instances from named bundle", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := executeCommandWithIn("bundle apply -f - -p main --wait", strings.NewReader(bundleData))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		clientCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "frontend-client",
+				Namespace: namespace,
+			},
+		}
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output, err := executeCommand(fmt.Sprintf("bundle delete --name %[1]s --namespace %[2]s --wait", bundleName, namespace))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("frontend"))
+		g.Expect(output).To(ContainSubstring("backend"))
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+}
+
+func Test_BundleDelete_MultiNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	bundleName := "my-bundle"
+	modPath := "testdata/module"
+	namespaceFrontend := rnd("my-namespace", 5)
+	namespaceBackend := rnd("my-namespace", 5)
+	modName := rnd("my-mod", 5)
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
+	modVer := "1.0.0"
+
+	_, err := executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v %s",
+		modPath,
+		modURL,
+		modVer,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	bundleData := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "%[1]s"
+	instances: {
+		frontend: {
+			module: {
+				url:     "oci://%[2]s"
+				version: "%[3]s"
+			}
+			namespace: "%[4]s"
+			values: server: enabled: false
+		}
+		backend: {
+			module: {
+				url:     "oci://%[2]s"
+				version: "%[3]s"
+			}
+			namespace: "%[5]s"
+			values: client: enabled: false
+		}
+	}
+}
+`, bundleName, modURL, modVer, namespaceFrontend, namespaceBackend)
+
+	t.Run("deletes multi-namespace instances from named bundle", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := executeCommandWithIn("bundle apply -f - -p main --wait", strings.NewReader(bundleData))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		clientCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "frontend-client",
+				Namespace: namespaceFrontend,
+			},
+		}
+
+		serverCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backend-server",
+				Namespace: namespaceBackend,
+			},
+		}
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(serverCM), serverCM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output, err := executeCommand(fmt.Sprintf("bundle delete --name %[1]s --wait -n %[2]s", bundleName, namespaceFrontend))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("frontend"))
+		g.Expect(output).NotTo(ContainSubstring("backend"))
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(serverCM), serverCM)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("deletes multi-namespace instances from named bundle namespace-by-namespace", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := executeCommandWithIn("bundle apply -f - -p main --wait", strings.NewReader(bundleData))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		clientCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "frontend-client",
+				Namespace: namespaceFrontend,
+			},
+		}
+
+		serverCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backend-server",
+				Namespace: namespaceBackend,
+			},
+		}
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(serverCM), serverCM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output, err := executeCommand(fmt.Sprintf("bundle delete --name %[1]s --wait -n %[2]s", bundleName, namespaceFrontend))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("frontend"))
+		g.Expect(output).NotTo(ContainSubstring("backend"))
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(serverCM), serverCM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output, err = executeCommand(fmt.Sprintf("bundle delete --name %[1]s --wait -n %[2]s", bundleName, namespaceBackend))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("backend"))
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(serverCM), serverCM)
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	t.Run("deletes multi-namespace instances from named bundle all-namespaces", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := executeCommandWithIn("bundle apply -f - -p main --wait", strings.NewReader(bundleData))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		clientCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "frontend-client",
+				Namespace: namespaceFrontend,
+			},
+		}
+
+		serverCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backend-server",
+				Namespace: namespaceBackend,
+			},
+		}
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(serverCM), serverCM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output, err := executeCommand(fmt.Sprintf("bundle delete --name %[1]s --wait --all-namespaces", bundleName))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("frontend"))
+		g.Expect(output).To(ContainSubstring("backend"))
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(serverCM), serverCM)
 		g.Expect(errors.IsNotFound(err)).To(BeTrue())
 	})
 }

--- a/cmd/timoni/bundle_lint.go
+++ b/cmd/timoni/bundle_lint.go
@@ -77,16 +77,16 @@ func runBundleLintCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	instances, err := bm.GetInstances(v)
+	bundle, err := bm.GetBundle(v)
 	if err != nil {
 		return err
 	}
 
-	if len(instances) == 0 {
+	if len(bundle.Instances) == 0 {
 		return fmt.Errorf("no instances found in bundle")
 	}
 
-	for _, i := range instances {
+	for _, i := range bundle.Instances {
 		if i.Namespace == "" {
 			return fmt.Errorf("instance %s does not have a namespace", i.Name)
 		}

--- a/cmd/timoni/bundle_lint_test.go
+++ b/cmd/timoni/bundle_lint_test.go
@@ -38,6 +38,7 @@ func Test_BundleLint(t *testing.T) {
 			bundle: `
 bundle: {
 	apiVersion: "v1alpha2"
+	name: "test"
 	instances: {
 		test: {
 			module: {
@@ -57,6 +58,7 @@ bundle: {
 			bundle: `
 bundle: {
 	apiVersion: "v1alpha1"
+	name: "test"
 	instances: {
 		test: {
 			module: {
@@ -76,6 +78,7 @@ bundle: {
 			bundle: `
 bundle: {
 	apiVersion: "v1alpha1"
+	name: "test"
 	instances: {
 		test: {
 			module: {
@@ -95,6 +98,7 @@ bundle: {
 			bundle: `
 bundle: {
 	apiVersion: "v1alpha1"
+	name: "test"
 	instances: {
 		test: {
 			module: {
@@ -112,7 +116,25 @@ bundle: {
 			bundle: `
 bundle: {
 	apiVersion: "v1alpha1"
+	name: "test"
 	instances: {}
+}
+`,
+		},
+		{
+			name:     "fails for missing name",
+			matchErr: "bundle.name",
+			bundle: `
+bundle: {
+	apiVersion: "v1alpha1"
+	instances: {
+		test: {
+			module: {
+				url:     "oci://docker.io/test"
+				version: "latest"
+			}
+		}
+	}
 }
 `,
 		},

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -14,6 +14,7 @@ master-replica cluster and a podinfo instance connected to the Redis instance.
 ```cue
 bundle: {
 	apiVersion: "v1alpha1"
+	name: "podinfo"
 	instances: {
 		redis: {
 			module: {
@@ -104,9 +105,25 @@ List the instances in the `podinfo` namespace:
 === "output"
 
      ```text
-     NAME    MODULE                                          VERSION LAST APPLIED         
-     podinfo oci://ghcr.io/stefanprodan/modules/podinfo      6.3.5   2023-04-10T16:20:07Z    
-     redis   oci://ghcr.io/stefanprodan/modules/redis        7.0.10  2023-04-10T16:20:00Z
+     NAME    MODULE                                          VERSION LAST APPLIED            BUNDLE
+     podinfo oci://ghcr.io/stefanprodan/modules/podinfo      6.3.5   2023-05-02T12:36:59Z    podinfo
+     redis   oci://ghcr.io/stefanprodan/modules/redis        7.0.10  2023-05-02T12:36:51Z    podinfo
+     ```
+
+List the instances in Bundle `podinfo` across all namespaces:
+
+=== "command"
+
+      ```sh
+      timoni list --bundle podinfo -A
+      ```
+
+=== "output"
+
+     ```text
+     NAME    NAMESPACE         MODULE                                          VERSION LAST APPLIED          BUNDLE
+     podinfo podinfo           oci://ghcr.io/stefanprodan/modules/podinfo      6.3.5   2023-04-10T16:20:07Z  podinfo
+     redis   podinfo           oci://ghcr.io/stefanprodan/modules/redis        7.0.10  2023-04-10T16:20:00Z  podinfo
      ```
 
 List the instance resources and their rollout status:
@@ -153,6 +170,7 @@ A Bundle file must contain a definition that matches the following schema:
 ```cue
 #Bundle: {
 	apiVersion: string
+	name: string
 	instances: [string]: {
 		module: {
 			url:     string
@@ -185,6 +203,7 @@ A Bundle must contain at least one instance with the following required fields:
 ```cue
 bundle: {
 	apiVersion: "v1alpha1"
+	name: "podinfo"
 	instances: {
 		podinfo: {
 			module: url: "oci://ghcr.io/stefanprodan/modules/podinfo"
@@ -310,6 +329,17 @@ timoni bundle apply --force -f bundle.cue
 
 With `--force`, Timoni will recreate only the resources that contain changes
 to immutable fields.
+
+### Transfer ownership
+
+If an install or upgrade involves Instances already created, either separately or as a part of another Bundle, the operation
+will fail. To transfer ownership to the current Bundle, you need to set the `--overwrite-ownership` flag.
+
+Example:
+
+```shell
+timoni bundle apply --overwrite-ownership -f bundle.cue
+```
 
 ### Uninstall
 

--- a/examples/bundles/podinfo.cue
+++ b/examples/bundles/podinfo.cue
@@ -5,6 +5,7 @@
 // a podinfo instance connected to Redis using the supplied password.
 bundle: {
 	apiVersion: "v1alpha1"
+	name: "podinfo"
 	instances: {
 		redis: {
 			module: {


### PR DESCRIPTION
The PR contains a take on https://github.com/stefanprodan/timoni/issues/76. Implementing both name-oriented Bundle deletion and Bundle-aware Instance listing, by extending the Bundle API with `.metadata.name` and tracking Instances by label `bundle.timoni.sh/name`.

Test coverage, documentation, CLI adjustments, etc, remains. Can fix this if the overall approach is okay.