### PR TITLE
Add support for building instances of a bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Commands for working with bundles:
 - `timoni bundle lint -f bundle.cue`
 - `timoni bundle apply -f bundle.cue -f bundle_extras.cue --dry-run --diff`
 - `timoni bundle delete -f bundle.cue -f bundle_extras.cue`
+- `timoni bundle build -f bundle.cue -f bundle_extras.cue`
 
 To learn more about bundles, please see the [Bundle API documentation](https://timoni.sh/bundles/).
 

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/fluxcd/pkg/ssa"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/flags"
+)
+
+var bundleBuildCmd = &cobra.Command{
+	Use:     "build",
+	Aliases: []string{"template"},
+	Short:   "Build and print the resulting Kubernetes resources for all instances from a Bundle",
+	Long: `The bundle build command builds and prints the resulting Kubernetes resources for all instances defined in a Bundle.
+`,
+	Example: `  # Build all instances from a bundle
+  timoni bundle build -f bundle.cue
+
+  # Pass secret values from stdin
+  cat ./bundle_secrets.cue | timoni bundle build -f ./bundle.cue -f -
+`,
+	RunE: runBundleBuildCmd,
+}
+
+type bundleBuildFlags struct {
+	pkg   flags.Package
+	files []string
+	creds flags.Credentials
+}
+
+var bundleBuildArgs bundleBuildFlags
+
+func init() {
+	bundleBuildCmd.Flags().VarP(&bundleBuildArgs.pkg, bundleBuildArgs.pkg.Type(), bundleBuildArgs.pkg.Shorthand(), bundleBuildArgs.pkg.Description())
+	bundleBuildCmd.Flags().StringSliceVarP(&bundleBuildArgs.files, "file", "f", nil,
+		"The local path to bundle.cue files.")
+	bundleBuildCmd.Flags().Var(&bundleBuildArgs.creds, bundleBuildArgs.creds.Type(), bundleBuildArgs.creds.Description())
+	bundleCmd.AddCommand(bundleBuildCmd)
+}
+
+func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
+	bundleSchema, err := os.CreateTemp("", "schema.*.cue")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(bundleSchema.Name())
+	if _, err := bundleSchema.WriteString(apiv1.BundleSchema); err != nil {
+		return err
+	}
+
+	files := append(bundleBuildArgs.files, bundleSchema.Name())
+	for i, file := range files {
+		if file == "-" {
+			path, err := saveReaderToFile(cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+
+			defer os.Remove(path)
+
+			files[i] = path
+		}
+	}
+
+	ctx := cuecontext.New()
+	bm := engine.NewBundleBuilder(ctx, files)
+
+	v, err := bm.Build()
+	if err != nil {
+		return err
+	}
+
+	bundle, err := bm.GetBundle(v)
+	if err != nil {
+		return err
+	}
+
+	var sb strings.Builder
+
+	for i, instance := range bundle.Instances {
+		sb.WriteString("---\n")
+		sb.WriteString(fmt.Sprintf("# Instance: %s\n", instance.Name))
+		sb.WriteString("---\n")
+
+		instance, err := buildBundleInstance(instance)
+		if err != nil {
+			return err
+		}
+
+		sb.WriteString(instance)
+		if i < len(bundle.Instances)-1 {
+			sb.WriteString("\n")
+		}
+	}
+
+	cmd.OutOrStdout().Write([]byte(sb.String()))
+
+	return nil
+}
+
+func buildBundleInstance(instance engine.BundleInstance) (string, error) {
+	moduleVersion := instance.Module.Version
+
+	if moduleVersion == engine.LatestTag && instance.Module.Digest != "" {
+		moduleVersion = "@" + instance.Module.Digest
+	}
+
+	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ctxPull, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	fetcher := engine.NewFetcher(
+		ctxPull,
+		instance.Module.Repository,
+		moduleVersion,
+		tmpDir,
+		bundleBuildArgs.creds.String(),
+	)
+	mod, err := fetcher.Fetch()
+	if err != nil {
+		return "", err
+	}
+
+	if instance.Module.Digest != "" && mod.Digest != instance.Module.Digest {
+		return "", fmt.Errorf("the upstream digest %s of version %s doesn't match the specified digest %s",
+			mod.Digest, instance.Module.Version, instance.Module.Digest)
+	}
+
+	cuectx := cuecontext.New()
+	builder := engine.NewModuleBuilder(
+		cuectx,
+		instance.Name,
+		instance.Namespace,
+		fetcher.GetModuleRoot(),
+		bundleBuildArgs.pkg.String(),
+	)
+
+	if err := builder.WriteSchemaFile(); err != nil {
+		return "", err
+	}
+
+	mod.Name, err = builder.GetModuleName()
+	if err != nil {
+		return "", err
+	}
+
+	err = builder.WriteValuesFile(instance.Values)
+	if err != nil {
+		return "", err
+	}
+
+	buildResult, err := builder.Build()
+	if err != nil {
+		return "", describeErr(fetcher.GetModuleRoot(), "failed to build instance", err)
+	}
+
+	bundleBuildSets, err := builder.GetApplySets(buildResult)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract objects: %w", err)
+	}
+
+	var objects []*unstructured.Unstructured
+	for _, set := range bundleBuildSets {
+		objects = append(objects, set.Objects...)
+	}
+	sort.Sort(ssa.SortableUnstructureds(objects))
+
+	var sb strings.Builder
+
+	for i, r := range objects {
+		data, err := yaml.Marshal(r)
+		if err != nil {
+			return "", fmt.Errorf("converting objects failed: %w", err)
+		}
+
+		if i != 0 {
+			sb.WriteString("---\n")
+		}
+		sb.Write(data)
+	}
+
+	return sb.String(), nil
+}

--- a/cmd/timoni/bundle_build_test.go
+++ b/cmd/timoni/bundle_build_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fluxcd/pkg/ssa"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func Test_BundleBuild(t *testing.T) {
+	g := NewWithT(t)
+
+	bundleName := "my-bundle"
+	modPath := "testdata/module"
+	namespace := rnd("my-namespace", 5)
+	modName := rnd("my-mod", 5)
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
+	modVer := "1.0.0"
+
+	// Push the module to registry
+	_, err := executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v %s",
+		modPath,
+		modURL,
+		modVer,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	bundleData := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "%[1]s"
+	instances: {
+		frontend: {
+			module: {
+				url:     "oci://%[2]s"
+				version: "%[3]s"
+			}
+			namespace: "%[4]s"
+			values: server: enabled: false
+		}
+		backend: {
+			module: {
+				url:     "oci://%[2]s"
+				version: "%[3]s"
+			}
+			namespace: "%[4]s"
+			values: client: enabled: false
+		}
+	}
+}
+`, bundleName, modURL, modVer, namespace)
+
+	bundlePath := filepath.Join(t.TempDir(), "bundle.cue")
+	err = os.WriteFile(bundlePath, []byte(bundleData), 0644)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	t.Run("builds instances from bundle", func(t *testing.T) {
+		execCommands := map[string]func() (string, error){
+			"using a file": func() (string, error) {
+				return executeCommand(fmt.Sprintf(
+					"bundle build -f %s -p main",
+					bundlePath,
+				))
+			},
+			"using stdin": func() (string, error) {
+				r := strings.NewReader(bundleData)
+				return executeCommandWithIn("bundle build -f - -p main", r)
+			},
+		}
+
+		for name, execCommand := range execCommands {
+			t.Run(name, func(t *testing.T) {
+				g := NewWithT(t)
+				output, err := execCommand()
+				g.Expect(err).ToNot(HaveOccurred())
+
+				objects, err := ssa.ReadObjects(strings.NewReader(output))
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(objects).To(HaveLen(2))
+
+				frontendClientCm, err := getObjectByName(objects, "frontend-client")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(frontendClientCm.GetKind()).To(BeEquivalentTo("ConfigMap"))
+				g.Expect(frontendClientCm.GetNamespace()).To(ContainSubstring(namespace))
+
+				backendClientCm, err := getObjectByName(objects, "backend-server")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(backendClientCm.GetKind()).To(BeEquivalentTo("ConfigMap"))
+				g.Expect(backendClientCm.GetNamespace()).To(ContainSubstring(namespace))
+			})
+		}
+	})
+}
+
+func getObjectByName(objs []*unstructured.Unstructured, name string) (*unstructured.Unstructured, error) {
+	for _, obj := range objs {
+		if obj.GetName() == name {
+			return obj, nil
+		}
+	}
+	return nil, fmt.Errorf("Object with name '%s' does not exist.", name)
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,6 +179,7 @@ Commands for working with bundles:
 - `timoni bundle lint -f bundle.cue`
 - `timoni bundle apply -f bundle.cue -f bundle_extras.cue --dry-run --diff`
 - `timoni bundle delete -f bundle.cue -f bundle_extras.cue`
+- `timoni bundle build -f bundle.cue -f bundle_extras.cue`
 
 To learn more about bundles, please see the [Bundle API documentation](https://timoni.sh/bundles/).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
           - Status: cmd/timoni_status.md
       - Bundles:
           - Apply: cmd/timoni_bundle_apply.md
+          - Build: cmd/timoni_bundle_build.md
           - Delete: cmd/timoni_bundle_delete.md
           - Lint: cmd/timoni_bundle_lint.md
       - Completion:


### PR DESCRIPTION
This adds support for building all instances of a bundle and print the resulting Kubernetes resources to stdout using the following command: `timoni bundle build`. This is intended to be work similar to how a single instance can be built using the [timoni build](https://timoni.sh/cmd/timoni_build/) command.

Fix: #97.