### PR TITLE
Document SLSA Provenance & SBOMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![platforms](https://img.shields.io/badge/platforms-linux|macos|windows-9cf.svg)](https://timoni.sh/install)
 [![build](https://github.com/stefanprodan/timoni/workflows/build/badge.svg)](https://github.com/stefanprodan/timoni/actions)
 [![license](https://img.shields.io/github/license/stefanprodan/timoni.svg)](https://github.com/stefanprodan/timoni/blob/main/LICENSE)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 [Timoni](https://timoni.sh) is a package manager for Kubernetes,
 powered by [CUE](https://cuelang.org/)

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,6 @@
 
 Timoni is available as a binary executable for Linux, macOS and Windows.
 The AMD64 and ARM64 binaries can be downloaded from GitHub [releases](https://github.com/stefanprodan/timoni/releases).
-Each release comes with a Software Bill of Materials (SBOM) in SPDX format.
 
 === "Install with brew"
 
@@ -115,3 +114,36 @@ Configure your shell to load timoni completions:
     mv _timoni ~/.oh-my-zsh/completions  # oh-my-zsh
     mv _timoni ~/.zprezto/modules/completion/external/src/  # zprezto
     ```
+
+## SLSA Provenance & SBOMs
+
+Starting with v0.7, Timoni is compliant with [SLSA Level 3](https://slsa.dev/).
+The release artifacts are produced on GitHub-hosted runners using
+[GoReleaser](https://goreleaser.com) and the provenance generation
+is handled by the official
+[SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator).
+
+To verify a release artifact such as the Timoni binary,
+you can use the [slsa-verifier](https://github.com/slsa-framework/slsa-verifier) tool:
+
+```shell
+TIMONI_VER=0.7.1 && \
+gh release download v${TIMONI_VER} -R=stefanprodan/timoni -p="*" && \
+slsa-verifier verify-artifact \
+--provenance-path multiple.intoto.jsonl \
+--source-uri github.com/stefanprodan/timoni  \
+--source-tag v${TIMONI_VER} \
+timoni_${TIMONI_VER}_darwin_arm64.tar.gz
+```
+
+Each release comes with a Software Bill of Materials (SBOM) in [SPDX](https://spdx.dev) format.
+The SBOMs are generated on GitHub-hosted runners using
+[GoReleaser](https://goreleaser.com) and [Syft](https://github.com/anchore/syft).
+
+To scan a release for vulnerabilities, you can use [Grype](https://github.com/anchore/grype):
+
+```shell
+TIMONI_VER=0.7.1 && \
+gh release download v${TIMONI_VER} -R=stefanprodan/timoni -p="*sbom.spdx.json" && \
+grype sbom:./timoni_${TIMONI_VER}_sbom.spdx.json
+```


### PR DESCRIPTION
Add SLSA Provenance & SBOMs section to docs, explain how to verify the provenance and how to scan the SBOM for vulnerabilities. 