### PR TITLE
Increase default timeout to 5m

### DIFF
--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -64,7 +64,7 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().DurationVar(&rootArgs.timeout, "timeout", time.Minute,
+	rootCmd.PersistentFlags().DurationVar(&rootArgs.timeout, "timeout", 5*time.Minute,
 		"The length of time to wait before giving up on the current operation.")
 	rootCmd.PersistentFlags().BoolVar(&rootArgs.prettyLog, "log-pretty", true,
 		"Adds timestamps and colorized output to the logs.")


### PR DESCRIPTION
Change the timeout default to accommodate statefulsets and complex module such as https://github.com/stefanprodan/flux-aio   