### PR TITLE
Add support for injecting values from environment variables

### DIFF
--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -176,7 +176,7 @@ func buildBundleInstance(instance engine.BundleInstance) (string, error) {
 		return "", err
 	}
 
-	err = builder.WriteValuesFile(instance.Values)
+	err = builder.WriteValuesFileWithDefaults(instance.Values)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -66,16 +66,7 @@ func init() {
 }
 
 func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
-	bundleSchema, err := os.CreateTemp("", "schema.*.cue")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(bundleSchema.Name())
-	if _, err := bundleSchema.WriteString(apiv1.BundleSchema); err != nil {
-		return err
-	}
-
-	files := append(bundleBuildArgs.files, bundleSchema.Name())
+	files := bundleBuildArgs.files
 	for i, file := range files {
 		if file == "-" {
 			path, err := saveReaderToFile(cmd.InOrStdin())
@@ -89,12 +80,22 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
 	ctx := cuecontext.New()
 	bm := engine.NewBundleBuilder(ctx, files)
 
+	if err := bm.InitWorkspace(tmpDir); err != nil {
+		return describeErr(tmpDir, "failed to parse bundle", err)
+	}
+
 	v, err := bm.Build()
 	if err != nil {
-		return err
+		return describeErr(tmpDir, "failed to build bundle", err)
 	}
 
 	bundle, err := bm.GetBundle(v)

--- a/cmd/timoni/bundle_lint_test.go
+++ b/cmd/timoni/bundle_lint_test.go
@@ -138,9 +138,30 @@ bundle: {
 }
 `,
 		},
+		{
+			name:     "fails for invalid attribute",
+			matchErr: "unknown type",
+			bundle: `
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "test"
+	instances: {
+		test: {
+			namespace: "default"
+			module: {
+				url:     "oci://docker.io/test"
+				version: "latest" @timoni(env:strings:TEST_BLINT_VER)
+			}
+		}
+	}
+}
+`,
+		},
 	}
 
 	tmpDir := t.TempDir()
+	t.Setenv("TEST_BLINT_VER", "1.0.0")
+
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -101,8 +101,12 @@ func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
 		rootCmd.SetIn(in)
 	}
 
-	zlog := zerolog.ConsoleWriter{Out: buf, NoColor: true}
-	zl := zerolog.New(zlog)
+	zcfg := zerolog.ConsoleWriter{Out: buf, NoColor: true}
+	zcfg.PartsExclude = []string{
+		zerolog.TimestampFieldName,
+		zerolog.LevelFieldName,
+	}
+	zl := zerolog.New(zcfg)
 	logger = zerologr.New(&zl)
 	runtimeLog.SetLogger(logger)
 

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -598,6 +598,33 @@ The `instance.values` is an optional field that specifies custom values used to 
 At apply time, Timoni merges the custom values with the defaults,
 validates the final values against the config schema and creates the instance.
 
+#### Values from environment variables
+
+The `@timoni(env:[string|number|bool]:[ENV_VAR_NAME])` CUE attribute can be placed next
+to a field to set its value from the environment.
+
+```cue
+values: {
+	host:    "example.com" @timoni(env:string:MY_HOST)
+	enabled: true          @timoni(env:bool:MY_ENABLED)
+	score:   1             @timoni(env:number:MY_SCORE)
+}
+```
+
+To make an environment variable required, the field value can be set to its type:
+
+```cue
+values: {
+	host:    string @timoni(env:string:MY_HOST)
+	enabled: bool   @timoni(env:bool:MY_ENABLED)
+	score:   int    @timoni(env:number:MY_SCORE)
+}
+```
+
+At apply time, Timoni injects the fields values from the environment,
+if a specified env var is not found and if a default is not provided,
+the build operation with fail with an `incomplete value` error.
+
 ## Working with Bundles
 
 ### Install and Upgrade
@@ -660,6 +687,49 @@ Example:
 timoni bundle apply --overwrite-ownership -f bundle.cue
 ```
 
+#### Inject values from environment variables
+
+To inject values from environment variables, you can add CUE attributes next to fields
+in the format `@timoni(env:[string|number|bool]:[ENV_VAR_NAME])`.
+
+Example:
+
+```cue
+registry: "my-registry.com/my-org" @timoni(env:string:APP_REGISTRY)
+
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "my-apps"
+	instances: {
+		"app": {
+			module: {
+				url:     "oci://\(registry)/modules/app"
+				version: "1.0.0" @timoni(env:string:APP_VER)
+			}
+			values: {
+				// required string (can be multi-line)
+				sshKey: string @timoni(env:string:SSH_KEY)
+				// optional boolean (defaults to false)
+				isAdmin: false @timoni(env:bool:IS_ADMIN)
+				// required number
+				age: int @timoni(env:number:AGE)
+			}
+		}
+	}
+}
+```
+
+Export the env vars and run the `timoni bundle apply` command.
+
+```shell
+EXPORT APP_REGISTRY="localhost:5050"
+EXPORT SSH_KEY=$(cat .ssh/id_ecdsa.pub)
+EXPORT IS_ADMIN="true"
+EXPORT AGE="41"
+
+timoni bundle apply -f bundle.cue
+```
+
 ### Build
 
 To build the instances defined in a Bundle file and print the resulting Kubernetes resources,
@@ -717,7 +787,8 @@ The readiness check is performed for the Kubernetes resources with the following
 - Kubernetes built-in kinds: Deployment, DaemonSet, StatefulSet,
   PersistentVolumeClaim, Pod, PodDisruptionBudget, Job, CronJob, Service,
   Secret, ConfigMap, CustomResourceDefinition
-- Custom resources that are compatible with [kstatus](https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus)
+- Custom resources that are compatible
+  with [kstatus](https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus)
 
 Example:
 

--- a/internal/engine/injector.go
+++ b/internal/engine/injector.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/ast/astutil"
+	"cuelang.org/go/cue/format"
+	"cuelang.org/go/cue/literal"
+	"cuelang.org/go/cue/parser"
+	"cuelang.org/go/cue/token"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+// Injector injects field values in CUE files based on @timoni() attributes.
+type Injector struct {
+	ctx *cue.Context
+}
+
+// NewInjector creates an Injector for the given context.
+func NewInjector(ctx *cue.Context) *Injector {
+	return &Injector{ctx: ctx}
+}
+
+// Inject searches for attributes in the format
+// '@timoni(env:[string|number|bool]:[ENV_VAR_NAME])'
+// and sets the CUE field value to the env var value.
+// If an env var is not found in the current environment,
+// the CUE field is left untouched.
+func (in *Injector) Inject(src string) ([]byte, error) {
+	tree, err := parser.ParseFile(src, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := in.injectFromEnv(tree)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := format.Node(output)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (in *Injector) injectFromEnv(tree *ast.File) (ast.Node, error) {
+	var re error
+	f := func(c astutil.Cursor) bool {
+		n := c.Node()
+		switch n.(type) {
+		case *ast.Field:
+			field := n.(*ast.Field)
+			if len(field.Attrs) == 0 {
+				return true
+			}
+
+			var key, body string
+			for _, a := range field.Attrs {
+				key, body = a.Split()
+				if key == apiv1.FieldManager {
+					break
+				}
+			}
+
+			if key == "" {
+				return true
+			}
+
+			parts := strings.Split(body, ":")
+
+			if len(parts) != 3 || parts[0] != "env" {
+				return true
+			}
+
+			envKind := parts[1]
+			envKey := parts[2]
+
+			if envVal, ok := os.LookupEnv(envKey); ok {
+				switch envKind {
+				case "string":
+					field.Value = ast.NewLit(token.STRING, in.quoteString(envVal))
+				case "number":
+					field.Value = ast.NewLit(token.INT, envVal)
+				case "bool":
+					field.Value = ast.NewIdent(envVal)
+				default:
+					re = fmt.Errorf("failed to parse attribute '@%s(%s)', unkown type '%s' must be string, number or bool",
+						apiv1.FieldManager, body, envKind)
+					return false
+				}
+				c.Replace(field)
+			}
+		}
+		return true
+	}
+
+	return astutil.Apply(tree, f, nil), re
+}
+
+func (in *Injector) quoteString(s string) string {
+	lines := []string{}
+	last := 0
+	for i, c := range s {
+		if c == '\n' {
+			lines = append(lines, s[last:i])
+			last = i + 1
+		}
+		if c == '\r' {
+			goto quoted
+		}
+	}
+	lines = append(lines, s[last:])
+	if len(lines) >= 2 {
+		buf := []byte{}
+		buf = append(buf, `"""`+"\n"...)
+		for _, l := range lines {
+			if l == "" {
+				// no indentation for empty lines
+				buf = append(buf, '\n')
+				continue
+			}
+			buf = append(buf, '\t')
+			p := len(buf)
+			buf = strconv.AppendQuote(buf, l)
+			// remove quotes
+			buf[p] = '\t'
+			buf[len(buf)-1] = '\n'
+		}
+		buf = append(buf, "\t\t"+`"""`...)
+		return string(buf)
+	}
+quoted:
+	return literal.String.Quote(s)
+}

--- a/internal/engine/injector.go
+++ b/internal/engine/injector.go
@@ -108,7 +108,7 @@ func (in *Injector) injectFromEnv(tree *ast.File) (ast.Node, error) {
 				case "bool":
 					field.Value = ast.NewIdent(envVal)
 				default:
-					re = fmt.Errorf("failed to parse attribute '@%s(%s)', unkown type '%s' must be string, number or bool",
+					re = fmt.Errorf("failed to parse attribute '@%s(%s)', unknown type '%s' must be string, number or bool",
 						apiv1.FieldManager, body, envKind)
 					return false
 				}

--- a/internal/engine/injector_test.go
+++ b/internal/engine/injector_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	. "github.com/onsi/gomega"
+)
+
+func TestInjector_Env(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	t.Setenv("USERNAME", "stefanprodan")
+	key := `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQSuBF9+HgMRDADKT8UBcSzpTi4JXt/ohhVW3x81AGFPrQvs6MYrcnNJfIkPTJD8
+.........
+=/4e+
+-----END PGP PUBLIC KEY BLOCK-----`
+	t.Setenv("PGP_PUB_KEY", key)
+	t.Setenv("AGE", "41")
+	t.Setenv("IS_ADMIN", "true")
+
+	vb := NewInjector(ctx)
+
+	base := "testdata/inject/env.cue"
+
+	result, err := vb.Inject(base)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	want := `package test
+
+// these secret values are injected at apply time from OS ENV
+secrets: {
+	username: "stefanprodan" @timoni(env:string:USERNAME)
+
+	// The OpenPGP key will be injected as a multi-line string
+	key: """
+		-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+		mQSuBF9+HgMRDADKT8UBcSzpTi4JXt/ohhVW3x81AGFPrQvs6MYrcnNJfIkPTJD8
+		.........
+		=/4e+
+		-----END PGP PUBLIC KEY BLOCK-----
+		""" @timoni(env:string:PGP_PUB_KEY)
+
+	age:     41   @timoni(env:number:AGE)
+	isAdmin: true @timoni(env:bool:IS_ADMIN)
+}
+`
+	g.Expect(string(result)).To(BeIdenticalTo(want))
+}

--- a/internal/engine/module_builder.go
+++ b/internal/engine/module_builder.go
@@ -82,20 +82,7 @@ func (b *ModuleBuilder) MergeValuesFile(overlays [][]byte) error {
 	return os.WriteFile(defaultFile, []byte(cueGen), 0644)
 }
 
-// WriteValuesFile overwrites the module's root values.cue.
-func (b *ModuleBuilder) WriteValuesFile(val cue.Value) error {
-	defaultFile := filepath.Join(b.pkgPath, defaultValuesFile)
-
-	cueGen := fmt.Sprintf("package %s\n%s: %v", b.pkgName, apiv1.ValuesSelector, val)
-
-	// overwrite the values.cue file with the merged values
-	if err := os.MkdirAll(b.moduleRoot, os.ModePerm); err != nil {
-		return err
-	}
-	return os.WriteFile(defaultFile, []byte(cueGen), 0644)
-}
-
-// WriteValuesFileWithDefaults merges the module's root values.cue with supplied ones.
+// WriteValuesFileWithDefaults merges the module's root values.cue with the supplied value.
 func (b *ModuleBuilder) WriteValuesFileWithDefaults(val cue.Value) error {
 	defaultFile := filepath.Join(b.pkgPath, defaultValuesFile)
 

--- a/internal/engine/testdata/inject/env.cue
+++ b/internal/engine/testdata/inject/env.cue
@@ -1,0 +1,12 @@
+package test
+
+// these secret values are injected at apply time from OS ENV
+secrets: {
+	username: *"test" | string @timoni(env:string:USERNAME)
+
+	// The OpenPGP key will be injected as a multi-line string
+	key: string @timoni(env:string:PGP_PUB_KEY)
+
+	age:     int  @timoni(env:number:AGE)
+	isAdmin: bool @timoni(env:bool:IS_ADMIN)
+}


### PR DESCRIPTION
This PR introduces a CUE attribute in the format `@timoni(env:[string|number|bool]:[ENV_VAR_NAME])`. The attribute can be placed in bundles next to any field to set its value from the environment at runtime.

### Motivation

As shown [here](https://github.com/stefanprodan/timoni/tree/main/examples/bundles), a Timoni bundle can be made out of multiple files, so we can have a CUE file that contains some values generated at runtime from various sources e.g. an encrypted store, CI vars, etc. While this approach works, it forces uses into storing or generating CUE files in CI, which can be cumbersome. By introducing support for environment variables, users can easily inject values without having to modify their pipelines, as most workflow engines can set env vars before running a command. 

Another reason for implementing environment variables is offering a similar feature to Helm's `--set-file` and `--set-json`. Some modules may require users to provide TLS certs, or app config files (JSON, INI, XML). Instead of forcing users into embedding the file text content in a bundle, the content can be stored in an env var and Timoni will inject it at runtime in the bundle as  multi-line string, preserving the original indentation.

An alternative to using the environment to inject file contents, would be adding an attribute for reading files from disk e.g. `@timoni(import:string:ssh/id_ecdsa.pub)`. But then we'll have to deal with relative paths (to the bundle or to the execution root?), symlinks, path traversal protection, etc. I think for now, we can ship the environment solution and see what issues users will have with it, then decide if we really need a file reader.

### Example

```cue
appName: string @timoni(env:string:APP_NAME)

bundle: {
	apiVersion: "v1alpha1"
	name:       "\(appName)"
	instances: {
		"\(appName)": {
			module: {
				url:     "oci://my-registry/modules/app"
				version: "1.0.0" @timoni(env:string:APP_VER)
			}
			values: {
				// required string (can be multi-line)
				sshKey: string @timoni(env:string:SSH_KEY)
				// optional boolean (defaults to false)
				isAdmin: false @timoni(env:bool:IS_ADMIN)
				// required number
				age: int @timoni(env:number:AGE)
			}
		}
	}
}
```

Export the env vars and run the `timoni bundle apply` command.

```shell
EXPORT APP_NAME="my-app"
EXPORT SSH_KEY=$(cat .ssh/id_ecdsa.pub)
EXPORT IS_ADMIN="true"
EXPORT AGE="41"

timoni bundle apply -f bundle.cue
```

At apply time, Timoni injects the fields values from the environment, if a specified env var is not found and if a default is not provided, the build operation with fail with an `incomplete value` error.