### PR TITLE
feat: add YAML and JSON support for bundles

### DIFF
--- a/internal/engine/bundle_builder.go
+++ b/internal/engine/bundle_builder.go
@@ -22,8 +22,10 @@ import (
 	"path/filepath"
 
 	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/load"
+	"cuelang.org/go/encoding/yaml"
 	cp "github.com/otiai10/copy"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
@@ -118,6 +120,15 @@ func (b *BundleBuilder) Build() (cue.Value, error) {
 	}
 
 	v := b.ctx.BuildInstance(inst)
+	for _, f := range inst.OrphanedFiles {
+		if f.Encoding == build.YAML {
+			a, err := yaml.Extract(f.Filename, f.Source)
+			if err != nil {
+				return value, err
+			}
+			v = v.Unify(b.ctx.BuildFile(a))
+		}
+	}
 	if v.Err() != nil {
 		return value, v.Err()
 	}

--- a/internal/engine/injector.go
+++ b/internal/engine/injector.go
@@ -54,6 +54,10 @@ func (in *Injector) Inject(src string) ([]byte, error) {
 		return nil, err
 	}
 
+	return in.InjectNode(tree)
+}
+
+func (in *Injector) InjectNode(tree ast.Node) ([]byte, error) {
 	output, err := in.injectFromEnv(tree)
 	if err != nil {
 		return nil, err
@@ -67,7 +71,7 @@ func (in *Injector) Inject(src string) ([]byte, error) {
 	return data, nil
 }
 
-func (in *Injector) injectFromEnv(tree *ast.File) (ast.Node, error) {
+func (in *Injector) injectFromEnv(tree ast.Node) (ast.Node, error) {
 	var re error
 	f := func(c astutil.Cursor) bool {
 		n := c.Node()


### PR DESCRIPTION
This little addition add YAML support for bundle file. It can be useful for multiple purposes, like using `sops` encrypted files until we address #74.

I'm also referencing cue-lang/cue/discussions/2452 in case a better way of including Orphan files exists.