### PR TITLE
Add completion for instances and namespaces

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -86,6 +86,16 @@ The apply command performs the following steps:
   --values ./values-2.json
 `,
 	RunE: runApplyCmd,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return completeInstanceList(cmd, args, toComplete)
+		case 1:
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		default:
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	},
 }
 
 type applyFlags struct {

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -53,6 +53,16 @@ var buildCmd = &cobra.Command{
   --values ./values-2.cue
 `,
 	RunE: runBuildCmd,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return completeInstanceList(cmd, args, toComplete)
+		case 1:
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		default:
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	},
 }
 
 type buildFlags struct {

--- a/cmd/timoni/completion_funcs.go
+++ b/cmd/timoni/completion_funcs.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/stefanprodan/timoni/internal/runtime"
+)
+
+// completeNamespaceList completes a Cobra argument or flag with
+// a Timoni instance, based on the current context in ~/.kube/config,
+// and the current namespace set via --namespace.
+func completeInstanceList(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	instances, err := listInstancesFromFlags()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	var completions []string
+	for _, inst := range instances {
+		if strings.HasPrefix(inst.Name, toComplete) {
+			completions = append(completions, inst.Name)
+		}
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeNamespaceList completes a Cobra argument or flag with
+// a Kubernetes namespace, based on the current context in ~/.kube/config
+func completeNamespaceList(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	sm, err := runtime.NewResourceManager(kubeconfigArgs)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	iStorage := runtime.NewStorageManager(sm)
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	namespaces, err := iStorage.ListNamespaces(ctx)
+
+	var completions []string
+	for _, ns := range namespaces {
+		if strings.HasPrefix(ns, toComplete) {
+			completions = append(completions, ns)
+		}
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/timoni/delete.go
+++ b/cmd/timoni/delete.go
@@ -39,6 +39,14 @@ var deleteCmd = &cobra.Command{
   timoni delete --dry-run app
 `,
 	RunE: runDeleteCmd,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return completeInstanceList(cmd, args, toComplete)
+		default:
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	},
 }
 
 type deleteFlags struct {

--- a/cmd/timoni/inspect_module.go
+++ b/cmd/timoni/inspect_module.go
@@ -33,6 +33,14 @@ var inspectModuleCmd = &cobra.Command{
   timoni -n default inspect module app
 `,
 	RunE: runInspectModuleCmd,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return completeInstanceList(cmd, args, toComplete)
+		default:
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	},
 }
 
 type inspectModuleFlags struct {

--- a/cmd/timoni/inspect_resources.go
+++ b/cmd/timoni/inspect_resources.go
@@ -32,6 +32,14 @@ var inspectResourcesCmd = &cobra.Command{
   timoni -n default inspect resources app
 `,
 	RunE: runInspectResourcesCmd,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return completeInstanceList(cmd, args, toComplete)
+		default:
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	},
 }
 
 type inspectResourcesFlags struct {

--- a/cmd/timoni/inspect_values.go
+++ b/cmd/timoni/inspect_values.go
@@ -34,6 +34,14 @@ var inspectValuesCmd = &cobra.Command{
   timoni -n default inspect values app > values.cue
 `,
 	RunE: runInspectValuesCmd,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return completeInstanceList(cmd, args, toComplete)
+		default:
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	},
 }
 
 type inspectValuesFlags struct {

--- a/cmd/timoni/list.go
+++ b/cmd/timoni/list.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"context"
-	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"io"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -60,22 +61,7 @@ func init() {
 }
 
 func runListCmd(cmd *cobra.Command, args []string) error {
-	sm, err := runtime.NewResourceManager(kubeconfigArgs)
-	if err != nil {
-		return err
-	}
-
-	iStorage := runtime.NewStorageManager(sm)
-
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
-	defer cancel()
-
-	ns := *kubeconfigArgs.Namespace
-	if listArgs.allNamespaces {
-		ns = ""
-	}
-
-	instances, err := iStorage.List(ctx, ns, listArgs.bundleName)
+	instances, err := listInstancesFromFlags()
 	if err != nil {
 		return err
 	}
@@ -111,6 +97,25 @@ func runListCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func listInstancesFromFlags() ([]*apiv1.Instance, error) {
+	sm, err := runtime.NewResourceManager(kubeconfigArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	iStorage := runtime.NewStorageManager(sm)
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	ns := *kubeconfigArgs.Namespace
+	if listArgs.allNamespaces {
+		ns = ""
+	}
+
+	return iStorage.List(ctx, ns, listArgs.bundleName)
 }
 
 func printTable(writer io.Writer, header []string, rows [][]string) {

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -114,4 +114,5 @@ func addKubeConfigFlags(cmd *cobra.Command) {
 	kubeconfigArgs.Namespace = &namespace
 
 	cmd.PersistentFlags().StringVarP(kubeconfigArgs.Namespace, "namespace", "n", *kubeconfigArgs.Namespace, "The instance namespace.")
+	cmd.RegisterFlagCompletionFunc("namespace", completeNamespaceList)
 }

--- a/cmd/timoni/status.go
+++ b/cmd/timoni/status.go
@@ -38,6 +38,14 @@ var statusCmd = &cobra.Command{
   timoni status -n apps app
 `,
 	RunE: runstatusCmd,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return completeInstanceList(cmd, args, toComplete)
+		default:
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	},
 }
 
 type statusFlags struct {

--- a/internal/runtime/storage.go
+++ b/internal/runtime/storage.go
@@ -171,6 +171,21 @@ func (s *StorageManager) GetStaleObjects(ctx context.Context, i *apiv1.Instance)
 	return objects, nil
 }
 
+func (s *StorageManager) ListNamespaces(ctx context.Context) ([]string, error) {
+	nsList := &corev1.NamespaceList{}
+	err := s.resManager.Client().List(ctx, nsList)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]string, len(nsList.Items))
+	for _, ns := range nsList.Items {
+		res = append(res, ns.Name)
+	}
+
+	return res, nil
+}
+
 // NamespaceExists returns false if the namespace is not found.
 func (s *StorageManager) NamespaceExists(ctx context.Context, name string) (bool, error) {
 	ns := &corev1.Namespace{


### PR DESCRIPTION
Adds Cobra completion on installed instances.

I've not yet added them to all commands, as I want to ensure design is good first, so I don't have that many places to edit it.

Preview:

```console
$ timoni delete <TAB>
 »» completions ««
podinfo  nginx  -- Installed in namespace "timoni-testing"

$ timoni delete -n default
 »» no matches found ««
```

Clarification: Those `»»««` headers are from Zsh I think, or some weird plugin I have installed. They're at least not from Cobra or timoni
