### PR TITLE
Prettier and more colorized output for the apply commands

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -268,7 +268,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 
 	if applyArgs.dryrun || applyArgs.diff {
 		if !nsExists {
-			log.Info(fmt.Sprintf("%s (server dry run)", colorizeChange("Namespace/"+*kubeconfigArgs.Namespace, ssa.CreatedAction)))
+			log.Info(colorizeJoin(colorizeNamespaceFromArgs(), ssa.CreatedAction, dryRunServer))
 		}
 		return instanceDryRunDiff(logr.NewContext(ctx, log), rm, objects, staleObjects, nsExists, tmpDir, applyArgs.diff)
 	}
@@ -281,7 +281,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		if !nsExists {
-			log.Info(colorizeChange("Namespace/"+*kubeconfigArgs.Namespace, ssa.CreatedAction))
+			log.Info(colorizeJoin(colorizeNamespaceFromArgs(), ssa.CreatedAction))
 		}
 	} else {
 		log.Info(fmt.Sprintf("upgrading %s in namespace %s", applyArgs.name, *kubeconfigArgs.Namespace))
@@ -303,7 +303,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		for _, change := range cs.Entries {
-			log.Info(colorizeChangeSetEntry(change))
+			log.Info(colorizeJoin(change))
 		}
 
 		if applyArgs.wait {
@@ -330,7 +330,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 		}
 		deletedObjects = runtime.SelectObjectsFromSet(changeSet, ssa.DeletedAction)
 		for _, change := range changeSet.Entries {
-			log.Info(colorizeChangeSetEntry(change))
+			log.Info(colorizeJoin(change))
 		}
 	}
 

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -277,7 +277,7 @@ func applyBundleInstance(ctx context.Context, cuectx *cue.Context, instance engi
 
 	if bundleApplyArgs.dryrun || bundleApplyArgs.diff {
 		if !nsExists {
-			log.Info(fmt.Sprintf("%s (server dry run)", colorizeChange("Namespace/"+*kubeconfigArgs.Namespace, ssa.CreatedAction)))
+			log.Info(colorizeJoin(colorizeNamespaceFromArgs(), ssa.CreatedAction, dryRunServer))
 		}
 		if err := instanceDryRunDiff(logr.NewContext(ctx, log), rm, objects, staleObjects, nsExists, tmpDir, bundleApplyArgs.diff); err != nil {
 			return err
@@ -295,7 +295,7 @@ func applyBundleInstance(ctx context.Context, cuectx *cue.Context, instance engi
 		}
 
 		if !nsExists {
-			log.Info(colorizeChange("Namespace/"+*kubeconfigArgs.Namespace, ssa.CreatedAction))
+			log.Info(colorizeJoin(colorizeNamespaceFromArgs(), ssa.CreatedAction))
 		}
 	} else {
 		log.Info(fmt.Sprintf("upgrading %s in namespace %s", instance.Name, instance.Namespace))
@@ -317,7 +317,7 @@ func applyBundleInstance(ctx context.Context, cuectx *cue.Context, instance engi
 			return err
 		}
 		for _, change := range cs.Entries {
-			log.Info(colorizeChangeSetEntry(change))
+			log.Info(colorizeJoin(change))
 		}
 
 		if bundleApplyArgs.wait {
@@ -344,7 +344,7 @@ func applyBundleInstance(ctx context.Context, cuectx *cue.Context, instance engi
 		}
 		deletedObjects = runtime.SelectObjectsFromSet(changeSet, ssa.DeletedAction)
 		for _, change := range changeSet.Entries {
-			log.Info(colorizeChangeSetEntry(change))
+			log.Info(colorizeJoin(change))
 		}
 	}
 

--- a/cmd/timoni/bundle_delete.go
+++ b/cmd/timoni/bundle_delete.go
@@ -94,7 +94,7 @@ func deleteBundleByName(ctx context.Context, bundle string) error {
 		return err
 	}
 
-	log := LoggerFrom(ctx, "bundle", bundle)
+	log := LoggerBundle(ctx, bundle)
 	iStorage := runtime.NewStorageManager(sm)
 
 	instances, err := iStorage.List(ctx, "", bundle)
@@ -153,7 +153,7 @@ func deleteBundleFromFile(ctx context.Context, cmd *cobra.Command) error {
 		return err
 	}
 
-	log := LoggerFrom(ctx, "bundle", bundle.Name)
+	log := LoggerBundle(ctx, bundle.Name)
 
 	if len(bundle.Instances) == 0 {
 		return fmt.Errorf("no instances found in bundle")
@@ -170,7 +170,7 @@ func deleteBundleFromFile(ctx context.Context, cmd *cobra.Command) error {
 }
 
 func deleteBundleInstance(ctx context.Context, instance engine.BundleInstance, wait bool, dryrun bool) error {
-	log := LoggerFrom(ctx, "bundle", instance.Bundle)
+	log := LoggerBundle(ctx, instance.Bundle)
 
 	sm, err := runtime.NewResourceManager(kubeconfigArgs)
 	if err != nil {
@@ -196,9 +196,8 @@ func deleteBundleInstance(ctx context.Context, instance engine.BundleInstance, w
 
 	if dryrun {
 		for _, object := range objects {
-			log.Info(fmt.Sprintf(
-				"%s/%s/%s deleted (dry run)",
-				object.GetKind(), object.GetNamespace(), object.GetName()))
+			subject := fmt.Sprintf("%s/%s/%s", object.GetKind(), object.GetNamespace(), object.GetName())
+			log.Info(fmt.Sprintf("%s (dry run)", colorizeChange(subject, ssa.DeletedAction)))
 		}
 		return nil
 	}
@@ -215,7 +214,7 @@ func deleteBundleInstance(ctx context.Context, instance engine.BundleInstance, w
 			continue
 		}
 		cs.Add(*change)
-		log.Info(fmt.Sprintf(change.String()))
+		log.Info(colorizeChangeSetEntry(*change))
 	}
 
 	if hasErrors {

--- a/cmd/timoni/bundle_delete.go
+++ b/cmd/timoni/bundle_delete.go
@@ -196,8 +196,7 @@ func deleteBundleInstance(ctx context.Context, instance engine.BundleInstance, w
 
 	if dryrun {
 		for _, object := range objects {
-			subject := fmt.Sprintf("%s/%s/%s", object.GetKind(), object.GetNamespace(), object.GetName())
-			log.Info(fmt.Sprintf("%s (dry run)", colorizeChange(subject, ssa.DeletedAction)))
+			log.Info(colorizeJoin(object, ssa.DeletedAction, dryRunClient))
 		}
 		return nil
 	}
@@ -214,7 +213,7 @@ func deleteBundleInstance(ctx context.Context, instance engine.BundleInstance, w
 			continue
 		}
 		cs.Add(*change)
-		log.Info(colorizeChangeSetEntry(*change))
+		log.Info(colorizeJoin(change))
 	}
 
 	if hasErrors {

--- a/cmd/timoni/delete.go
+++ b/cmd/timoni/delete.go
@@ -97,8 +97,7 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 
 	if deleteArgs.dryrun {
 		for _, object := range objects {
-			subject := fmt.Sprintf("%s/%s/%s", object.GetKind(), object.GetNamespace(), object.GetName())
-			log.Info(fmt.Sprintf("%s (dry run)", colorizeChange(subject, ssa.DeletedAction)))
+			log.Info(colorizeJoin(object, ssa.DeletedAction, dryRunClient))
 		}
 		return nil
 	}
@@ -115,7 +114,7 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		cs.Add(*change)
-		log.Info(colorizeChangeSetEntry(*change))
+		log.Info(colorizeJoin(change))
 	}
 
 	if hasErrors {

--- a/cmd/timoni/delete.go
+++ b/cmd/timoni/delete.go
@@ -72,7 +72,7 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 
 	deleteArgs.name = args[0]
 
-	log := LoggerFrom(cmd.Context(), "instance", deleteArgs.name)
+	log := LoggerInstance(cmd.Context(), deleteArgs.name)
 	sm, err := runtime.NewResourceManager(kubeconfigArgs)
 	if err != nil {
 		return err
@@ -97,9 +97,8 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 
 	if deleteArgs.dryrun {
 		for _, object := range objects {
-			log.Info(fmt.Sprintf(
-				"%s/%s/%s deleted (dry run)",
-				object.GetKind(), object.GetNamespace(), object.GetName()))
+			subject := fmt.Sprintf("%s/%s/%s", object.GetKind(), object.GetNamespace(), object.GetName())
+			log.Info(fmt.Sprintf("%s (dry run)", colorizeChange(subject, ssa.DeletedAction)))
 		}
 		return nil
 	}
@@ -116,7 +115,7 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		cs.Add(*change)
-		log.Info(change.String())
+		log.Info(colorizeChangeSetEntry(*change))
 	}
 
 	if hasErrors {

--- a/cmd/timoni/dyff.go
+++ b/cmd/timoni/dyff.go
@@ -94,7 +94,7 @@ func instanceDryRunDiff(ctx context.Context,
 
 	for _, r := range objects {
 		if !nsExists {
-			log.Info(fmt.Sprintf("%s created (server dry run)", ssa.FmtUnstructured(r)))
+			log.Info(fmt.Sprintf("%s (server dry run)", colorizeChange(ssa.FmtUnstructured(r), ssa.CreatedAction)))
 			continue
 		}
 
@@ -104,7 +104,7 @@ func instanceDryRunDiff(ctx context.Context,
 			continue
 		}
 
-		log.Info(fmt.Sprintf("%s (server dry run)", change.String()))
+		log.Info(fmt.Sprintf("%s (server dry run)", colorizeChangeSetEntry(*change)))
 		if withDiff && change.Action == ssa.ConfiguredAction {
 			liveYAML, _ := yaml.Marshal(liveObject)
 			liveFile := filepath.Join(tmpDir, "live.yaml")
@@ -125,7 +125,7 @@ func instanceDryRunDiff(ctx context.Context,
 	}
 
 	for _, r := range staleObjects {
-		log.Info(fmt.Sprintf("%s deleted (server dry run)", ssa.FmtUnstructured(r)))
+		log.Info(fmt.Sprintf("%s (server dry run)", colorizeChange(ssa.FmtUnstructured(r), ssa.DeletedAction)))
 	}
 
 	return nil

--- a/cmd/timoni/dyff.go
+++ b/cmd/timoni/dyff.go
@@ -94,7 +94,7 @@ func instanceDryRunDiff(ctx context.Context,
 
 	for _, r := range objects {
 		if !nsExists {
-			log.Info(fmt.Sprintf("%s (server dry run)", colorizeChange(ssa.FmtUnstructured(r), ssa.CreatedAction)))
+			log.Info(colorizeJoin(r, ssa.CreatedAction, dryRunServer))
 			continue
 		}
 
@@ -104,7 +104,7 @@ func instanceDryRunDiff(ctx context.Context,
 			continue
 		}
 
-		log.Info(fmt.Sprintf("%s (server dry run)", colorizeChangeSetEntry(*change)))
+		log.Info(colorizeJoin(change, dryRunServer))
 		if withDiff && change.Action == ssa.ConfiguredAction {
 			liveYAML, _ := yaml.Marshal(liveObject)
 			liveFile := filepath.Join(tmpDir, "live.yaml")
@@ -125,7 +125,7 @@ func instanceDryRunDiff(ctx context.Context,
 	}
 
 	for _, r := range staleObjects {
-		log.Info(fmt.Sprintf("%s (server dry run)", colorizeChange(ssa.FmtUnstructured(r), ssa.DeletedAction)))
+		log.Info(colorizeJoin(r, ssa.DeletedAction, dryRunServer))
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/briandowns/spinner v1.23.0
 	github.com/distribution/distribution/v3 v3.0.0-20230621170613-87b280718d38
+	github.com/fatih/color v1.15.0
 	github.com/fluxcd/pkg/oci v0.28.0
 	github.com/fluxcd/pkg/sourceignore v0.3.4
 	github.com/fluxcd/pkg/ssa v0.28.2
@@ -80,7 +81,6 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
-	github.com/fatih/color v1.7.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fluxcd/pkg/tar v0.2.0 // indirect
 	github.com/fluxcd/pkg/version v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJ
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
-github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=


### PR DESCRIPTION
I was fiddling around with the logging output. I'm used to zerolog, and know this little hack you can do by setting the `caller` field to get the text at the beginning (meant for source code line:number)

Then I started playing around with the coloring of the changes it can make, to make them stand out a bit more.

## Preview

### Before

![image](https://github.com/stefanprodan/timoni/assets/2477952/97ef9e8c-914c-4272-acc6-8b4c1b20c6c5)

### After

![image](https://github.com/stefanprodan/timoni/assets/2477952/ae6cb269-42b2-4322-b632-4187a69eb50a)
