### PR TITLE
Colorize `inspect`, `status`, & `bundle lint`

### DIFF
--- a/cmd/timoni/bundle_lint.go
+++ b/cmd/timoni/bundle_lint.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"cuelang.org/go/cue/cuecontext"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
@@ -68,8 +69,8 @@ func runBundleLintCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	ctx := cuecontext.New()
-	bm := engine.NewBundleBuilder(ctx, files)
+	cuectx := cuecontext.New()
+	bm := engine.NewBundleBuilder(cuectx, files)
 
 	if err := bm.InitWorkspace(tmpDir); err != nil {
 		return describeErr(tmpDir, "failed to parse bundle", err)
@@ -84,6 +85,7 @@ func runBundleLintCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	log = LoggerBundle(logr.NewContext(cmd.Context(), log), bundle.Name)
 
 	if len(bundle.Instances) == 0 {
 		return fmt.Errorf("no instances found in bundle")
@@ -93,7 +95,8 @@ func runBundleLintCmd(cmd *cobra.Command, args []string) error {
 		if i.Namespace == "" {
 			return fmt.Errorf("instance %s does not have a namespace", i.Name)
 		}
-		log.Info(fmt.Sprintf("instance %s is valid", i.Name))
+		log := LoggerBundleInstance(logr.NewContext(cmd.Context(), log), bundle.Name, i.Name)
+		log.Info("instance is valid")
 	}
 
 	log.Info("bundle is valid")

--- a/cmd/timoni/completion_funcs.go
+++ b/cmd/timoni/completion_funcs.go
@@ -55,6 +55,9 @@ func completeNamespaceList(cmd *cobra.Command, args []string, toComplete string)
 	defer cancel()
 
 	namespaces, err := iStorage.ListNamespaces(ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
 
 	var completions []string
 	for _, ns := range namespaces {

--- a/cmd/timoni/inspect_resources.go
+++ b/cmd/timoni/inspect_resources.go
@@ -80,7 +80,7 @@ func runInspectResourcesCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, meta := range metas {
-		cmd.OutOrStdout().Write([]byte(fmt.Sprintf("%s\n", ssa.FmtObjMetadata(meta))))
+		fmt.Fprintln(cmd.OutOrStdout(), colorizeSubject(ssa.FmtObjMetadata(meta)))
 	}
 
 	return nil

--- a/cmd/timoni/inspect_values.go
+++ b/cmd/timoni/inspect_values.go
@@ -74,6 +74,6 @@ func runInspectValuesCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cmd.OutOrStdout().Write([]byte("values: " + inst.Values + "\n"))
+	fmt.Fprintln(cmd.OutOrStdout(), "values:", inst.Values)
 	return nil
 }

--- a/cmd/timoni/log.go
+++ b/cmd/timoni/log.go
@@ -39,7 +39,7 @@ import (
 // Pretty print adds timestamp, log level and colorized output to the logs.
 func NewConsoleLogger() logr.Logger {
 	color.NoColor = !rootArgs.coloredLog
-	zconfig := zerolog.ConsoleWriter{Out: os.Stderr, NoColor: !rootArgs.coloredLog}
+	zconfig := zerolog.ConsoleWriter{Out: color.Error, NoColor: !rootArgs.coloredLog}
 	if !rootArgs.prettyLog {
 		zconfig.PartsExclude = []string{
 			zerolog.TimestampFieldName,

--- a/cmd/timoni/log.go
+++ b/cmd/timoni/log.go
@@ -32,6 +32,7 @@ import (
 	gcrLog "github.com/google/go-containerregistry/pkg/logs"
 	"github.com/rs/zerolog"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	runtimeLog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -64,6 +65,7 @@ func NewConsoleLogger() logr.Logger {
 
 var (
 	colorDryRun       = color.New(color.FgHiBlack, color.Italic)
+	colorError        = color.New(color.FgHiRed)
 	colorCallerPrefix = color.New(color.FgHiBlack)
 	colorBundle       = color.New(color.FgHiMagenta)
 	colorInstance     = color.New(color.FgHiMagenta)
@@ -73,7 +75,15 @@ var (
 		ssa.UnchangedAction:  color.New(color.FgHiBlack),
 		ssa.DeletedAction:    color.New(color.FgRed),
 		ssa.SkippedAction:    color.New(color.FgHiBlack),
-		ssa.UnknownAction:    color.New(color.FgYellow),
+		ssa.UnknownAction:    color.New(color.FgYellow, color.Italic),
+	}
+	colorPerStatus = map[status.Status]*color.Color{
+		status.InProgressStatus:  color.New(color.FgHiCyan, color.Italic),
+		status.FailedStatus:      color.New(color.FgHiRed),
+		status.CurrentStatus:     color.New(color.FgHiGreen),
+		status.TerminatingStatus: color.New(color.FgRed),
+		status.NotFoundStatus:    color.New(color.FgYellow, color.Italic),
+		status.UnknownStatus:     color.New(color.FgYellow, color.Italic),
 	}
 )
 
@@ -107,6 +117,10 @@ func colorizeAny(v any) string {
 		return colorizeChangeSetEntry(v)
 	case *ssa.ChangeSetEntry:
 		return colorizeChangeSetEntry(*v)
+	case status.Status:
+		return colorizeStatus(v)
+	case error:
+		return colorizeError(v)
 	case string:
 		return v
 	default:
@@ -143,6 +157,17 @@ func colorizeChangeSetEntry(change ssa.ChangeSetEntry) string {
 
 func colorizeDryRun(dryRun dryRunType) string {
 	return colorDryRun.Sprint(string(dryRun))
+}
+
+func colorizeError(err error) string {
+	return colorError.Sprint(err.Error())
+}
+
+func colorizeStatus(status status.Status) string {
+	if c, ok := colorPerStatus[status]; ok {
+		return c.Sprint(status)
+	}
+	return status.String()
 }
 
 func colorizeBundle(bundle string) string {

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -83,7 +83,8 @@ func init() {
 	addKubeConfigFlags(rootCmd)
 
 	rootCmd.DisableAutoGenTag = true
-	rootCmd.SetOut(os.Stdout)
+	rootCmd.SetOut(color.Output)
+	rootCmd.SetErr(color.Error)
 
 	oci.UserAgent = apiv1.UserAgent
 	oci.CanonicalConfigMediaType = apiv1.ConfigMediaType


### PR DESCRIPTION
# Changes

- Added missing 'return if err' check
- Colorize inspect
- Colorize status
- Colorize bundle lint

Closes #140

# `timoni inspect resources`

## Before

![image](https://github.com/stefanprodan/timoni/assets/2477952/8af291ab-c6f6-4494-9cb8-0e84fc4604c8)

## After

![image](https://github.com/stefanprodan/timoni/assets/2477952/9d2eedd0-9c38-4fdf-bbee-9523f603a6b1)

# `timoni status`

## Before 

![image](https://github.com/stefanprodan/timoni/assets/2477952/7c73e463-38de-4546-98e1-f50f47b98fb1)

## After

![image](https://github.com/stefanprodan/timoni/assets/2477952/7e76fdd7-e171-4c4b-b748-52bb28d50e7d)

# `timoni bundle lint`

## Before 

![image](https://github.com/stefanprodan/timoni/assets/2477952/40616b8a-a187-4fd4-8ac0-ea0343125a03)

## After

![image](https://github.com/stefanprodan/timoni/assets/2477952/4b408d23-df91-45c8-b95d-9ca5c48a64a0)
