### PR TITLE
Fix test flake for `timoni bundle build`

### DIFF
--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -130,6 +130,7 @@ func resetCmdArgs() {
 	bundleApplyArgs = bundleApplyFlags{}
 	bundleLintArgs = bundleLintFlags{}
 	bundleDelArgs = bundleDelFlags{}
+	bundleBuildArgs = bundleBuildFlags{}
 }
 
 func rnd(prefix string, n int) string {


### PR DESCRIPTION
Reset flags to avoid test failures of `timoni bundle build`