### PR TITLE
Fail fast when waiting for resources

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -291,6 +291,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 	waitOptions := ssa.WaitOptions{
 		Interval: 5 * time.Second,
 		Timeout:  rootArgs.timeout,
+		FailFast: true,
 	}
 
 	for _, set := range applySets {

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -305,6 +305,7 @@ func applyBundleInstance(ctx context.Context, cuectx *cue.Context, instance engi
 	waitOptions := ssa.WaitOptions{
 		Interval: 5 * time.Second,
 		Timeout:  rootArgs.timeout,
+		FailFast: true,
 	}
 
 	for _, set := range bundleApplySets {


### PR DESCRIPTION
Give up waiting for resources to become ready as soon as a resource becomes stalled e.g. when a Kubernetes Deployment exceeded its progress deadline.