### PR TITLE
Inject runtime version info

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -206,6 +206,13 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	kubeVersion, err := runtime.ServerVersion(kubeconfigArgs)
+	if err != nil {
+		return err
+	}
+
+	builder.SetVersionInfo(mod.Version, kubeVersion)
+
 	buildResult, err := builder.Build()
 	if err != nil {
 		return describeErr(fetcher.GetModuleRoot(), "failed to build instance", err)

--- a/cmd/timoni/apply_test.go
+++ b/cmd/timoni/apply_test.go
@@ -25,11 +25,12 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
 func TestApply(t *testing.T) {
@@ -61,6 +62,8 @@ func TestApply(t *testing.T) {
 
 		g.Expect(clientCM.GetLabels()).To(HaveKeyWithValue(tGroup+"/name", name))
 		g.Expect(clientCM.GetLabels()).To(HaveKeyWithValue(tGroup+"/namespace", namespace))
+		g.Expect(clientCM.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/version", "0.0.0-devel"))
+		g.Expect(clientCM.GetLabels()).To(HaveKey("app.kubernetes.io/kube"))
 	})
 
 	t.Run("updates instance with custom values", func(t *testing.T) {

--- a/cmd/timoni/bundle_apply_test.go
+++ b/cmd/timoni/bundle_apply_test.go
@@ -109,6 +109,8 @@ bundle: {
 
 				err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
 				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(clientCM.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/version", modVer))
+				g.Expect(clientCM.GetLabels()).To(HaveKey("app.kubernetes.io/kube"))
 
 				serverCM := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{

--- a/cmd/timoni/testdata/module/templates/config.cue
+++ b/cmd/timoni/testdata/module/templates/config.cue
@@ -4,9 +4,16 @@ package templates
 	metadata: {
 		name:      *"test" | string
 		namespace: *"default" | string
-		labels:    *{"app.kubernetes.io/name": metadata.name} | {[ string]: string}
+		labels:    *{
+				"app.kubernetes.io/name":    metadata.name
+				"app.kubernetes.io/version": moduleVersion
+				"app.kubernetes.io/kube":    kubeVersion
+		} | {[ string]: string}
 		annotations?: {[ string]: string}
 	}
+
+	moduleVersion: string
+	kubeVersion:   string
 
 	client: enabled: *true | bool
 	server: enabled: *true | bool

--- a/cmd/timoni/testdata/module/timoni.cue
+++ b/cmd/timoni/testdata/module/timoni.cue
@@ -31,6 +31,10 @@ timoni: {
 			name:      string @tag(name)
 			namespace: string @tag(namespace)
 		}
+		config: {
+			moduleVersion: string @tag(mv, var=moduleVersion)
+			kubeVersion:   string @tag(kv, var=kubeVersion)
+		}
 	}
 
 	// Pass Kubernetes resources outputted by the instance

--- a/examples/minimal/templates/config.cue
+++ b/examples/minimal/templates/config.cue
@@ -18,6 +18,10 @@ import (
 	metadata: labels: "app.kubernetes.io/version": image.tag
 	metadata: annotations?: {[ string]:            string}
 
+	// Runtime version info
+	moduleVersion?: string
+	kubeVersion?:   string
+
 	// App settings
 	message: string
 

--- a/examples/minimal/timoni.cue
+++ b/examples/minimal/timoni.cue
@@ -31,6 +31,11 @@ timoni: {
 			name:      string @tag(name)
 			namespace: string @tag(namespace)
 		}
+		// Optional runtime version info.
+		config: {
+			moduleVersion: string @tag(mv, var=moduleVersion)
+			kubeVersion:   string @tag(kv, var=kubeVersion)
+		}
 	}
 
 	// Pass Kubernetes resources outputted by the instance

--- a/internal/engine/fetcher.go
+++ b/internal/engine/fetcher.go
@@ -76,7 +76,7 @@ func (f *Fetcher) Fetch() (*apiv1.ModuleReference, error) {
 
 	mr := apiv1.ModuleReference{
 		Repository: f.src,
-		Version:    "devel",
+		Version:    defaultDevelVersion,
 		Digest:     "unknown",
 	}
 

--- a/internal/engine/module_builder_test.go
+++ b/internal/engine/module_builder_test.go
@@ -46,6 +46,8 @@ func TestModuleBuilder(t *testing.T) {
 	err = mb.MergeValuesFile([][]byte{mustReadFile(g, "testdata/module-values/overlay.cue")})
 	g.Expect(err).ToNot(HaveOccurred())
 
+	mb.SetVersionInfo("", "1.25.3")
+
 	val, err := mb.Build()
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/internal/engine/testdata/module-golden/overlay.cue
+++ b/internal/engine/testdata/module-golden/overlay.cue
@@ -6,6 +6,8 @@ objects: [{
 		namespace: "test-namespace"
 	}
 	data: {
-		url: "https://test.internal"
+		url:           "https://test.internal"
+		kubeVersion:   "1.25.3"
+		moduleVersion: "0.0.0-devel"
 	}
 }]

--- a/internal/engine/testdata/module/templates/config.cue
+++ b/internal/engine/testdata/module/templates/config.cue
@@ -5,7 +5,9 @@ package templates
 		name:      *"test" | string
 		namespace: *"default" | string
 	}
-	hostname: *"default.internal" | string
+	hostname:      *"default.internal" | string
+	moduleVersion: string
+	kubeVersion:   string
 }
 
 #Instance: {

--- a/internal/engine/testdata/module/templates/kube.cue
+++ b/internal/engine/testdata/module/templates/kube.cue
@@ -1,11 +1,17 @@
 package templates
 
+import "strings"
+
 #KubeConfig: {
 	_config:    #Config
 	apiVersion: "v1"
 	kind:       "ConfigMap"
 	metadata:   _config.metadata
 	data: {
-		url: "https://\(_config.hostname)"
+		url:           "https://\(_config.hostname)"
+		moduleVersion: _config.moduleVersion
+		if strings.HasPrefix(_config.kubeVersion, "1.25") {
+			kubeVersion: _config.kubeVersion
+		}
 	}
 }

--- a/internal/engine/testdata/module/timoni.cue
+++ b/internal/engine/testdata/module/timoni.cue
@@ -31,6 +31,10 @@ timoni: {
 			name:      string @tag(name)
 			namespace: string @tag(namespace)
 		}
+		config: {
+			moduleVersion: string @tag(mv, var=moduleVersion)
+			kubeVersion:   string @tag(kv, var=kubeVersion)
+		}
 	}
 
 	// Pass Kubernetes resources outputted by the instance

--- a/internal/runtime/version.go
+++ b/internal/runtime/version.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ServerVersion retrieves and parses the Kubernetes server's version.
+func ServerVersion(rcg genericclioptions.RESTClientGetter) (string, error) {
+	cfg, err := rcg.ToRESTConfig()
+	if err != nil {
+		return "", fmt.Errorf("loading kubeconfig failed: %w", err)
+	}
+
+	cfg.Timeout = 5 * time.Second
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return "", fmt.Errorf("initialising client failed: %w", err)
+	}
+
+	serverVer, err := kubeClient.Discovery().ServerVersion()
+	if err != nil {
+		return "", fmt.Errorf("reading server version failed: %w", err)
+	}
+
+	ver, err := semver.NewVersion(serverVer.GitVersion)
+	if err != nil {
+		return "", fmt.Errorf("parsing server version failed: %w", err)
+	}
+
+	return ver.String(), nil
+}


### PR DESCRIPTION
This PR adds optional tags for injecting the module version and Kubernetes version at runtime.

To capture the runtime version info add the following tags to `timoni.cue`:

```cue
config: {
	moduleVersion: string @tag(mv, var=moduleVersion)
	kubeVersion:   string @tag(kv, var=kubeVersion)
}
```

The module used by `timoni mod init` was modified to showcase how to capture these values and will be made available in the next Timoni release.

Closes: #159