### PR TITLE
Introduce Kubernetes metadata CUE definition

### DIFF
--- a/examples/minimal/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
+++ b/examples/minimal/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
@@ -16,17 +16,17 @@ import "strings"
 	// Version should be in the strict semver format. Is required when creating resources.
 	version!: string & strings.MaxRunes(63)
 
-	// Map of string keys and values that can be used to organize and categorize
-	// (scope and select) objects.
-	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-	labels?: {[string]: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)}
-
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set o store and retrieve arbitrary metadata.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
 	annotations?: {[string]: string}
 
-	// Required Kubernetes labels.
+	// Map of string keys and values that can be used to organize and categorize
+	// (scope and select) objects.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+	labels: {[string]: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)}
+
+	// Standard Kubernetes labels: app name and version.
 	labels: {
 		"app.kubernetes.io/name":    name
 		"app.kubernetes.io/version": version

--- a/examples/minimal/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
+++ b/examples/minimal/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
@@ -1,0 +1,39 @@
+package v1alpha1
+
+import "strings"
+
+// Metadata defines the schema for the Kubernetes object metadata.
+#Metadata: {
+	// Name must be unique within a namespace. Is required when creating resources.
+	// Name is primarily intended for creation idempotence and configuration definition.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+	name!: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)
+
+	// Namespace defines the space within which each name must be unique.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces
+	namespace!: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)
+
+	// Version should be in the strict semver format. Is required when creating resources.
+	version!: string & strings.MaxRunes(63)
+
+	// Map of string keys and values that can be used to organize and categorize
+	// (scope and select) objects.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+	labels?: {[string]: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)}
+
+	// Annotations is an unstructured key value map stored with a resource that may be
+	// set o store and retrieve arbitrary metadata.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+	annotations?: {[string]: string}
+
+	// Required Kubernetes labels.
+	labels: {
+		"app.kubernetes.io/name":    name
+		"app.kubernetes.io/version": version
+	}
+
+	// Labels used to select pods for Kubernetes Deployment, Service, Job, etc.
+	labelSelector: *{
+			"app.kubernetes.io/name": name
+	} | {[ string]: string}
+}

--- a/examples/minimal/debug_tool.cue
+++ b/examples/minimal/debug_tool.cue
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"tool/cli"
+	"encoding/yaml"
+	"text/tabwriter"
+)
+
+// The build command generates the Kubernetes manifests and prints the multi-docs YAML to stdout.
+// Example 'cue cmd -t name=test -t namespace=test -t mv=1.0.0 -t kv=1.28.0 build'.
+command: build: {
+	task: print: cli.Print & {
+		text: yaml.MarshalStream(timoni.apply.all)
+	}
+}
+
+// The ls command prints a table with the Kubernetes resources kind, namespace, name and version.
+// Example 'cue cmd -t name=test -t namespace=test -t mv=1.0.0 -t kv=1.28.0 ls'.
+command: ls: {
+	task: print: cli.Print & {
+		text: tabwriter.Write([
+			"RESOURCE \tAPI VERSION",
+			for r in timoni.apply.all {
+				if r.metadata.namespace == _|_ {
+					"\(r.kind)/\(r.metadata.name) \t\(r.apiVersion)"
+				}
+				if r.metadata.namespace != _|_ {
+					"\(r.kind)/\(r.metadata.namespace)/\(r.metadata.name)  \t\(r.apiVersion)"
+				}
+			},
+		])
+	}
+}

--- a/examples/minimal/templates/config.cue
+++ b/examples/minimal/templates/config.cue
@@ -1,33 +1,25 @@
 package templates
 
 import (
-	"strings"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	timoniv1 "timoni.sh/core/v1alpha1"
 )
 
 // Config defines the schema and defaults for the Instance values.
 #Config: {
-	// Metadata (common to all resources)
-	metadata: metav1.#ObjectMeta
-	metadata: name:      string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)
-	metadata: namespace: string & strings.MaxRunes(63)
-	metadata: labels:    *selectorLabels | {[ string]: string}
-	metadata: labels: "app.kubernetes.io/version": image.tag
-	metadata: annotations?: {[ string]:            string}
-
 	// Runtime version info
-	moduleVersion?: string
-	kubeVersion?:   string
+	moduleVersion: string
+	kubeVersion:   string
+
+	// Metadata (common to all resources)
+	metadata: timoniv1.#Metadata
+	metadata: version: moduleVersion
 
 	// App settings
 	message: string
 
 	// Deployment
-	replicas:       *1 | int & >0
-	selectorLabels: *{"app.kubernetes.io/name": metadata.name} | {[ string]: string}
+	replicas: *1 | int & >0
 
 	// Pod
 	podAnnotations?: {[ string]: string}

--- a/examples/minimal/templates/configmap.cue
+++ b/examples/minimal/templates/configmap.cue
@@ -13,10 +13,12 @@ import (
 	apiVersion: "v1"
 	kind:       "ConfigMap"
 	metadata: {
-		name:         "\(_config.metadata.name)-\(_checksum)"
-		namespace:    _config.metadata.namespace
-		labels:       _config.metadata.labels
-		annotations?: _config.metadata.annotations
+		name:      "\(_config.metadata.name)-\(_checksum)"
+		namespace: _config.metadata.namespace
+		labels:    _config.metadata.labels
+		if _config.metadata.annotations != _|_ {
+			annotations: _config.metadata.annotations
+		}
 	}
 	immutable: true
 	let _checksum = strings.Split(uuid.SHA1(uuid.ns.DNS, yaml.Marshal(data)), "-")[0]

--- a/examples/minimal/templates/deployment.cue
+++ b/examples/minimal/templates/deployment.cue
@@ -10,13 +10,20 @@ import (
 	_cmName:    string
 	apiVersion: "apps/v1"
 	kind:       "Deployment"
-	metadata:   _config.metadata
-	spec:       appsv1.#DeploymentSpec & {
+	metadata: {
+		name:      _config.metadata.name
+		namespace: _config.metadata.namespace
+		labels:    _config.metadata.labels
+		if _config.metadata.annotations != _|_ {
+			annotations: _config.metadata.annotations
+		}
+	}
+	spec: appsv1.#DeploymentSpec & {
 		replicas: _config.replicas
-		selector: matchLabels: _config.selectorLabels
+		selector: matchLabels: _config.metadata.labelSelector
 		template: {
 			metadata: {
-				labels: _config.selectorLabels
+				labels: _config.metadata.labelSelector
 				if _config.podAnnotations != _|_ {
 					annotations: _config.podAnnotations
 				}

--- a/examples/minimal/templates/service.cue
+++ b/examples/minimal/templates/service.cue
@@ -8,10 +8,17 @@ import (
 	_config:    #Config
 	apiVersion: "v1"
 	kind:       "Service"
-	metadata:   _config.metadata
-	spec:       corev1.#ServiceSpec & {
+	metadata: {
+		name:      _config.metadata.name
+		namespace: _config.metadata.namespace
+		labels:    _config.metadata.labels
+		if _config.metadata.annotations != _|_ {
+			annotations: _config.metadata.annotations
+		}
+	}
+	spec: corev1.#ServiceSpec & {
 		type:     corev1.#ServiceTypeClusterIP
-		selector: _config.selectorLabels
+		selector: _config.metadata.labelSelector
 		ports: [
 			{
 				name:       "http"

--- a/examples/minimal/templates/serviceaccount.cue
+++ b/examples/minimal/templates/serviceaccount.cue
@@ -8,5 +8,12 @@ import (
 	_config:    #Config
 	apiVersion: "v1"
 	kind:       "ServiceAccount"
-	metadata:   _config.metadata
+	metadata: {
+		name:      _config.metadata.name
+		namespace: _config.metadata.namespace
+		labels:    _config.metadata.labels
+		if _config.metadata.annotations != _|_ {
+			annotations: _config.metadata.annotations
+		}
+	}
 }


### PR DESCRIPTION
This PR introduces a CUE definition to Timoni's core package for working with Kubernetes metadata.

The metadata helper tries to standardise how Kubernetes common metadata is injected in the generated objects.

The metadata helper enforces the usage of Kubernetes standard labels:
- `app.kubernetes.io/name`
- `app.kubernetes.io/version`