### PR TITLE
Build with Go 1.21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,15 +23,15 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod
       - name: Setup Kubernetes
         uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
         with:
-          version: v0.18.0
-          node_image: kindest/node:v1.27.2
+          version: v0.20.0
+          node_image: kindest/node:v1.28.0
           cluster_name: kind
       - name: Install
         run: make install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod


### PR DESCRIPTION
Bump Go to 1.21 and Kubernetes to 1.28 in CI.