### PR TITLE
Fix panic when waiting for global resources

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -295,8 +295,10 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	applyOpts := runtime.ApplyOptions(applyArgs.force, rootArgs.timeout)
+	applyOpts.WaitInterval = 5 * time.Second
+
 	waitOptions := ssa.WaitOptions{
-		Interval: 5 * time.Second,
+		Interval: applyOpts.WaitInterval,
 		Timeout:  rootArgs.timeout,
 		FailFast: true,
 	}

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -309,8 +309,10 @@ func applyBundleInstance(ctx context.Context, cuectx *cue.Context, instance engi
 	}
 
 	applyOpts := runtime.ApplyOptions(bundleApplyArgs.force, rootArgs.timeout)
+	applyOpts.WaitInterval = 5 * time.Second
+
 	waitOptions := ssa.WaitOptions{
-		Interval: 5 * time.Second,
+		Interval: applyOpts.WaitInterval,
 		Timeout:  rootArgs.timeout,
 		FailFast: true,
 	}

--- a/cmd/timoni/testdata/module/templates/config.cue
+++ b/cmd/timoni/testdata/module/templates/config.cue
@@ -18,6 +18,8 @@ package templates
 	client: enabled: *true | bool
 	server: enabled: *true | bool
 	domain: *"example.internal" | string
+
+	ns: enabled: *false | bool
 }
 
 #Instance: {
@@ -30,6 +32,10 @@ package templates
 
 		if config.server.enabled {
 			"\(config.metadata.name)-server": #ServerConfig & {_config: config}
+		}
+
+		if config.ns.enabled {
+			"\(config.metadata.name)-ns": #Namespace & {_config: config}
 		}
 	}
 }

--- a/cmd/timoni/testdata/module/templates/namespace.cue
+++ b/cmd/timoni/testdata/module/templates/namespace.cue
@@ -1,0 +1,14 @@
+package templates
+
+#Namespace: {
+	_config:    #Config
+	apiVersion: "v1"
+	kind:       "Namespace"
+	metadata: {
+		name:      "\(_config.metadata.name)-ns"
+		labels:    _config.metadata.labels
+		if _config.metadata.annotations != _|_ {
+			annotations: _config.metadata.annotations
+		}
+	}
+}


### PR DESCRIPTION
Set wait interval to SSA options to fix:

```
panic: non-positive interval for NewTicker

goroutine 138 [running]:
time.NewTicker(0x0?)
	/opt/hostedtoolcache/go/1.21.0/x64/src/time/tick.go:22 +0xe5
sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine.(*statusPollerRunner).Run(0xc000739f60, {0x1f60a48, 0xc0053fe310})
	/home/runner/go/pkg/mod/sigs.k8s.io/cli-utils@v0.35.0/pkg/kstatus/polling/engine/engine.go:[15](https://github.com/stefanprodan/flux-aio/actions/runs/6064991268/job/16454005975#step:7:16)9 +0x47
sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine.(*PollerEngine).Poll.func1()
	/home/runner/go/pkg/mod/sigs.k8s.io/cli-utils@v0.35.0/pkg/kstatus/polling/engine/engine.go:72 +0x297
created by sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine.(*PollerEngine).Poll in goroutine 1
	/home/runner/go/pkg/mod/sigs.k8s.io/cli-utils@v0.35.0/pkg/kstatus/polling/engine/engine.go:48 +0x105
```