### PR TITLE
Add cosign signing and verification for modules

### DIFF
--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -50,7 +50,7 @@ type pullModFlags struct {
 	version                     flags.Version
 	output                      string
 	creds                       flags.Credentials
-	verify                      bool
+	verify                      string
 	cosignKey                   string
 	certificateIdentity         string
 	certificateIdentityRegexp   string
@@ -65,8 +65,8 @@ func init() {
 	pullModCmd.Flags().StringVarP(&pullModArgs.output, "output", "o", "",
 		"The directory path where the module content should be extracted.")
 	pullModCmd.Flags().Var(&pullModArgs.creds, pullModArgs.creds.Type(), pullModArgs.creds.Description())
-	pullModCmd.Flags().BoolVar(&pullModArgs.verify, "verify", false,
-		"Verifies the signed module with Cosign.")
+	pullModCmd.Flags().StringVar(&pullModArgs.verify, "verify", "",
+		"Verifies the signed module with the specified provvider.")
 	pullModCmd.Flags().StringVar(&pullModArgs.cosignKey, "cosign-key", "",
 		"The Cosign public key for verifying the module.")
 	pullModCmd.Flags().StringVar(&pullModArgs.certificateIdentity, "certificate-identity", "",
@@ -126,9 +126,9 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if pullModArgs.verify {
-		err = signutil.Verify(log, url, pullModArgs.cosignKey, pullModArgs.certificateIdentity, pullModArgs.certificateIdentityRegexp,
-			pullModArgs.certificateOidcIssuer, pullModArgs.certificateOidcIssuerRegexp)
+	if pullModArgs.verify != "" {
+		err = signutil.Verify(log, pullModArgs.verify, url, pullModArgs.cosignKey, pullModArgs.certificateIdentity,
+			pullModArgs.certificateIdentityRegexp, pullModArgs.certificateOidcIssuer, pullModArgs.certificateOidcIssuerRegexp)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stefanprodan/timoni/internal/engine"
 	"github.com/stefanprodan/timoni/internal/flags"
+	"github.com/stefanprodan/timoni/internal/signutil"
 )
 
 var pullModCmd = &cobra.Command{
@@ -46,9 +47,15 @@ extract its contents the specified directory.`,
 }
 
 type pullModFlags struct {
-	version flags.Version
-	output  string
-	creds   flags.Credentials
+	version                     flags.Version
+	output                      string
+	creds                       flags.Credentials
+	verify                      bool
+	cosignKey                   string
+	certificateIdentity         string
+	certificateIdentityRegexp   string
+	certificateOidcIssuer       string
+	certificateOidcIssuerRegexp string
 }
 
 var pullModArgs pullModFlags
@@ -58,6 +65,26 @@ func init() {
 	pullModCmd.Flags().StringVarP(&pullModArgs.output, "output", "o", "",
 		"The directory path where the module content should be extracted.")
 	pullModCmd.Flags().Var(&pullModArgs.creds, pullModArgs.creds.Type(), pullModArgs.creds.Description())
+	pullModCmd.Flags().BoolVar(&pullModArgs.verify, "verify", false,
+		"Verifies the signed module with Cosign.")
+	pullModCmd.Flags().StringVar(&pullModArgs.cosignKey, "cosign-key", "",
+		"The Cosign public key for verifying the module.")
+	pullModCmd.Flags().StringVar(&pullModArgs.certificateIdentity, "certificate-identity", "",
+		"The identity expected in a valid Fulcio certificate for verifying the Cosign signature.\n"+
+			"Valid values include email address, DNS names, IP addresses, and URIs.\n"+
+			"Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.")
+	pullModCmd.Flags().StringVar(&pullModArgs.certificateIdentityRegexp, "certificate-identity-regexp", "",
+		"A regular expression alternative to --certificate-identity for verifying the Cosign signature.\n"+
+			"Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax.\n"+
+			"Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.")
+	pullModCmd.Flags().StringVar(&pullModArgs.certificateOidcIssuer, "certificate-oidc-issuer", "",
+		"The OIDC issuer expected in a valid Fulcio certificate for verifying the Cosign signature,\n"+
+			"e.g. https://token.actions.githubusercontent.com or https://oauth2.sigstore.dev/auth.\n"+
+			"Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.")
+	pullModCmd.Flags().StringVar(&pullModArgs.certificateOidcIssuerRegexp, "certificate-oidc-issuer-regexp", "",
+		"A regular expression alternative to --certificate-oidc-issuer for verifying the Cosign signature.\n"+
+			"Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax.\n"+
+			"Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.")
 
 	modCmd.AddCommand(pullModCmd)
 }
@@ -96,6 +123,14 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	if pullModArgs.creds != "" {
 		if err := ociClient.LoginWithCredentials(pullModArgs.creds.String()); err != nil {
 			return fmt.Errorf("could not login with credentials: %w", err)
+		}
+	}
+
+	if pullModArgs.verify {
+		err = signutil.Verify(log, url, pullModArgs.cosignKey, pullModArgs.certificateIdentity, pullModArgs.certificateIdentityRegexp,
+			pullModArgs.certificateOidcIssuer, pullModArgs.certificateOidcIssuerRegexp)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -97,9 +97,9 @@ func init() {
 	pushModCmd.Flags().StringVarP(&pushModArgs.output, "output", "o", "",
 		"The format in which the artifact digest should be printed, can be 'yaml' or 'json'.")
 	pushModCmd.Flags().BoolVar(&pushModArgs.sign, "sign", false,
-		"Signs the module with Cosign")
+		"Signs the module with Cosign.")
 	pushModCmd.Flags().StringVar(&pushModArgs.cosignKey, "cosign-key", "",
-		"The Cosign private key for signing the module")
+		"The Cosign private key for signing the module.")
 
 	modCmd.AddCommand(pushModCmd)
 }

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -79,7 +79,7 @@ type pushModFlags struct {
 	ignorePaths []string
 	output      string
 	annotations []string
-	sign        bool
+	sign        string
 	cosignKey   string
 }
 
@@ -96,8 +96,8 @@ func init() {
 		"Set custom OCI annotations in the format '<key>=<value>'.")
 	pushModCmd.Flags().StringVarP(&pushModArgs.output, "output", "o", "",
 		"The format in which the artifact digest should be printed, can be 'yaml' or 'json'.")
-	pushModCmd.Flags().BoolVar(&pushModArgs.sign, "sign", false,
-		"Signs the module with Cosign.")
+	pushModCmd.Flags().StringVar(&pushModArgs.sign, "sign", "",
+		"Signs the module with the specified provider.")
 	pushModCmd.Flags().StringVar(&pushModArgs.cosignKey, "cosign-key", "",
 		"The Cosign private key for signing the module.")
 
@@ -201,8 +201,8 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("artifact tag parsing failed: %w", err)
 	}
 
-	if pushModArgs.sign {
-		err = signutil.Sign(log, digestURL, pushModArgs.cosignKey)
+	if pushModArgs.sign != "" {
+		err = signutil.Sign(log, pushModArgs.sign, digestURL, pushModArgs.cosignKey)
 		if err != nil {
 			return err
 		}

--- a/internal/signutil/cosign.go
+++ b/internal/signutil/cosign.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signutil
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/go-logr/logr"
+)
+
+// SignCosign signs an image (`imageRef`) using a cosign private key (`keyRef`)
+func SignCosign(log logr.Logger, imageRef string, keyRef string) error {
+	cosignExecutable, err := exec.LookPath("cosign")
+	if err != nil {
+		return fmt.Errorf("executing cosign failed: %w", err)
+	}
+
+	cosignCmd := exec.Command(cosignExecutable, []string{"sign"}...)
+	cosignCmd.Env = os.Environ()
+
+	// if key is empty, use keyless mode
+	if keyRef != "" {
+		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
+	}
+
+	cosignCmd.Args = append(cosignCmd.Args, "--yes")
+	cosignCmd.Args = append(cosignCmd.Args, imageRef)
+
+	err = processCosignIO(log, cosignCmd)
+	if err != nil {
+		return err
+	}
+
+	return cosignCmd.Wait()
+}
+
+// VerifyCosign verifies an image (`rawRef`) with a cosign public key (`keyRef`)
+// Either --cosign-certificate-identity or --cosign-certificate-identity-regexp and either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows.
+func VerifyCosign(log logr.Logger, imageRef string, keyRef string,
+	certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
+	cosignExecutable, err := exec.LookPath("cosign")
+	if err != nil {
+		return fmt.Errorf("executing cosign failed: %w", err)
+	}
+
+	cosignCmd := exec.Command(cosignExecutable, []string{"verify"}...)
+	cosignCmd.Env = os.Environ()
+
+	// if key is empty, use keyless mode
+	if keyRef != "" {
+		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
+	} else {
+		if certIdentity == "" && certIdentityRegexp == "" {
+			return errors.New("--certificate-identity or --certificate-identity-regexp is required for Cosign verification in keyless mode")
+		}
+		if certIdentity != "" {
+			cosignCmd.Args = append(cosignCmd.Args, "--certificate-identity", certIdentity)
+		}
+		if certIdentityRegexp != "" {
+			cosignCmd.Args = append(cosignCmd.Args, "--certificate-identity-regexp", certIdentityRegexp)
+		}
+		if certOidcIssuer == "" && certOidcIssuerRegexp == "" {
+			return errors.New("--certificate-oidc-issuer or --certificate-oidc-issuer-regexp is required for Cosign verification in keyless mode")
+		}
+		if certOidcIssuer != "" {
+			cosignCmd.Args = append(cosignCmd.Args, "--certificate-oidc-issuer", certOidcIssuer)
+		}
+		if certOidcIssuerRegexp != "" {
+			cosignCmd.Args = append(cosignCmd.Args, "--certificate-oidc-issuer-regexp", certOidcIssuerRegexp)
+		}
+	}
+
+	cosignCmd.Args = append(cosignCmd.Args, imageRef)
+
+	err = processCosignIO(log, cosignCmd)
+	if err != nil {
+		return err
+	}
+	if err := cosignCmd.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func processCosignIO(log logr.Logger, cosignCmd *exec.Cmd) error {
+	stdout, err := cosignCmd.StdoutPipe()
+	if err != nil {
+		log.Error(err, "cosign stdout pipe failed")
+	}
+	stderr, err := cosignCmd.StderrPipe()
+	if err != nil {
+		log.Error(err, "cosign stderr pipe failed")
+	}
+
+	merged := io.MultiReader(stdout, stderr)
+	scanner := bufio.NewScanner(merged)
+
+	if err := cosignCmd.Start(); err != nil {
+		return fmt.Errorf("executing cosign failed: %w", err)
+	}
+
+	for scanner.Scan() {
+		log.Info("cosign: " + scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		log.Error(err, "cosign stdout/stderr scanner failed")
+	}
+
+	return nil
+}

--- a/internal/signutil/doc.go
+++ b/internal/signutil/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package signutil manages signing of OCI images
+package signutil

--- a/internal/signutil/signutil.go
+++ b/internal/signutil/signutil.go
@@ -1,130 +1,33 @@
-/*
-Copyright 2023 Stefan Prodan
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package signutil
 
 import (
-	"bufio"
-	"errors"
 	"fmt"
-	"io"
-	"os"
-	"os/exec"
 
 	"github.com/go-logr/logr"
 )
 
-// Sign signs an image (`imageRef`) using a cosign private key (`keyRef`)
-func Sign(log logr.Logger, imageRef string, keyRef string) error {
-	cosignExecutable, err := exec.LookPath("cosign")
-	if err != nil {
-		return fmt.Errorf("executing cosign failed: %w", err)
-	}
-
-	cosignCmd := exec.Command(cosignExecutable, []string{"sign"}...)
-	cosignCmd.Env = os.Environ()
-
-	// if key is empty, use keyless mode
-	if keyRef != "" {
-		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
-	}
-
-	cosignCmd.Args = append(cosignCmd.Args, "--yes")
-	cosignCmd.Args = append(cosignCmd.Args, imageRef)
-
-	err = processCosignIO(log, cosignCmd)
-	if err != nil {
-		return err
-	}
-
-	return cosignCmd.Wait()
-}
-
-// Verify verifies an image (`rawRef`) with a cosign public key (`keyRef`)
-// Either --cosign-certificate-identity or --cosign-certificate-identity-regexp and either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows.
-func Verify(log logr.Logger, imageRef string, keyRef string,
-	certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
-	cosignExecutable, err := exec.LookPath("cosign")
-	if err != nil {
-		return fmt.Errorf("executing cosign failed: %w", err)
-	}
-
-	cosignCmd := exec.Command(cosignExecutable, []string{"verify"}...)
-	cosignCmd.Env = os.Environ()
-
-	// if key is empty, use keyless mode
-	if keyRef != "" {
-		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
-	} else {
-		if certIdentity == "" && certIdentityRegexp == "" {
-			return errors.New("--certificate-identity or --certificate-identity-regexp is required for Cosign verification in keyless mode")
+// Sign signs an image using the specified provider.
+func Sign(log logr.Logger, provider string, imageRef string, keyRef string) error {
+	switch provider {
+	case "cosign":
+		if err := SignCosign(log, imageRef, keyRef); err != nil {
+			return err
 		}
-		if certIdentity != "" {
-			cosignCmd.Args = append(cosignCmd.Args, "--certificate-identity", certIdentity)
-		}
-		if certIdentityRegexp != "" {
-			cosignCmd.Args = append(cosignCmd.Args, "--certificate-identity-regexp", certIdentityRegexp)
-		}
-		if certOidcIssuer == "" && certOidcIssuerRegexp == "" {
-			return errors.New("--certificate-oidc-issuer or --certificate-oidc-issuer-regexp is required for Cosign verification in keyless mode")
-		}
-		if certOidcIssuer != "" {
-			cosignCmd.Args = append(cosignCmd.Args, "--certificate-oidc-issuer", certOidcIssuer)
-		}
-		if certOidcIssuerRegexp != "" {
-			cosignCmd.Args = append(cosignCmd.Args, "--certificate-oidc-issuer-regexp", certOidcIssuerRegexp)
-		}
+	default:
+		return fmt.Errorf("no signers found: %s", provider)
 	}
-
-	cosignCmd.Args = append(cosignCmd.Args, imageRef)
-
-	err = processCosignIO(log, cosignCmd)
-	if err != nil {
-		return err
-	}
-	if err := cosignCmd.Wait(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
-func processCosignIO(log logr.Logger, cosignCmd *exec.Cmd) error {
-	stdout, err := cosignCmd.StdoutPipe()
-	if err != nil {
-		log.Error(err, "cosign stdout pipe failed")
+// Verify verifies an image using the specified provider.
+func Verify(log logr.Logger, provider string, imageRef string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
+	switch provider {
+	case "cosign":
+		if err := VerifyCosign(log, imageRef, keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("no verifiers found: %s", provider)
 	}
-	stderr, err := cosignCmd.StderrPipe()
-	if err != nil {
-		log.Error(err, "cosign stderr pipe failed")
-	}
-
-	merged := io.MultiReader(stdout, stderr)
-	scanner := bufio.NewScanner(merged)
-
-	if err := cosignCmd.Start(); err != nil {
-		return fmt.Errorf("executing cosign failed: %w", err)
-	}
-
-	for scanner.Scan() {
-		log.Info("cosign: " + scanner.Text())
-	}
-	if err := scanner.Err(); err != nil {
-		log.Error(err, "cosign stdout/stderr scanner failed")
-	}
-
 	return nil
 }

--- a/internal/signutil/signutil.go
+++ b/internal/signutil/signutil.go
@@ -37,11 +37,9 @@ func Sign(log logr.Logger, imageRef string, keyRef string) error {
 	cosignCmd := exec.Command(cosignExecutable, []string{"sign"}...)
 	cosignCmd.Env = os.Environ()
 
-	// if key is empty, use keyless mode(experimental)
+	// if key is empty, use keyless mode
 	if keyRef != "" {
 		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
-	} else {
-		cosignCmd.Env = append(cosignCmd.Env, "COSIGN_EXPERIMENTAL=true")
 	}
 
 	cosignCmd.Args = append(cosignCmd.Args, "--yes")
@@ -67,7 +65,7 @@ func Verify(log logr.Logger, imageRef string, keyRef string,
 	cosignCmd := exec.Command(cosignExecutable, []string{"verify"}...)
 	cosignCmd.Env = os.Environ()
 
-	// if key is empty, use keyless mode(experimental)
+	// if key is empty, use keyless mode
 	if keyRef != "" {
 		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
 	} else {
@@ -89,7 +87,6 @@ func Verify(log logr.Logger, imageRef string, keyRef string,
 		if certOidcIssuerRegexp != "" {
 			cosignCmd.Args = append(cosignCmd.Args, "--certificate-oidc-issuer-regexp", certOidcIssuerRegexp)
 		}
-		cosignCmd.Env = append(cosignCmd.Env, "COSIGN_EXPERIMENTAL=true")
 	}
 
 	cosignCmd.Args = append(cosignCmd.Args, imageRef)

--- a/internal/signutil/signutil.go
+++ b/internal/signutil/signutil.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signutil
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/go-logr/logr"
+)
+
+// Sign signs an image (`imageRef`) using a cosign private key (`keyRef`)
+func Sign(log logr.Logger, imageRef string, keyRef string) error {
+	cosignExecutable, err := exec.LookPath("cosign")
+	if err != nil {
+		return fmt.Errorf("executing cosign failed: %w", err)
+	}
+
+	cosignCmd := exec.Command(cosignExecutable, []string{"sign"}...)
+	cosignCmd.Env = os.Environ()
+
+	// if key is empty, use keyless mode(experimental)
+	if keyRef != "" {
+		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
+	} else {
+		cosignCmd.Env = append(cosignCmd.Env, "COSIGN_EXPERIMENTAL=true")
+	}
+
+	cosignCmd.Args = append(cosignCmd.Args, "--yes")
+	cosignCmd.Args = append(cosignCmd.Args, imageRef)
+
+	err = processCosignIO(log, cosignCmd)
+	if err != nil {
+		return err
+	}
+
+	return cosignCmd.Wait()
+}
+
+// Verify verifies an image (`rawRef`) with a cosign public key (`keyRef`)
+// Either --cosign-certificate-identity or --cosign-certificate-identity-regexp and either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows.
+func Verify(log logr.Logger, imageRef string, keyRef string,
+	certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
+	cosignExecutable, err := exec.LookPath("cosign")
+	if err != nil {
+		return fmt.Errorf("executing cosign failed: %w", err)
+	}
+
+	cosignCmd := exec.Command(cosignExecutable, []string{"verify"}...)
+	cosignCmd.Env = os.Environ()
+
+	// if key is empty, use keyless mode(experimental)
+	if keyRef != "" {
+		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
+	} else {
+		if certIdentity == "" && certIdentityRegexp == "" {
+			return errors.New("--certificate-identity or --certificate-identity-regexp is required for Cosign verification in keyless mode")
+		}
+		if certIdentity != "" {
+			cosignCmd.Args = append(cosignCmd.Args, "--certificate-identity", certIdentity)
+		}
+		if certIdentityRegexp != "" {
+			cosignCmd.Args = append(cosignCmd.Args, "--certificate-identity-regexp", certIdentityRegexp)
+		}
+		if certOidcIssuer == "" && certOidcIssuerRegexp == "" {
+			return errors.New("--certificate-oidc-issuer or --certificate-oidc-issuer-regexp is required for Cosign verification in keyless mode")
+		}
+		if certOidcIssuer != "" {
+			cosignCmd.Args = append(cosignCmd.Args, "--certificate-oidc-issuer", certOidcIssuer)
+		}
+		if certOidcIssuerRegexp != "" {
+			cosignCmd.Args = append(cosignCmd.Args, "--certificate-oidc-issuer-regexp", certOidcIssuerRegexp)
+		}
+		cosignCmd.Env = append(cosignCmd.Env, "COSIGN_EXPERIMENTAL=true")
+	}
+
+	cosignCmd.Args = append(cosignCmd.Args, imageRef)
+
+	err = processCosignIO(log, cosignCmd)
+	if err != nil {
+		return err
+	}
+	if err := cosignCmd.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func processCosignIO(log logr.Logger, cosignCmd *exec.Cmd) error {
+	stdout, err := cosignCmd.StdoutPipe()
+	if err != nil {
+		log.Error(err, "cosign stdout pipe failed")
+	}
+	stderr, err := cosignCmd.StderrPipe()
+	if err != nil {
+		log.Error(err, "cosign stderr pipe failed")
+	}
+
+	merged := io.MultiReader(stdout, stderr)
+	scanner := bufio.NewScanner(merged)
+
+	if err := cosignCmd.Start(); err != nil {
+		return fmt.Errorf("executing cosign failed: %w", err)
+	}
+
+	for scanner.Scan() {
+		log.Info("cosign: " + scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		log.Error(err, "cosign stdout/stderr scanner failed")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add Cosgin integration for image signing to close #25

Flags for `mod push`
```
--sign=cosign Signs the module with Cosign
--cosign-key  The Cosign private key for signing the module
```

Flags for `mod pull`
```
--certificate-identity string             The identity expected in a valid Fulcio certificate for verifying the Cosign signature.
                                          Valid values include email address, DNS names, IP addresses, and URIs.
                                          Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.
--certificate-identity-regexp string      A regular expression alternative to --certificate-identity for verifying the Cosign signature.
                                          Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax.
                                          Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.
--certificate-oidc-issuer string          The OIDC issuer expected in a valid Fulcio certificate for verifying the Cosign signature,
                                          e.g. https://token.actions.githubusercontent.com or https://oauth2.sigstore.dev/auth.
                                          Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.
--certificate-oidc-issuer-regexp string   A regular expression alternative to --certificate-oidc-issuer for verifying the Cosign signature.
                                          Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax.
                                          Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.
--verify=cosign                           Verifies the signed module with Cosign.
--cosign-key string                       The Cosign public key for verifying the module.
```