### PR TITLE
Prefix Kubernetes flags

### DIFF
--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -109,19 +109,25 @@ func main() {
 // addKubeConfigFlags maps the kubectl config flags to the given persistent flags.
 // The default namespace is set to the value found in current kubeconfig context.
 func addKubeConfigFlags(cmd *cobra.Command) {
-	kubeconfigArgs.Timeout = nil
-	kubeconfigArgs.Namespace = nil
-	kubeconfigArgs.AddFlags(cmd.PersistentFlags())
-
 	namespace := "default"
-
 	// Try to read the default namespace from the current context.
 	if ns, _, err := kubeconfigArgs.ToRawKubeConfigLoader().Namespace(); err == nil {
 		namespace = ns
 	}
-
 	kubeconfigArgs.Namespace = &namespace
 
-	cmd.PersistentFlags().StringVarP(kubeconfigArgs.Namespace, "namespace", "n", *kubeconfigArgs.Namespace, "The instance namespace.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.KubeConfig, "kubeconfig", os.Getenv("KUBECONFIG"), "Path to the kubeconfig file.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.Context, "kube-context", "", "The name of the kubeconfig context to use.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.Impersonate, "kube-as", "", "Username to impersonate for the operation. User could be a regular user or a service account in a namespace.")
+	cmd.PersistentFlags().StringArrayVar(kubeconfigArgs.ImpersonateGroup, "kube-as-group", nil, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.ImpersonateUID, "kube-as-uid", "", "UID to impersonate for the operation.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.BearerToken, "kube-token", "", "Bearer token for authentication to the API server.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.APIServer, "kube-server", "", "The address and port of the Kubernetes API server.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.TLSServerName, "kube-tls-server-name", "", "Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.CertFile, "kube-client-certificate", "", "Path to a client certificate file for TLS.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.KeyFile, "kube-client-key", "", "Path to a client key file for TLS.")
+	cmd.PersistentFlags().StringVar(kubeconfigArgs.CAFile, "kube-certificate-authority", "", "Path to a cert file for the certificate authority.")
+	cmd.PersistentFlags().BoolVar(kubeconfigArgs.Insecure, "kube-insecure-skip-tls-verify", false, "if true, the Kubernetes API server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")
+	cmd.PersistentFlags().StringVarP(kubeconfigArgs.Namespace, "namespace", "n", *kubeconfigArgs.Namespace, "The the namespace scope for the operation.")
 	cmd.RegisterFlagCompletionFunc("namespace", completeNamespaceList)
 }


### PR DESCRIPTION
This PR adds the `kube-` prefix to all the flags specific to Kubernetes to avoid collision with OCI registry.

### Breaking changes

The Kubernetes flags are now:

```
--kube-as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
--kube-as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
--kube-as-uid string                  UID to impersonate for the operation.
--kube-certificate-authority string   Path to a cert file for the certificate authority.
--kube-client-certificate string      Path to a client certificate file for TLS.
--kube-client-key string              Path to a client key file for TLS.
--kube-context string                 The name of the kubeconfig context to use.
--kube-insecure-skip-tls-verify       if true, the Kubernetes API server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
--kube-server string                  The address and port of the Kubernetes API server.
--kube-tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used.
--kube-token string                   Bearer token for authentication to the API server.
--kubeconfig string                   Path to the kubeconfig file.
```
