### PR TITLE
docs: Sign and verify modules with Cosign

### DIFF
--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -66,6 +66,11 @@ container registry using the version as the image tag.`,
 	--annotations='org.opencontainers.image.licenses=Apache-2.0' \
 	--annotations='org.opencontainers.image.documentation=https://app.org/docs' \
 	--annotations='org.opencontainers.image.description=A timoni.sh module for my app.'
+
+  # Push a module and sign it with Cosign Keyless (the cosign binary must be present in PATH)
+  timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
+	--version=1.0.0 \
+	--sign=cosign
 `,
 	RunE: pushModCmdRun,
 }

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -13,7 +13,7 @@ steps:
   - name: Setup Timoni
     uses: stefanprodan/timoni/actions/setup@main
     with:
-      version: latest # latest or exact version e.g. 0.2.0
+      version: latest # latest or exact version e.g. 0.13.0
   - name: Run Timoni
     run: timoni version
 ```
@@ -40,8 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup CUE
-        uses: cue-lang/setup-cue@main
       - name: Setup Timoni
         uses: stefanprodan/timoni/actions/setup@main
       - name: Lint
@@ -54,8 +52,47 @@ jobs:
         run: |
           timoni mod push ./modules/my-module \
             oci://ghcr.io/${{ github.repository_owner }}/modules/my-module \
-          	--version ${{ github.ref_name }} \
+            --version ${{ github.ref_name }} \
             --creds ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+```
+
+### Push and sign with Cosign Keyless
+
+Example workflow for pushing and signing the module using Cosign and GitHub OIDC:
+
+```yaml
+name: Release and sign module
+on:
+  push:
+    tag: ['*'] # semver format
+
+permissions:
+  contents: read # needed for checkout
+  packages: write # needed for GHCR access
+  id-token: write # needed for signing
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@main
+      - name: Setup Timoni
+        uses: stefanprodan/timoni/actions/setup@main
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push and Sign
+        run: |
+          timoni mod push ./modules/my-module \
+            oci://ghcr.io/${{ github.repository_owner }}/modules/my-module \
+            --version ${{ github.ref_name }} \
+            --sign=cosign
 ```
 
 ### Push to Docker Hub

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,9 +65,7 @@ Commands for working with remote modules:
 - `timoni mod pull oci://<module-url> -v <semver> -o <path/to/module>`
 - `timoni mod list oci://<module-url>`
 
-Timoni produces artifacts compatible with Docker Hub, GitHub Container Registry,
-Azure Container Registry, Amazon Elastic Container Registry, Google Artifact Registry,
-self-hosted Docker Registry and others.
+Timoni produces OCI artifacts that can be cryptographically [signed and verified](module-sign.md).
 
 ### Timoni Instances
 

--- a/docs/module-semver.md
+++ b/docs/module-semver.md
@@ -65,6 +65,8 @@ then it will tag the version as `latest` in the container registry.
 
 To automate the publishing of module versions, please see the [Timoni GitHub Actions](github-actions.md).
 
+To cryptographically sign a module version, please see the [Timoni module signing and verification doc](module-sign.md).
+
 ## Listing module versions
 
 Timoni offer a command for listing all the versions available in a container registry for a particular module.

--- a/docs/module-sign.md
+++ b/docs/module-sign.md
@@ -1,0 +1,103 @@
+# Module Signing and Verification
+
+Timoni modules are distributed as OCI artifacts. When publishing a module version to a container registry,
+the OCI artifact can be cryptographically signed to improve the software supply chain security.
+
+## Cosign
+
+Timoni can sign modules using Sigstore Cosign.
+[Cosign](https://github.com/sigstore/cosign) is tool that allows you to sign and verify
+OCI artifacts with a public/private key pair or with an OIDC token provided by GitHub, Google or Microsoft.
+
+To sign modules, you need to [install](https://docs.sigstore.dev/system_config/installation/)
+the Cosign v2 binary and place it in the `PATH` for Timoni to use it.
+
+### Sign with static keys
+
+Generate a cosign key pair:
+
+```shell
+cosign generate-key-pair
+```
+
+Export the private key password with:
+
+```shell
+export COSIGN_PASSWORD=<your password>
+```
+
+Sign the module while pushing:
+
+```shell
+timoni mod push ./modules/my-app oci://ghcr.io/my-org/modules/my-app \
+  --version=1.0.0 \
+  --sign=cosign \
+  --cosign-key=cosign.key
+```
+
+Timoni will push the module to the registry and will pass the OCI artifact digest to Cosign.
+Cosign will push the signature to the registry and will record the signature in
+the [Rekor](https://github.com/sigstore/rekor) transparency log.
+
+To verify the module signature:
+
+```shell
+cosign verify ghcr.io/my-org/modules/my-app:1.0.0 --key=cosign.pub
+```
+
+To verify the module signature while pulling:
+
+```shell
+timoni mod pull oci://ghcr.io/my-org/modules/my-app -v 1.0.0 \
+  --output ./my-module \
+  --verify=cosign \
+  --cosign-key=cosign.pub
+```
+
+### Sign with Cosign keyless
+
+For keyless signing, the Cosign CLI would prompt you to confirm that your email will be stored
+in the public transparency logs. Timoni adds `--yes` to the cosign command to prevents this prompt.
+
+Using Timoni with Cosign keyless signature means that users agree to this statement:
+
+```text
+Note that there may be personally identifiable information associated with this signed artifact.
+This may include the email address associated with the account with which you authenticate.
+This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
+
+By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs.
+```
+
+Sign the module while pushing:
+
+```shell
+timoni mod push ./modules/my-app oci://ghcr.io/my-org/modules/my-app \
+  --version=1.0.0 \
+  --sign=cosign
+```
+
+!!! tip "Signing in CI"
+
+    When using `timoni push` in CI workflows, you can configure [GitHub](https://github.com/marketplace/actions/cosign-installer) and
+    [GitLab](https://docs.gitlab.com/ee/ci/yaml/signing_examples.html) to provide Cosign with an OIDC token. 
+
+    To automate the publishing and signing of module versions, please see the [Timoni GitHub Actions](github-actions.md).
+
+To verify the module signature:
+
+```shell
+cosign verify ghcr.io/my-org/modules/my-app:1.0.0 \
+  --certificate-identity-regexp=<your email address> \
+  --certificate-oidc-issuer-regexp=<your issuer URL>
+```
+
+To verify the module signature while pulling:
+
+```shell
+timoni mod pull oci://ghcr.io/my-org/modules/my-app -v 1.0.0 \
+  --output ./my-module \
+  --verify=cosign \
+  --certificate-identity-regexp=<your email address> \
+  --certificate-oidc-issuer-regexp=<your issuer URL>
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Bundle runtime: bundle-runtime.md
       - Module structure: module.md
       - Module versioning: module-semver.md
+      - Module signing: module-sign.md
       - Values files: values.md
       - Compared to other tools: comparison.md
   - Automation:


### PR DESCRIPTION
Docs changes:
- Add documentation on how to sign and verify modules
- Add Cosign Keyless example to the GitHub Actions documentation

Followup: #182 