### PR TITLE
Add cmd for importing Kubernetes API schemas

### DIFF
--- a/cmd/timoni/mod_import.go
+++ b/cmd/timoni/mod_import.go
@@ -22,7 +22,7 @@ import (
 
 var modImportCmd = &cobra.Command{
 	Use:   "import",
-	Short: "Commands for importing CUE definitions",
+	Short: "Commands for importing CUE schemas",
 }
 
 func init() {

--- a/cmd/timoni/mod_import_k8s.go
+++ b/cmd/timoni/mod_import_k8s.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	oci "github.com/fluxcd/pkg/oci/client"
+	"github.com/spf13/cobra"
+)
+
+var importK8sCmd = &cobra.Command{
+	Use:   "k8s [MODULE PATH]",
+	Short: "Import Kubernetes API CUE schemas",
+	Example: `  # Import the latest Kubernetes API schemas
+  timoni mod import k8s
+
+  # Import s specific minor version of the Kubernetes API schemas
+  timoni mod import k8s -v 1.28
+`,
+	RunE: runimportK8sCmd,
+}
+
+type importK8sFlags struct {
+	modRoot string
+	version string
+}
+
+var importK8sArgs importK8sFlags
+
+func init() {
+	importK8sCmd.Flags().StringVarP(&importK8sArgs.version, "version", "v", "latest",
+		"The Kubernetes minor version e.g. 1.28.")
+
+	modImportCmd.AddCommand(importK8sCmd)
+}
+
+const k8sSchemaURL = "ghcr.io/stefanprodan/timoni/kubernetes-schema"
+
+func runimportK8sCmd(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		importK8sArgs.modRoot = args[0]
+	}
+
+	log := LoggerFrom(cmd.Context())
+
+	// Make sure we're importing into a CUE module.
+	cueModDir := path.Join(importK8sArgs.modRoot, "cue.mod")
+	if fs, err := os.Stat(cueModDir); err != nil || !fs.IsDir() {
+		return fmt.Errorf("cue.mod not found in the module path %s", importK8sArgs.modRoot)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	ociClient := oci.NewClient(nil)
+
+	url := fmt.Sprintf("%s:%s", k8sSchemaURL, importK8sArgs.version)
+	if ver := importK8sArgs.version; ver != "latest" && !strings.HasPrefix(ver, "v") {
+		url = fmt.Sprintf("%s:v%s", k8sSchemaURL, ver)
+	}
+
+	spin := StartSpinner(fmt.Sprintf("importing schemas from %s", url))
+	_, err := ociClient.Pull(ctx, url, path.Join(cueModDir, "gen"))
+	spin.Stop()
+	if err != nil {
+		return err
+	}
+
+	log.Info(fmt.Sprintf("schemas imported: %s", colorizeSubject(path.Join(cueModDir, "gen", "k8s.io", "api"))))
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a new command for simplifying the import and generation of CUE schemas for Kubernetes APIs.

The `timoni mod import k8s` along with `timoni mod import crd` improve the UX of developing and maintaining app modules.

### Motivation

Currently module authors have to install Go, create a dummy Go module, run `go get` for all the Kubernetes API Go packages for a specific Kubernetes version, then run `cue get go` for each API group to generate CUE schemas out of the Go types. Keeping this schemas up to date with the Kubernetes releases is a tedious process, since the Go types depend on each other e.g. `k8s.io/api/apps/v1@0.28.2` depends on `k8s.io/api/core/v1` which depends various packages under `k8s.io/apimachinery`. 

### Solution

Timoni offers a simple command for importing and updating all the Kubernetes builtin APIs for a specific minor version.

```console
$ timoni mod import k8s -h
Import Kubernetes API CUE schemas

Usage:
  timoni mod import k8s [MODULE PATH] [flags]

Examples:
  # Import the latest Kubernetes API schemas
  timoni mod import k8s

  # Import s specific minor version of the Kubernetes API schemas
  timoni mod import k8s -v 1.28
```

The `timoni mod import k8s` command pulls the CUE schemas from GitHub Container Registry.  These schemas are generated after each Kubernetes minor release in the [kubernetes-cue-schema](https://github.com/stefanprodan/kubernetes-cue-schema) repository and published as OCI artifacts at [ghcr.io/stefanprodan/timoni/kubernetes-schema](https://github.com/stefanprodan/kubernetes-cue-schema/pkgs/container/timoni%2Fkubernetes-schema).

For each Kubernetes **minor version**, a dedicated set of CUE schemas are generated for the following Kubernetes GA APIs:

- `k8s.io/api/admission/v1`
- `k8s.io/api/admissionregistration/v1`
- `k8s.io/api/apps/v1`
- `k8s.io/api/authentication/v1`
- `k8s.io/api/authorization/v1`
- `k8s.io/api/autoscaling/v2`
- `k8s.io/api/autoscaling/v1`
- `k8s.io/api/batch/v1`
- `k8s.io/api/certificates/v1`
- `k8s.io/api/coordination/v1`
- `k8s.io/api/core/v1`
- `k8s.io/api/discovery/v1`
- `k8s.io/api/events/v1`
- `k8s.io/api/networking/v1`
- `k8s.io/api/node/v1`
- `k8s.io/api/policy/v1`
- `k8s.io/api/rbac/v1`
- `k8s.io/api/scheduling/v1`
- `k8s.io/api/storage/v1`
