### PR TITLE
Add registry login/logout commands

### DIFF
--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -36,8 +36,8 @@ from a container registry and extract the selected layers to the specified direc
   timoni artifact pull oci://docker.io/org/app:latest
 
   # Pull an artifact by tag from a private GHCR repository
+  echo $GITHUB_TOKEN | timoni registry login ghcr.io -u timoni --password-stdin
   timoni artifact pull oci://ghcr.io/org/schemas/app:1.0.0 \
-	--creds=timoni:$GITHUB_TOKEN \
 	--output=./modules/my-app/cue.mod/pkg
 
   # VerifyArtifact the Cosign signature and pull (the cosign binary must be present in PATH)

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -49,6 +49,7 @@ the ignore rules will be used to exclude files from the artifact.`,
 	--content-type="timoni.sh/bundles"
 
   # Push and sign with Cosign (the cosign binary must be present in PATH)
+  echo $GITHUB_TOKEN | timoni registry login ghcr.io -u timoni --password-stdin
   export COSIGN_PASSWORD=password
   timoni artifact push oci://ghcr.io/org/schemas/app \
 	-f=/path/to/schemas \

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -34,6 +34,7 @@ var pullModCmd = &cobra.Command{
 	Long: `The pull command downloads the module from a container registry and
 extract its contents the specified directory.`,
 	Example: `  # Pull the latest stable version of a module
+  echo $DOCKER_TOKEN | timoni registry login docker.io -u timoni --password-stdin
   timoni mod pull oci://docker.io/org/app \
 	--output ./path/to/module
 

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -57,6 +57,7 @@ container registry using the version as the image tag.`,
 	--latest=false
 
   # Push a module with custom OCI annotations
+  echo $GITHUB_TOKEN | timoni registry login ghcr.io -u timoni --password-stdin
   timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
 	--version=1.0.0 \
 	--source='https://github.com/my-org/my-app' \
@@ -65,6 +66,7 @@ container registry using the version as the image tag.`,
 	--annotations='org.opencontainers.image.description=A timoni.sh module for my app.'
 
   # Push a module and sign it with Cosign Keyless (the cosign binary must be present in PATH)
+  echo $GITHUB_TOKEN | timoni registry login ghcr.io -u timoni --password-stdin
   timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
 	--version=1.0.0 \
 	--sign=cosign

--- a/cmd/timoni/registry.go
+++ b/cmd/timoni/registry.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	cranecmd "github.com/google/go-containerregistry/cmd/crane/cmd"
+	"github.com/spf13/cobra"
+)
+
+var registryCmd = &cobra.Command{
+	Use:   "registry",
+	Short: "Commands for managing the authentication to container registries",
+}
+
+func init() {
+	rootCmd.AddCommand(registryCmd)
+	registryCmd.AddCommand(cranecmd.NewCmdAuthLogin("timoni", "registry"))
+	registryCmd.AddCommand(cranecmd.NewCmdAuthLogout("timoni", "registry"))
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,9 @@ nav:
           - Build: cmd/timoni_bundle_build.md
           - Delete: cmd/timoni_bundle_delete.md
           - Lint: cmd/timoni_bundle_lint.md
+      - Registries:
+          - Login: cmd/timoni_registry_login.md
+          - Logout: cmd/timoni_registry_logout.md
       - Completion:
           - Bash: cmd/timoni_completion_bash.md
           - Fish: cmd/timoni_completion_fish.md


### PR DESCRIPTION
For when the Docker CLI is not installed on the machine running Timoni, the auth to container registries can be setup with `timoni registry` commands that will write to `~/.docker/config.json`. On macOS and Windows, the login command uses the credential store.

Example:

Login:

```shell
echo $GITHUB_TOKEN | timoni registry login ghcr.io --username timoni --password-stdin
echo $DOCKER_TOKEN | timoni registry login docker.io --username timoni --password-stdin
```

Logout:

```shell
timoni registry logout ghcr.io
timoni registry logout docker.io
```