### PR TITLE
Consolidate artifact annotations and Git metadata

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,6 +34,7 @@ jobs:
           timoni mod push ./examples/minimal oci://ghcr.io/stefanprodan/timoni/minimal \
           --sign cosign \
           --version ${{ github.event.inputs.version }} \
-          --source https://github.com/stefanprodan/timoni/tree/main/examples/minimal  \
+          -a 'org.opencontainers.image.licenses=Apache-2.0' \
+          -a 'org.opencontainers.image.source=https://github.com/stefanprodan/timoni/tree/main/examples/minimal'  \
           -a 'org.opencontainers.image.description=A minimal timoni.sh module example.' \
           -a 'org.opencontainers.image.documentation=https://github.com/stefanprodan/timoni/blob/main/examples/minimal/README.md'

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint-samples: build
 REDIS_VER=$(shell cat ./examples/redis/templates/config.cue | awk '/tag:/ {print $$2}' | tr -d '*"')
 push-redis: build
 	./bin/timoni mod push ./examples/redis oci://ghcr.io/stefanprodan/modules/redis -v $(REDIS_VER) --latest \
-		--source https://github.com/stefanprodan/timoni/tree/main/examples/redis  \
+		-a 'org.opencontainers.image.source=https://github.com/stefanprodan/timoni/tree/main/examples/redis'  \
 		-a 'org.opencontainers.image.description=A timoni.sh module for deploying Redis master-replica clusters.' \
 		-a 'org.opencontainers.image.documentation=https://github.com/stefanprodan/timoni/blob/main/examples/redis/README.md'
 

--- a/api/v1alpha1/artifact.go
+++ b/api/v1alpha1/artifact.go
@@ -37,12 +37,12 @@ const (
 	AnyContentType = ""
 
 	// TimoniModContentType is the value of ContentTypeAnnotation for setting the
-	// content to Timoni module content without cue.mod.
+	// layer type to Timoni module content.
 	TimoniModContentType = "module"
 
-	// CueModContentType is the value of ContentTypeAnnotation for setting the
-	// content to CUE vendor schemas.
-	CueModContentType = "cue.mod"
+	// TimoniModVendorContentType is the value of ContentTypeAnnotation for setting the
+	// layer type to Timoni module vendored CUE schemas.
+	TimoniModVendorContentType = "module/vendor"
 
 	// CueModGenContentType is the value of ContentTypeAnnotation for setting the
 	// content to CUE generated schemas.
@@ -59,6 +59,10 @@ const (
 	// RevisionAnnotation is the OpenContainers annotation for specifying
 	// the upstream source revision of an artifact.
 	RevisionAnnotation = "org.opencontainers.image.revision"
+
+	// VersionAnnotation is the OpenContainers annotation for specifying
+	// the semantic version of an artifact.
+	VersionAnnotation = "org.opencontainers.image.version"
 
 	// CreatedAnnotation is the OpenContainers annotation for specifying
 	// the build date and time on an artifact (RFC 3339).

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -126,7 +126,7 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	oci.AppendCreated(ctx, pushArtifactArgs.path, annotations)
+	oci.AppendGitMetadata(pushArtifactArgs.path, annotations)
 
 	spin := StartSpinner("pushing artifact")
 	defer spin.Stop()

--- a/cmd/timoni/artifact_push_test.go
+++ b/cmd/timoni/artifact_push_test.go
@@ -34,16 +34,18 @@ func Test_PushArtifact(t *testing.T) {
 	aURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-artifact", 5))
 	aTag := "1.0.0"
 	aLicense := "org.opencontainers.image.licenses=Apache-2.0"
+	aSource := "org.opencontainers.image.source=https://host/repo.git"
 	aRevision := "org.opencontainers.image.revision=1.0.0"
 
 	// Push the artifact to registry
 	output, err := executeCommand(fmt.Sprintf(
-		"artifact push oci://%s -f %s -t %s -a '%s' -a '%s' --content-type=generic",
+		"artifact push oci://%s -f %s -t %s -a '%s' -a '%s' -a '%s' --content-type=generic",
 		aURL,
 		aPath,
 		aTag,
 		aLicense,
 		aRevision,
+		aSource,
 	))
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(output).To(ContainSubstring(aURL))
@@ -58,6 +60,7 @@ func Test_PushArtifact(t *testing.T) {
 
 	// Verify that annotations exist in manifest
 	g.Expect(manifest.Annotations[apiv1.CreatedAnnotation]).ToNot(BeEmpty())
+	g.Expect(manifest.Annotations[apiv1.SourceAnnotation]).To(BeEquivalentTo("https://host/repo.git"))
 	g.Expect(manifest.Annotations[apiv1.RevisionAnnotation]).To(BeEquivalentTo(aTag))
 	g.Expect(manifest.Annotations["org.opencontainers.image.licenses"]).To(BeEquivalentTo("Apache-2.0"))
 

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
@@ -41,8 +39,7 @@ var pushModCmd = &cobra.Command{
 container registry using the version as the image tag.`,
 	Example: `  # Push a module to Docker Hub using the credentials from '~/.docker/config.json'
   echo $DOCKER_PAT | docker login --username timoni --password-stdin
-  timoni mod push ./path/to/module oci://docker.io/org/app-module \
-	--version=1.0.0
+  timoni mod push ./path/to/module oci://docker.io/org/app-module -v 1.0.0
 
   # Push a module to GitHub Container Registry using a GitHub token
   timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
@@ -56,13 +53,20 @@ container registry using the version as the image tag.`,
 	--latest=false
 
   # Push a module with custom OCI annotations
-  echo $GITHUB_TOKEN | timoni registry login ghcr.io -u timoni --password-stdin
   timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
 	--version=1.0.0 \
 	--source='https://github.com/my-org/my-app' \
-	--annotations='org.opencontainers.image.licenses=Apache-2.0' \
-	--annotations='org.opencontainers.image.documentation=https://app.org/docs' \
-	--annotations='org.opencontainers.image.description=A timoni.sh module for my app.'
+	--annotation='org.opencontainers.image.licenses=Apache-2.0' \
+	--annotation='org.opencontainers.image.documentation=https://app.org/docs' \
+	--annotation='org.opencontainers.image.description=A timoni.sh module for my app.'
+
+  # Push and sign with Cosign (the cosign binary must be present in PATH)
+  echo $GITHUB_TOKEN | timoni registry login ghcr.io -u timoni --password-stdin
+  export COSIGN_PASSWORD=password
+  timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
+	--version=1.0.0 \
+	--sign=cosign \
+	--cosign-key=/path/to/cosign.key
 
   # Push a module and sign it with Cosign Keyless (the cosign binary must be present in PATH)
   echo $GITHUB_TOKEN | timoni registry login ghcr.io -u timoni --password-stdin
@@ -95,7 +99,7 @@ func init() {
 	pushModCmd.Flags().Var(&pushModArgs.creds, pushModArgs.creds.Type(), pushModArgs.creds.Description())
 	pushModCmd.Flags().BoolVar(&pushModArgs.latest, "latest", true,
 		"Tags the current version as the latest stable release.")
-	pushModCmd.Flags().StringArrayVarP(&pushModArgs.annotations, "annotations", "a", nil,
+	pushModCmd.Flags().StringArrayVarP(&pushModArgs.annotations, "annotation", "a", nil,
 		"Set custom OCI annotations in the format '<key>=<value>'.")
 	pushModCmd.Flags().StringVarP(&pushModArgs.output, "output", "o", "",
 		"The format in which the artifact digest should be printed, can be 'yaml' or 'json'.")
@@ -131,20 +135,14 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	annotations[apiv1.VersionAnnotation] = version
+	if pushModArgs.source != "" {
+		annotations[apiv1.SourceAnnotation] = pushModArgs.source
+	}
+	oci.AppendGitMetadata(pushModArgs.module, annotations)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
-
-	oci.AppendCreated(ctx, pushModArgs.module, annotations)
-
-	// Try to determine the Git origin URL
-	if pushModArgs.source == "" {
-		gitCmd := exec.CommandContext(ctx, "git", "config", "--get", "remote.origin.url")
-		gitCmd.Dir = pushModArgs.module
-		if repo, err := gitCmd.Output(); err == nil && len(repo) > 1 {
-			pushModArgs.source = strings.TrimSuffix(string(repo), "\n")
-		}
-	}
-	oci.AppendSource(pushModArgs.source, version, annotations)
 
 	ps, err := engine.ReadIgnoreFile(pushModArgs.module)
 	if err != nil {

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -48,14 +48,12 @@ container registry using the version as the image tag.`,
 
   # Push a release candidate without marking it as the latest stable
   timoni mod push ./path/to/module oci://docker.io/org/app-module \
-	--source="$(git config --get remote.origin.url)" \
 	--version=2.0.0-rc.1 \
 	--latest=false
 
   # Push a module with custom OCI annotations
   timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
 	--version=1.0.0 \
-	--source='https://github.com/my-org/my-app' \
 	--annotation='org.opencontainers.image.licenses=Apache-2.0' \
 	--annotation='org.opencontainers.image.documentation=https://app.org/docs' \
 	--annotation='org.opencontainers.image.description=A timoni.sh module for my app.'
@@ -79,7 +77,6 @@ container registry using the version as the image tag.`,
 
 type pushModFlags struct {
 	module      string
-	source      string
 	version     flags.Version
 	latest      bool
 	creds       flags.Credentials
@@ -94,8 +91,6 @@ var pushModArgs pushModFlags
 
 func init() {
 	pushModCmd.Flags().VarP(&pushModArgs.version, pushModArgs.version.Type(), pushModArgs.version.Shorthand(), pushModArgs.version.Description())
-	pushModCmd.Flags().StringVar(&pushModArgs.source, "source", "",
-		"The VCS address of the module. When left empty, the Git CLI is used to get the remote origin URL.")
 	pushModCmd.Flags().Var(&pushModArgs.creds, pushModArgs.creds.Type(), pushModArgs.creds.Description())
 	pushModCmd.Flags().BoolVar(&pushModArgs.latest, "latest", true,
 		"Tags the current version as the latest stable release.")
@@ -136,9 +131,6 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	annotations[apiv1.VersionAnnotation] = version
-	if pushModArgs.source != "" {
-		annotations[apiv1.SourceAnnotation] = pushModArgs.source
-	}
 	oci.AppendGitMetadata(pushModArgs.module, annotations)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)

--- a/cmd/timoni/mod_push_test.go
+++ b/cmd/timoni/mod_push_test.go
@@ -61,7 +61,9 @@ func Test_PushMod(t *testing.T) {
 
 	// Verify that annotations exist in manifest
 	g.Expect(manifest.Annotations[apiv1.CreatedAnnotation]).ToNot(BeEmpty())
-	g.Expect(manifest.Annotations[apiv1.RevisionAnnotation]).To(BeEquivalentTo(modVer))
+	g.Expect(manifest.Annotations[apiv1.RevisionAnnotation]).ToNot(BeEmpty())
+	g.Expect(manifest.Annotations[apiv1.SourceAnnotation]).To(ContainSubstring("github.com"))
+	g.Expect(manifest.Annotations[apiv1.VersionAnnotation]).To(BeEquivalentTo(modVer))
 	g.Expect(manifest.Annotations["org.opencontainers.image.licenses"]).To(BeEquivalentTo("Apache-2.0"))
 	g.Expect(manifest.Annotations["org.opencontainers.image.description"]).To(BeEquivalentTo("My, test."))
 
@@ -70,7 +72,7 @@ func Test_PushMod(t *testing.T) {
 	g.Expect(manifest.Config.MediaType).To(BeEquivalentTo(apiv1.ConfigMediaType))
 	g.Expect(len(manifest.Layers)).To(BeEquivalentTo(2))
 	g.Expect(manifest.Layers[0].MediaType).To(BeEquivalentTo(apiv1.ContentMediaType))
-	g.Expect(manifest.Layers[0].Annotations[apiv1.ContentTypeAnnotation]).To(BeEquivalentTo(apiv1.CueModContentType))
+	g.Expect(manifest.Layers[0].Annotations[apiv1.ContentTypeAnnotation]).To(BeEquivalentTo(apiv1.TimoniModVendorContentType))
 	g.Expect(manifest.Layers[1].MediaType).To(BeEquivalentTo(apiv1.ContentMediaType))
 	g.Expect(manifest.Layers[1].Annotations[apiv1.ContentTypeAnnotation]).To(BeEquivalentTo(apiv1.TimoniModContentType))
 
@@ -89,5 +91,5 @@ func Test_PushMod(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	manifest, err = image.Manifest()
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(manifest.Annotations[apiv1.RevisionAnnotation]).To(BeEquivalentTo(newVer))
+	g.Expect(manifest.Annotations[apiv1.VersionAnnotation]).To(BeEquivalentTo(newVer))
 }

--- a/docs/bundle-distribution.md
+++ b/docs/bundle-distribution.md
@@ -1,7 +1,25 @@
 # Bundle Distribution
 
 [Bundles](bundles.md) and their [Runtimes](bundle-runtime.md) can be distributed as
-Open Container Initiative (OCI) artifacts.
+[Open Container Initiative](https://opencontainers.org/) (OCI) artifacts.
+
+## Artifact format
+
+The OCI artifacts produced with `timoni artifact push` have the following media types:
+
+- Image media type `application/vnd.oci.image.manifest.v1+json`
+- Config media type `application/vnd.timoni.config.v1+json`
+- Layer media type `application/vnd.timoni.content.v1.tar+gzip`
+
+The artifacts are annotated with OpenContainers
+[standard annotations](https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1#pre-defined-annotation-keys):
+
+- `org.opencontainers.image.source: <GIT URL>`
+- `org.opencontainers.image.revision: <GIT COMMIT SHA>`
+- `org.opencontainers.image.created: <GIT COMMIT DATE>`
+
+To enable reproducible builds, Timoni tries to determine the 
+source, revision and created date from the Git metadata.
 
 ## Publishing bundles to container registries
 

--- a/docs/module-semver.md
+++ b/docs/module-semver.md
@@ -1,9 +1,27 @@
-# Module Versioning
+# Module Distribution
 
-Timoni modules are distributed as OCI artifacts. When publishing a module version
-to a container registry, the version number is used as the OCI artifact tag.
-The version number is also stored in the artifact manifest as the value of the
-`org.opencontainers.image.revision` annotation.
+Timoni modules are distributed as [Open Container Initiative](https://opencontainers.org/)
+(OCI) artifacts. When publishing a module version to a container registry,
+the version number is used as the OCI artifact tag.
+
+## Artifact format
+
+The OCI artifacts produced with `timoni mod push` have the following media types:
+
+- Image media type `application/vnd.oci.image.manifest.v1+json`
+- Config media type `application/vnd.timoni.config.v1+json`
+- Layer media type `application/vnd.timoni.content.v1.tar+gzip`
+
+The artifacts are annotated with OpenContainers
+[standard annotations](https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1#pre-defined-annotation-keys):
+
+- `org.opencontainers.image.version: <MODULE VERSION>`
+- `org.opencontainers.image.created: <MODULE LAST MODIFIED DATE>`
+- `org.opencontainers.image.source: <MODULE GIT URL>`
+- `org.opencontainers.image.revision: <MODULE GIT SHA>`
+
+To enable reproducible builds, Timoni tries to determine the module's
+last modified date, the source URL and source revision from the Git metadata.
 
 ## Version format
 
@@ -35,7 +53,6 @@ Example of publishing version `1.0.0` as the latest stable release:
 
 ```shell
 timoni mod push ./modules/my-app oci://ghcr.io/my-org/modules/my-app \
-  --source='https://github.com/my-org/my-app' \
   --latest=true \
   --version=1.0.0
 ```
@@ -47,7 +64,6 @@ Example of publishing a pre-release version:
 
 ```shell
 timoni mod push ./modules/my-app oci://ghcr.io/my-org/modules/my-app \
-  --source='https://github.com/my-org/my-app' \
   --latest=false \
   --version=2.0.0-beta.1
 ```

--- a/internal/oci/artifact_test.go
+++ b/internal/oci/artifact_test.go
@@ -42,8 +42,7 @@ func TestArtifactOperations(t *testing.T) {
 
 	annotations, err := ParseAnnotations([]string{imgLicense})
 	g.Expect(err).ToNot(HaveOccurred())
-	AppendCreated(ctx, srcPath, annotations)
-	AppendSource(imgURL, imgVersion, annotations)
+	AppendGitMetadata(srcPath, annotations)
 
 	opts := Options(ctx, "")
 	digestURL, err := PushArtifact(imgVersionURL, srcPath, imgIgnore, imgContentType, annotations, opts)

--- a/internal/oci/module_test.go
+++ b/internal/oci/module_test.go
@@ -41,8 +41,8 @@ func TestModuleOperations(t *testing.T) {
 
 	annotations, err := ParseAnnotations([]string{imgLicense})
 	g.Expect(err).ToNot(HaveOccurred())
-	AppendCreated(ctx, srcPath, annotations)
-	AppendSource(imgURL, imgVersion, annotations)
+	annotations[apiv1.VersionAnnotation] = imgVersion
+	AppendGitMetadata(srcPath, annotations)
 
 	opts := Options(ctx, "")
 	digestURL, err := PushModule(imgVersionURL, srcPath, imgIgnore, annotations, opts)
@@ -78,7 +78,7 @@ func TestModuleOperations(t *testing.T) {
 	}
 
 	dstVendorPath := filepath.Join(tmpDir, "module-vendor")
-	err = PullArtifact(imgURL, dstVendorPath, apiv1.CueModContentType, opts)
+	err = PullArtifact(imgURL, dstVendorPath, apiv1.TimoniModVendorContentType, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(filepath.Join(dstVendorPath, "timoni.cue")).ToNot(BeAnExistingFile())
 	g.Expect(filepath.Join(dstVendorPath, "templates")).ToNot(BeAnExistingFile())

--- a/internal/oci/pull_module.go
+++ b/internal/oci/pull_module.go
@@ -61,9 +61,18 @@ func PullModule(ociURL, dstPath string, opts []crane.Option) (*apiv1.ModuleRefer
 			manifest.Config.MediaType, apiv1.ConfigMediaType)
 	}
 
+	version := ""
+	if rev, ok := manifest.Annotations[apiv1.RevisionAnnotation]; ok == true {
+		// For backwards compatibility with Timoni v0.13
+		version = rev
+	}
+	if ver, ok := manifest.Annotations[apiv1.VersionAnnotation]; ok == true {
+		version = ver
+	}
+
 	moduleRef := &apiv1.ModuleReference{
 		Repository: fmt.Sprintf("%s%s", apiv1.ArtifactPrefix, repoURL),
-		Version:    manifest.Annotations[apiv1.RevisionAnnotation],
+		Version:    version,
 		Digest:     digest,
 	}
 

--- a/internal/oci/push_module.go
+++ b/internal/oci/push_module.go
@@ -73,7 +73,7 @@ func PushModule(ociURL, contentPath string, ignorePaths []string, annotations ma
 	img, err = mutate.Append(img, mutate.Addendum{
 		Layer: layerVendor,
 		Annotations: map[string]string{
-			apiv1.ContentTypeAnnotation: apiv1.CueModContentType,
+			apiv1.ContentTypeAnnotation: apiv1.TimoniModVendorContentType,
 		},
 	})
 	if err != nil {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - Bundle runtime: bundle-runtime.md
       - Bundle distribution: bundle-distribution.md
       - Module structure: module.md
-      - Module versioning: module-semver.md
+      - Module distribution: module-semver.md
       - Module signing: module-sign.md
       - Values files: values.md
       - Compared to other tools: comparison.md


### PR DESCRIPTION
Changes:
- Use the `org.opencontainers.image.version` annotation for modules
- Set the OCI source, revision and created annotations automatically from Git metadata
- Allow overriding the source and revision values with the `--annotation` flags
- Document artifact media types and standard annotations

⚠️ Breaking Changes:
- Rename `--annotations` to `--annotation` arg in `timoni mod push`
- Remove `--source` arg from `timoni mod push` (automatically set and can be overwitten via `--annotation`)