### PR TITLE
Uninstall bundle instances in reverse order

### DIFF
--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -335,7 +335,7 @@ func applyBundleInstance(ctx context.Context, cuectx *cue.Context, instance engi
 		}
 
 		if !nsExists {
-			log.Info(colorizeJoin(colorizeNamespaceFromArgs(), ssa.CreatedAction))
+			log.Info(colorizeJoin(colorizeSubject("Namespace/"+instance.Namespace), ssa.CreatedAction))
 		}
 	} else {
 		log.Info(fmt.Sprintf("upgrading %s in namespace %s", instance.Name, instance.Namespace))

--- a/cmd/timoni/bundle_delete.go
+++ b/cmd/timoni/bundle_delete.go
@@ -102,7 +102,13 @@ func deleteBundleByName(ctx context.Context, bundle string) error {
 		return err
 	}
 
-	for _, instance := range instances {
+	if len(instances) == 0 {
+		return fmt.Errorf("no instances found in bundle")
+	}
+
+	// delete in revers order (last installed, first to uninstall)
+	for index := len(instances) - 1; index >= 0; index-- {
+		instance := instances[index]
 		log.Info(fmt.Sprintf("deleting instance %s from bundle %s", instance.Name, bundleDelArgs.name))
 		if err := deleteBundleInstance(ctx, engine.BundleInstance{
 			Bundle:    bundle,
@@ -159,7 +165,8 @@ func deleteBundleFromFile(ctx context.Context, cmd *cobra.Command) error {
 		return fmt.Errorf("no instances found in bundle")
 	}
 
-	for _, instance := range bundle.Instances {
+	for index := len(bundle.Instances) - 1; index >= 0; index-- {
+		instance := bundle.Instances[index]
 		log.Info(fmt.Sprintf("deleting instance %s", instance.Name))
 		if err := deleteBundleInstance(ctx, instance, bundleDelArgs.wait, bundleDelArgs.dryrun); err != nil {
 			return err

--- a/cmd/timoni/list.go
+++ b/cmd/timoni/list.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"io"
+	"sort"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 
@@ -65,6 +66,11 @@ func runListCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// alphabetical sort by instance name
+	sort.Slice(instances, func(i, j int) bool {
+		return instances[i].Name < instances[j].Name
+	})
 
 	var rows [][]string
 	for _, inv := range instances {


### PR DESCRIPTION
When deleting a bundle, uninstall the instances in reverse order so that the first created instance is the last to be deleted. This ensures that bundles which contain an instance with a CRD controller and  other instances which deploy custom resources of that controller, can be deleted from the cluster. Timoni will delete the instances with CRs first, will wait for the objects to be finalized, and only after that will delete the controller and CRDs.
