### PR TITLE
Refactor `timoni bundle delete`

### DIFF
--- a/cmd/timoni/bundle_apply_test.go
+++ b/cmd/timoni/bundle_apply_test.go
@@ -228,7 +228,7 @@ bundle: {
 		g.Expect(output).To(ContainSubstring(anotherBundleName))
 
 		t.Cleanup(func() {
-			_, err = executeCommand(fmt.Sprintf("bundle delete --name %[1]s -n %[2]s", anotherBundleName, namespace))
+			_, err = executeCommand(fmt.Sprintf("bundle delete %s --wait", anotherBundleName))
 			g.Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/cmd/timoni/bundle_delete_test.go
+++ b/cmd/timoni/bundle_delete_test.go
@@ -88,32 +88,7 @@ bundle: {
 		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		output, err := executeCommandWithIn("bundle delete -f - --wait", strings.NewReader(bundleData))
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(output).To(ContainSubstring("frontend"))
-		g.Expect(output).To(ContainSubstring("backend"))
-
-		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
-		g.Expect(errors.IsNotFound(err)).To(BeTrue())
-	})
-
-	t.Run("deletes instances from named bundle", func(t *testing.T) {
-		g := NewWithT(t)
-
-		_, err := executeCommandWithIn("bundle apply -f - -p main --wait", strings.NewReader(bundleData))
-		g.Expect(err).ToNot(HaveOccurred())
-
-		clientCM := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "frontend-client",
-				Namespace: namespace,
-			},
-		}
-
-		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(clientCM), clientCM)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		output, err := executeCommand(fmt.Sprintf("bundle delete --name %[1]s --namespace %[2]s --wait", bundleName, namespace))
+		output, err := executeCommand(fmt.Sprintf("bundle delete %s --wait", bundleName))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(output).To(ContainSubstring("frontend"))
 		g.Expect(output).To(ContainSubstring("backend"))
@@ -193,7 +168,7 @@ bundle: {
 		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(serverCM), serverCM)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		output, err := executeCommand(fmt.Sprintf("bundle delete --name %[1]s --wait", bundleName))
+		output, err := executeCommand(fmt.Sprintf("bundle delete %s --wait", bundleName))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(output).To(ContainSubstring("frontend"))
 		g.Expect(output).To(ContainSubstring("backend"))

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -713,22 +713,25 @@ Timoni supports the following extensions: `.cue`, `.json`, `.yml`, `.yaml`.
 
 ### Uninstall
 
-To uninstall the instances defined in a Bundle file,
+To uninstall all the instances belonging to a Bundle,
 you can use the `timoni bundle delete` command.
 
-Example:
+Example using the bundle name:
+
+```shell
+timoni bundle delete my-bundle
+```
+
+Example using a bundle CUE file:
 
 ```shell
 timoni bundle delete -f bundle.cue
 ```
 
-Another option is to specify the Bundle name, and Timoni
-will search the cluster and delete all the instances having
-the `bundle.timoni.sh/name: <name>` label:
-
-```shell
-timoni bundle delete --name my-bundle
-```
+Timoni will search the cluster and delete all the instances having
+the `bundle.timoni.sh/name: <name>` label matching the given bundle name.
+The instances are uninstalled in reverse order,
+first created instance is last to be deleted.
 
 ### Garbage collection
 

--- a/internal/engine/utils.go
+++ b/internal/engine/utils.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,6 +104,30 @@ func ExtractValueFromBytes(ctx *cue.Context, data []byte, expr string) (cue.Valu
 	}
 
 	return value, nil
+}
+
+func ExtractStringFromFile(ctx *cue.Context, filePath, exprPath string) (string, error) {
+	vData, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	value := ctx.CompileBytes(vData)
+	if value.Err() != nil {
+		return "", fmt.Errorf("compiling CUE file failed: %w", value.Err())
+	}
+
+	expr := value.LookupPath(cue.ParsePath(exprPath))
+	if expr.Err() != nil {
+		return "", fmt.Errorf("lookup path failed: %w", expr.Err())
+	}
+
+	result, err := expr.String()
+	if expr.Err() != nil {
+		return "", fmt.Errorf("reading string failed: %w", expr.Err())
+	}
+
+	return result, nil
 }
 
 // MergeValue merges the given overlay on top of the base CUE value.


### PR DESCRIPTION
Simplify the delete command to `timoni bundle delete <name>` and deprecate the `--name` flag.

When deleting a bundle by referring to a file with `timoni bundle delete -f bundle.cue`, the name is extracted from the file without parsing the instances or any other fields.

Add allis to `timoni bundle uninstall`.

The `--namespace` flag is now ignored and the `-A` flag was removed (⚠️ breaking change).