### PR TITLE
Use tabular view for `timoni inspect resources`

### DIFF
--- a/cmd/timoni/inspect_resources.go
+++ b/cmd/timoni/inspect_resources.go
@@ -19,9 +19,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
-	"github.com/fluxcd/pkg/ssa"
 	"github.com/spf13/cobra"
+
 	"github.com/stefanprodan/timoni/internal/runtime"
 )
 
@@ -74,14 +75,35 @@ func runInspectResourcesCmd(cmd *cobra.Command, args []string) error {
 
 	iManager := runtime.InstanceManager{Instance: *inst}
 
-	metas, err := iManager.ListMeta()
+	//metas, err := iManager.ListMeta()
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//for _, meta := range metas {
+	//	fmt.Fprintln(cmd.OutOrStdout(), colorizeSubject(ssa.FmtObjMetadata(meta)))
+	//}
+
+	objects, err := iManager.ListObjects()
 	if err != nil {
 		return err
 	}
 
-	for _, meta := range metas {
-		fmt.Fprintln(cmd.OutOrStdout(), colorizeSubject(ssa.FmtObjMetadata(meta)))
+	var rows [][]string
+	for _, obj := range objects {
+		ns := "-"
+		if obj.GetNamespace() != "" {
+			ns = obj.GetNamespace()
+		}
+		row := []string{
+			strings.ToLower(obj.GetKind() + "/" + obj.GetName()),
+			ns,
+			obj.GetAPIVersion(),
+		}
+		rows = append(rows, row)
 	}
+
+	printTable(rootCmd.OutOrStdout(), []string{"name", "namespace", "API version"}, rows)
 
 	return nil
 }

--- a/cmd/timoni/inspect_test.go
+++ b/cmd/timoni/inspect_test.go
@@ -96,8 +96,8 @@ func TestInspect(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		// Verify inspect output contains the expected resources
-		g.Expect(output).To(ContainSubstring(fmt.Sprintf("ConfigMap/%s/%s-client", namespace, name)))
-		g.Expect(output).To(ContainSubstring(fmt.Sprintf("ConfigMap/%s/%s-server", namespace, name)))
+		g.Expect(output).To(ContainSubstring(fmt.Sprintf("configmap/%s-client", name)))
+		g.Expect(output).To(ContainSubstring(fmt.Sprintf("configmap/%s-server", name)))
 	})
 }
 


### PR DESCRIPTION
List the Kubernetes resources managed by a Timoni instance in a tabular view with `name`, `namespace` and `API version` columns.