### PR TITLE
Improve module validation and add `timoni mod vet` cmd 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Module examples can be found at [examples/minimal](examples/minimal) and [exampl
 Commands for working with local modules:
 
 - `timoni mod init <module-name>`
-- `timoni mod lint <path/to/module>`
+- `timoni mod vet <path/to/module>`
 - `timoni build <name> <path/to/module> -n <namespace>`
 - `timoni apply <name> <path/to/module> -f <path/to/values.cue> --dry-run --diff`
 
@@ -159,9 +159,10 @@ Commands for distributing bundles and runtimes:
 - `timoni artifact pull oci://<artifact-url> -o <path/to/dir>`
 - `timoni artifact list oci://<artifact-url>`
 
-To learn more about bundles, please see the documentation for [Bundle API](https://timoni.sh/bundle/)
-[Bundle Runtime API](https://timoni.sh/bundle-runtime/)
-and [Bundle distribution](https://timoni.sh/bundle-distribution/).
+To learn more about bundles, please see the documentation:
+- [Bundle API](https://timoni.sh/bundle/)
+- [Bundle Runtime API](https://timoni.sh/bundle-runtime/)
+- [Bundle distribution](https://timoni.sh/bundle-distribution/)
 
 ## Contributing
 

--- a/api/v1alpha1/instance.go
+++ b/api/v1alpha1/instance.go
@@ -22,11 +22,11 @@ const (
 	// APIVersionSelector is the CUE path for the Timoni's API version.
 	APIVersionSelector Selector = "timoni.apiVersion"
 
+	// InstanceSelector is the CUE path for the Timoni's instance.
+	InstanceSelector Selector = "timoni.instance"
+
 	// ApplySelector is the CUE path for the Timoni's apply resource sets.
 	ApplySelector Selector = "timoni.apply"
-
-	// ConfigValuesSelector is the CUE path for the Timoni's instance config values.
-	ConfigValuesSelector Selector = "timoni.instance.config"
 
 	// ValuesSelector is the CUE path for the Timoni's module values.
 	ValuesSelector Selector = "values"

--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -214,7 +214,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 
 	buildResult, err := builder.Build()
 	if err != nil {
-		return describeErr(fetcher.GetModuleRoot(), "failed to build instance", err)
+		return describeErr(fetcher.GetModuleRoot(), "build failed", err)
 	}
 
 	finalValues, err := builder.GetDefaultValues()

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -283,7 +283,7 @@ func applyBundleInstance(ctx context.Context, cuectx *cue.Context, instance *eng
 
 	buildResult, err := builder.Build()
 	if err != nil {
-		return describeErr(modDir, "failed to build instance", err)
+		return describeErr(modDir, "build failed for "+instance.Name, err)
 	}
 
 	finalValues, err := builder.GetDefaultValues()

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -204,7 +204,7 @@ func buildBundleInstance(cuectx *cue.Context, instance *engine.BundleInstance, r
 
 	buildResult, err := builder.Build()
 	if err != nil {
-		return "", describeErr(modDir, "failed to build instance", err)
+		return "", describeErr(modDir, "build failed for "+instance.Name, err)
 	}
 
 	bundleBuildSets, err := builder.GetApplySets(buildResult)

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -124,7 +124,7 @@ func resetCmdArgs() {
 	inspectModuleArgs = inspectModuleFlags{}
 	inspectResourcesArgs = inspectResourcesFlags{}
 	inspectValuesArgs = inspectValuesFlags{}
-	lintModArgs = lintModFlags{}
+	vetModArgs = vetModFlags{}
 	listArgs = listFlags{}
 	pullModArgs = pullModFlags{}
 	pushModArgs = pushModFlags{}

--- a/cmd/timoni/mod_vet_test.go
+++ b/cmd/timoni/mod_vet_test.go
@@ -23,27 +23,26 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestLint(t *testing.T) {
+func TestModVet(t *testing.T) {
 	modPath := "testdata/module"
 
-	t.Run("lints module with default values", func(t *testing.T) {
+	t.Run("vets module with default values", func(t *testing.T) {
 		g := NewWithT(t)
 		output, err := executeCommand(fmt.Sprintf(
-			"mod lint %s -p main",
+			"mod vet %s -p main",
 			modPath,
 		))
 		g.Expect(err).ToNot(HaveOccurred())
 
-		g.Expect(output).To(ContainSubstring("linted"))
+		g.Expect(output).To(ContainSubstring("valid"))
 	})
 
-	t.Run("fails to lint with undefined package", func(t *testing.T) {
+	t.Run("fails to vet with undefined package", func(t *testing.T) {
 		g := NewWithT(t)
-		output, err := executeCommand(fmt.Sprintf(
-			"mod lint %s -p test",
+		_, err := executeCommand(fmt.Sprintf(
+			"mod vet %s -p test",
 			modPath,
 		))
-		g.Expect(output).To(BeEmpty())
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("cannot find package"))
 	})

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Module structure:
 Commands for working with local modules:
 
 - `timoni mod init <module-name>`
-- `timoni mod lint <path/to/module>`
+- `timoni mod vet <path/to/module>`
 - `timoni build <name> <path/to/module> -n <namespace>`
 - `timoni apply <name> <path/to/module> -f <path/to/values.cue> --dry-run --diff`
 

--- a/docs/module.md
+++ b/docs/module.md
@@ -92,11 +92,11 @@ To enforce a minimum supported version for your module, set a constraint for the
 version e.g. `kubeMinorVersion: int & >=20`.
 
 To test the constraint, you can use the `TIMONI_KUBE_VERSION` env var
-with `timoni mod lint` and `timoni build`.
+with `timoni mod vet` and `timoni build`.
 
 ```console
-$ TIMONI_KUBE_VERSION=1.19.0 timoni mod lint ./myapp
-build failed: timoni.kubeMinorVersion: invalid value 19 (out of bound >=20)
+$ TIMONI_KUBE_VERSION=1.19.0 timoni mod vet ./myapp
+validation failed: timoni.kubeMinorVersion: invalid value 19 (out of bound >=20)
 ```
 
 ## Ignore

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,10 +77,10 @@ nav:
   - Command Reference:
       - Modules:
           - Init: cmd/timoni_mod_init.md
-          - Lint: cmd/timoni_mod_lint.md
           - Push: cmd/timoni_mod_push.md
           - Pull: cmd/timoni_mod_pull.md
           - List: cmd/timoni_mod_list.md
+          - Vet: cmd/timoni_mod_vet.md
           - Vendor Kubernetes APIs: cmd/timoni_mod_vendor_k8s.md
           - Vendor Kubernetes CRDs: cmd/timoni_mod_vendor_crd.md
       - Instances:


### PR DESCRIPTION
This PR adds the `timoni mod vet` command for validating the module file structure and the Kubernetes resources generated by the module's instance. 

The vetting of modules is also performed at build-time before apply actions.

Before:

```console
$ timoni mod lint .
10:57PM ERR failed to extract objects: timoni.apply.all.0.spec.url: cannot reference optional field: url (and 1 more errors)
```

After:

```console
$ timoni mod vet
10:58PM ERR validation failed:
timoni.instance.config.git.path: field is required but not present:
    ./templates/config.cue:19:3
    ./templates/config.cue:35:10
    ./timoni.cue:17:9
timoni.instance.config.git.url: field is required but not present:
    ./templates/config.cue:18:3
    ./templates/config.cue:35:10
    ./timoni.cue:17:9
timoni.instance.objects.gitrepository.spec.url: cannot reference optional field: url:
    ./templates/gitrepository.cue:13:25
timoni.instance.objects.kustomization.spec.path: cannot reference optional field: path:
    ./templates/kustomization.cue:18:30
```