### PR TITLE
Introduce `timoni bundle vet` command

### DIFF
--- a/cmd/timoni/bundle_vet.go
+++ b/cmd/timoni/bundle_vet.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"os"
 
+	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -131,11 +132,6 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 		return describeErr(tmpDir, "failed to build bundle", err)
 	}
 
-	if bundleVetArgs.printValue {
-		_, err := rootCmd.OutOrStdout().Write([]byte(fmt.Sprintf("%v\n", v)))
-		return err
-	}
-
 	bundle, err := bm.GetBundle(v)
 	if err != nil {
 		return err
@@ -144,6 +140,15 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 
 	if len(bundle.Instances) == 0 {
 		return fmt.Errorf("no instances found in bundle")
+	}
+
+	if bundleVetArgs.printValue {
+		val := v.LookupPath(cue.ParsePath("bundle"))
+		if val.Err() != nil {
+			return err
+		}
+		_, err := rootCmd.OutOrStdout().Write([]byte(fmt.Sprintf("bundle: %v\n", val)))
+		return err
 	}
 
 	for _, i := range bundle.Instances {

--- a/cmd/timoni/bundle_vet_test.go
+++ b/cmd/timoni/bundle_vet_test.go
@@ -198,3 +198,97 @@ bundle: {
 		})
 	}
 }
+
+func Test_BundleVet_PrintValue(t *testing.T) {
+	g := NewWithT(t)
+
+	bundleCue := `
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "podinfo"
+	_secrets: {
+		host:     string @timoni(runtime:string:TEST_BVET_HOST)
+		password: string @timoni(runtime:string:TEST_BVET_PASS)
+	}
+	instances: {
+		podinfo: {
+			module: url: "oci://ghcr.io/stefanprodan/modules/podinfo"
+			module: version: "latest"
+			namespace: "podinfo"
+			values: caching: {
+				enabled:  true
+				redisURL: "tcp://:\(_secrets.password)@\(_secrets.host):6379"
+			}
+		}
+	}
+}
+`
+	bundleYaml := `
+bundle:
+  instances:
+    podinfo:
+      values:
+        monitoring:
+          enabled: true
+`
+	bundleJson := `
+{
+  "bundle": {
+    "instances": {
+      "podinfo": {
+        "values": {
+          "autoscaling": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  }
+}
+`
+	bundleComputed := `bundle: {
+	apiVersion: "v1alpha1"
+	name:       "podinfo"
+	instances: {
+		podinfo: {
+			module: {
+				url:     "oci://ghcr.io/stefanprodan/modules/podinfo"
+				version: "latest"
+			}
+			namespace: "podinfo"
+			values: {
+				caching: {
+					enabled:  true
+					redisURL: "tcp://:password@test.host:6379"
+				}
+				monitoring: {
+					enabled: true
+				}
+				autoscaling: {
+					enabled: true
+				}
+			}
+		}
+	}
+}
+`
+	wd := t.TempDir()
+	cuePath := filepath.Join(wd, "bundle.cue")
+	g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
+
+	yamlPath := filepath.Join(wd, "bundle.yaml")
+	g.Expect(os.WriteFile(yamlPath, []byte(bundleYaml), 0644)).ToNot(HaveOccurred())
+
+	jsonPath := filepath.Join(wd, "bundle.json")
+	g.Expect(os.WriteFile(jsonPath, []byte(bundleJson), 0644)).ToNot(HaveOccurred())
+
+	t.Setenv("TEST_BVET_HOST", "test.host")
+	t.Setenv("TEST_BVET_PASS", "password")
+
+	output, err := executeCommand(fmt.Sprintf(
+		"bundle vet -f %s -f %s -f %s -p main --runtime-from-env --print-value",
+		cuePath, yamlPath, jsonPath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(BeEquivalentTo(bundleComputed))
+}

--- a/cmd/timoni/bundle_vet_test.go
+++ b/cmd/timoni/bundle_vet_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func Test_BundleLint(t *testing.T) {
+func Test_BundleVet(t *testing.T) {
 
 	tests := []struct {
 		name     string
@@ -189,7 +189,7 @@ bundle: {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			_, err = executeCommand(fmt.Sprintf(
-				"bundle lint -f %s --runtime-from-env",
+				"bundle vet -f %s --runtime-from-env",
 				bundlePath,
 			))
 

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -129,7 +129,7 @@ func resetCmdArgs() {
 	pullModArgs = pullModFlags{}
 	pushModArgs = pushModFlags{}
 	bundleApplyArgs = bundleApplyFlags{}
-	bundleLintArgs = bundleLintFlags{}
+	bundleVetArgs = bundleVetFlags{}
 	bundleDelArgs = bundleDelFlags{}
 	bundleBuildArgs = bundleBuildFlags{}
 	vendorCrdArgs = vendorCrdFlags{}

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -497,16 +497,28 @@ the apply command will exit with an error.
 
 The readiness check is enabled by default, to opt-out set `--wait=false`.
 
-### Lint
+### Vetting
 
 To verify that one or more CUE files contain a valid Bundle definition,
-you can use the `timoni bundle lint` command.
+you can use the `timoni bundle vet` command.
 
 Example:
 
 ```shell
-timoni bundle lint -f bundle.cue -f extras.cue
+timoni bundle vet -f bundle.cue -f extras.cue
 ```
+
+If the validation passes, Timoni will list all the instances found in the computed bundle.
+
+When `--print-value` is specified, Timoni will write the Bundle computed value to stdout.
+
+Example:
+
+```shell
+timoni bundle vet -f bundle.cue --runtime-from-env --print-value
+```
+
+Printing the computed value is particular useful when debugging runtime attributes.
 
 ### Format
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -145,10 +145,10 @@ string interpolation and everything else that CUE std lib supports.
 
 Commands for working with bundles:
 
-- `timoni bundle lint -f bundle.cue`
-- `timoni bundle build -f bundle.cue -f bundle_extras.cue`
 - `timoni bundle apply -f bundle.cue --runtime runtime.cue --diff`
+- `timoni bundle build -f bundle.cue -f bundle_extras.cue`
 - `timoni bundle delete -f bundle.cue`
+- `timoni bundle vet -f bundle.cue`
 
 To learn more about bundles, please see the [Bundle API documentation](bundle.md)
 and the [Bundle Runtime API documentation](bundle-runtime.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,8 +130,8 @@ nav:
           - cmd/timoni_bundle_apply.md
           - cmd/timoni_bundle_build.md
           - cmd/timoni_bundle_delete.md
-          - cmd/timoni_bundle_lint.md
           - cmd/timoni_bundle_status.md
+          - cmd/timoni_bundle_vet.md
       - Runtime:
           - cmd/timoni_runtime.md
           - cmd/timoni_runtime_build.md


### PR DESCRIPTION
The `timoni bundle vet` command validates that a bundle and its runtime definition conforms with Timoni's schema.


To verify that one or more CUE files contain a valid Bundle definition:

```shell
timoni bundle vet -f bundle.cue -f extras.cue -r runtime.cue
```

If the validation passes, Timoni will list all the instances found in the computed bundle.

When `--print-value` is specified, Timoni will write the Bundle computed value to stdout:

```shell
timoni bundle vet -f bundle.cue --runtime-from-env --print-value
```

Printing the computed value is particular useful when debugging runtime attributes.