### PR TITLE
Implement caching for modules pulled from registries

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -167,6 +167,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 		applyArgs.module,
 		version,
 		tmpDir,
+		rootArgs.cacheDir,
 		applyArgs.creds.String(),
 	)
 	mod, err := fetcher.Fetch()

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -118,6 +118,7 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 		buildArgs.module,
 		version,
 		tmpDir,
+		rootArgs.cacheDir,
 		buildArgs.creds.String(),
 	)
 	mod, err := fetcher.Fetch()

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -234,6 +234,7 @@ func fetchBundleInstanceModule(ctx context.Context, instance *engine.BundleInsta
 		instance.Module.Repository,
 		moduleVersion,
 		modDir,
+		rootArgs.cacheDir,
 		bundleApplyArgs.creds.String(),
 	)
 	mod, err := fetcher.Fetch()

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -75,6 +75,7 @@ func TestMain(m *testing.M) {
 	}
 
 	kubeconfigArgs.KubeConfig = &tmpFilename
+	rootArgs.cacheDir = tmpDir
 
 	code := m.Run()
 	testEnv.Stop()

--- a/cmd/timoni/mod_vet.go
+++ b/cmd/timoni/mod_vet.go
@@ -92,6 +92,7 @@ func runVetModCmd(cmd *cobra.Command, args []string) error {
 		vetModArgs.path,
 		apiv1.LatestVersion,
 		tmpDir,
+		rootArgs.cacheDir,
 		"",
 	)
 	mod, err := fetcher.Fetch()

--- a/internal/engine/fetcher.go
+++ b/internal/engine/fetcher.go
@@ -30,21 +30,23 @@ import (
 
 // Fetcher downloads a module and extracts it locally.
 type Fetcher struct {
-	ctx     context.Context
-	src     string
-	dst     string
-	version string
-	creds   string
+	ctx      context.Context
+	src      string
+	dst      string
+	cacheDir string
+	version  string
+	creds    string
 }
 
 // NewFetcher creates a Fetcher for the given module.
-func NewFetcher(ctx context.Context, src, version, dst, creds string) *Fetcher {
+func NewFetcher(ctx context.Context, src, version, dst, cacheDir, creds string) *Fetcher {
 	return &Fetcher{
-		ctx:     ctx,
-		src:     src,
-		dst:     dst,
-		version: version,
-		creds:   creds,
+		ctx:      ctx,
+		src:      src,
+		dst:      dst,
+		version:  version,
+		cacheDir: cacheDir,
+		creds:    creds,
 	}
 }
 
@@ -103,5 +105,5 @@ func (f *Fetcher) fetchRemoteModule(dstDir string) (*apiv1.ModuleReference, erro
 	}
 
 	opts := oci.Options(f.ctx, f.creds)
-	return oci.PullModule(ociURL, dstDir, opts)
+	return oci.PullModule(ociURL, dstDir, f.cacheDir, opts)
 }

--- a/internal/oci/module_test.go
+++ b/internal/oci/module_test.go
@@ -19,6 +19,7 @@ package oci
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -90,7 +91,8 @@ func TestModuleOperations(t *testing.T) {
 	}
 
 	dstPath := filepath.Join(tmpDir, "artifact")
-	modRef, err := PullModule(digestURL, dstPath, opts)
+	cacheDir := t.TempDir()
+	modRef, err := PullModule(digestURL, dstPath, cacheDir, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(modRef.Version).To(BeEquivalentTo(imgVersion))
 	g.Expect(filepath.Join(dstPath, "timoni.ignore")).ToNot(BeAnExistingFile())
@@ -106,4 +108,7 @@ func TestModuleOperations(t *testing.T) {
 	} {
 		g.Expect(filepath.Join(dstPath, entry)).To(Or(BeAnExistingFile(), BeADirectory()))
 	}
+	cachedLayers, err := os.ReadDir(cacheDir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(len(cachedLayers)).To(BeEquivalentTo(2))
 }


### PR DESCRIPTION
This PR introduces local caching for module layers based on OCI digests. Cashing is meant to reduce network traffic for sequential pull operations and will speed up applying bundles which refer to modules with identical layers.

CLI changes:
- Add `--cache-dir` global flag with the default location set to `$HOME/.timoni/cache`
- Allow disabling caching with `TIMONI_CACHING=false` env var