### PR TITLE
Create output dir instead of returning error for OCI artifacts

### DIFF
--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -108,7 +108,7 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	log := LoggerFrom(cmd.Context())
 
 	if err := os.MkdirAll(pullArtifactArgs.output, os.ModePerm); err != nil {
-		return fmt.Errorf("invalid output path %s: %s", pullArtifactArgs.output, err)
+		return fmt.Errorf("invalid output path %s: %w", pullArtifactArgs.output, err)
 	}
 
 	if pullArtifactArgs.verify != "" {

--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -107,8 +107,8 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	log := LoggerFrom(cmd.Context())
 
-	if fs, err := os.Stat(pullArtifactArgs.output); err != nil || !fs.IsDir() {
-		return fmt.Errorf("invalid output path %s", pullArtifactArgs.output)
+	if err := os.MkdirAll(pullArtifactArgs.output, os.ModePerm); err != nil {
+		return fmt.Errorf("invalid output path %s: %s", pullArtifactArgs.output, err)
 	}
 
 	if pullArtifactArgs.verify != "" {

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -118,7 +118,7 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := os.MkdirAll(pullModArgs.output, os.ModePerm); err != nil {
-		return fmt.Errorf("invalid output path %s", pullModArgs.output)
+		return fmt.Errorf("invalid output path %s: %s", pullModArgs.output, err)
 	}
 
 	log := LoggerFrom(cmd.Context())

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -118,7 +118,7 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := os.MkdirAll(pullModArgs.output, os.ModePerm); err != nil {
-		return fmt.Errorf("invalid output path %s: %s", pullModArgs.output, err)
+		return fmt.Errorf("invalid output path %s: %w", pullModArgs.output, err)
 	}
 
 	log := LoggerFrom(cmd.Context())

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -117,7 +117,7 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid output path %s", pullModArgs.output)
 	}
 
-	if fs, err := os.Stat(pullModArgs.output); err != nil || !fs.IsDir() {
+	if err := os.MkdirAll(pullModArgs.output, os.ModePerm); err != nil {
 		return fmt.Errorf("invalid output path %s", pullModArgs.output)
 	}
 


### PR DESCRIPTION
When a user wants to pull an OCI artifact, and they provide a location as the output, they more than likely want the output to be created if it doesn't exist. 
CMD modified:
* `mod pull`
* `artifact pull`

Instead of checking for its existence, it's better to attempt to create it. 
* If it exists, nothing will happen
* if it's a file, you'll get an error
* if it doesn't exist, it will be created

The above allows for a smoother UX, instead of getting a generic error: 
```
$ timoni mod pull oci://ghcr.io/stefanprodan/modules/redis --version 7.2.2 --output ./redis-oci 
12:48PM ERR invalid output path ./redis-oci
```

After the fix:
```
$ timoni mod pull oci://ghcr.io/stefanprodan/modules/redis --version 7.2.2 --output ./redis-oci
1:32PM INF extracted: ./redis-oci
```
Test with existing file:
```
$ touch redis-oci
$ timoni mod pull oci://ghcr.io/stefanprodan/modules/redis --version 7.2.2 --output ./redis-oci
1:32PM ERR error creating path ./redis-oci: mkdir ./redis-oci: not a directory
```