### PR TITLE
Improve Timoni's CUE `#Metadata` schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,13 @@ tidy: ## Tidy Go modules.
 fmt: ## Format Go code.
 	go fmt ./...
 
+cue-fmt: ## Format CUE schemas.
+	cue fmt ./schemas/...
+
 vet: ## Vet Go code.
 	go vet ./...
 
-lint-samples: build
+lint-samples: build cue-fmt ## Lint the CUE samples.
 	./bin/timoni mod lint ./examples/minimal
 	./bin/timoni mod lint ./examples/redis
 	./bin/timoni mod lint ./cmd/timoni/testdata/module

--- a/schemas/timoni.sh/core/v1alpha1/metadata.cue
+++ b/schemas/timoni.sh/core/v1alpha1/metadata.cue
@@ -5,6 +5,19 @@ package v1alpha1
 
 import "strings"
 
+// Annotations defines the schema for Kubernetes object metadata annotations.
+#Annotations: {[string & =~"^(([A-Za-z0-9][-A-Za-z0-9_./]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)]: string}
+
+// Labels defines the schema for Kubernetes object metadata labels.
+#Labels: {[string & =~"^(([A-Za-z0-9][-A-Za-z0-9_./]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)]: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)}
+
+#StdLabelName:      "app.kubernetes.io/name"
+#StdLabelVersion:   "app.kubernetes.io/version"
+#StdLabelPartOf:    "app.kubernetes.io/part-of"
+#StdLabelManagedBy: "app.kubernetes.io/managed-by"
+#StdLabelComponent: "app.kubernetes.io/component"
+#StdLabelInstance:  "app.kubernetes.io/instance"
+
 // Metadata defines the schema for Kubernetes object metadata.
 #Metadata: {
 	// Version should be in the strict semver format. Is required when creating resources.
@@ -22,15 +35,15 @@ import "strings"
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set to store and retrieve arbitrary metadata.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
-	annotations?: {[string & =~"^(([A-Za-z0-9][-A-Za-z0-9_./]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)]: string}
+	annotations?: #Annotations
 
 	// Map of string keys and values that can be used to organize and categorize (scope and select) objects.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-	labels: {[string & =~"^(([A-Za-z0-9][-A-Za-z0-9_./]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)]: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)}
+	labels: #Labels
 
-	// Standard Kubernetes labels: app name and version.
+	// Standard Kubernetes labels: app name, version and managed-by.
 	labels: {
-		"app.kubernetes.io/name":    name
-		"app.kubernetes.io/version": #Version
+		"\(#StdLabelName)":      name
+		"\(#StdLabelVersion)":   #Version
 	}
 }

--- a/schemas/timoni.sh/core/v1alpha1/metadata.cue
+++ b/schemas/timoni.sh/core/v1alpha1/metadata.cue
@@ -45,5 +45,6 @@ import "strings"
 	labels: {
 		"\(#StdLabelName)":      name
 		"\(#StdLabelVersion)":   #Version
+		"\(#StdLabelManagedBy)": "Timoni"
 	}
 }

--- a/schemas/timoni.sh/core/v1alpha1/selector.cue
+++ b/schemas/timoni.sh/core/v1alpha1/selector.cue
@@ -14,8 +14,8 @@ import "strings"
 
 	// Map of string keys and values that can be used to organize and categorize (scope and select) objects.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-	labels: {[string & =~"^(([A-Za-z0-9][-A-Za-z0-9_./]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)]: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63)}
+	labels: #Labels
 
 	// Standard Kubernetes label: app name.
-	labels: "app.kubernetes.io/name": #Name
+	labels: "\(#StdLabelName)": #Name
 }


### PR DESCRIPTION
This PR comes with improvements to Timoni's CUE `#Metadata` helpers:
- Add `#Annotations` and `#Labels` schemas
- Add all the standard `app.kubernetes.io` labels
- Set the `app.kubernetes.io/managed-by: Timoni` label by default
