### PR TITLE
Add semver validation to Timoni's CUE schemas

### DIFF
--- a/schemas/timoni.sh/core/v1alpha1/semver.cue
+++ b/schemas/timoni.sh/core/v1alpha1/semver.cue
@@ -1,0 +1,29 @@
+// Copyright 2023 Stefan Prodan
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"strconv"
+	"strings"
+)
+
+// SemVer validates the input version string and extracts the major and minor version numbers.
+// When Minimum is set, the major and minor parts must be greater or equal to the minimum
+// or a validation error is returned.
+#SemVer: {
+	// Input version string in strict semver format.
+	#Version!: string & =~"^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+	// Minimum is the minimum allowed MAJOR.MINOR version.
+	#Minimum: *"0.0.0" | string & =~"^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+	let minMajor = strconv.Atoi(strings.Split(#Minimum, ".")[0])
+	let minMinor = strconv.Atoi(strings.Split(#Minimum, ".")[1])
+
+	major: int & >=minMajor
+	major: strconv.Atoi(strings.Split(#Version, ".")[0])
+
+	minor: int & >=minMinor
+	minor: strconv.Atoi(strings.Split(#Version, ".")[1])
+}


### PR DESCRIPTION
Add semver helper to Timoni's CUE schemas for enforcing a minimum Kubernetes minor version, e.g.:

```
clusterVersion: timoniv1.#SemVer{#Version: kubeVersion, #Minimum: "1.20.0"}
```  

The above will fail on Kubernetes 1.18.0 with `clusterVersion.minor: invalid value 18 (out of bound >=20)`.

On Kubernetes 1.28.4 the `clusterVersion` will output:
```
major:    1
minor:    28
```