### PR TITLE
Add `#MatchLabelsComponent` generator to Timoni's CUE schemas

### DIFF
--- a/schemas/timoni.sh/core/v1alpha1/selector.cue
+++ b/schemas/timoni.sh/core/v1alpha1/selector.cue
@@ -3,6 +3,8 @@
 
 package v1alpha1
 
+import "strings"
+
 // Selector defines the schema for Kubernetes Pod label selector used in Deployments, Services, Jobs, etc.
 #Selector: {
 	// Name must be unique within a namespace. Is required when creating resources.
@@ -16,4 +18,25 @@ package v1alpha1
 
 	// Standard Kubernetes label: app name.
 	labels: "\(#StdLabelName)": #Name
+}
+
+// MatchLabelsComponent generates the Kubernetes Selector object for use in resources that manage Pods
+#MatchLabelsComponent: {
+	// Map of string keys and values that can be used to organize and categorize (scope and select) objects.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+	#SelectorLabels!: #Labels
+
+	// Component is the name of the component used
+	// as a suffix for the generated object name.
+	#Component!: string & strings.MaxRunes(30)
+
+	// Map of string keys and values that can be used to organize and categorize (scope and select) objects.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+	matchLabels: #Labels
+
+	// Add the labels supplied by the generated Selector
+	matchLabels: #SelectorLabels
+
+	// Add the standard component label
+	matchLabels: "\(#stdLabelComponent)": #Component
 }

--- a/schemas/timoni.sh/core/v1alpha1/selector.cue
+++ b/schemas/timoni.sh/core/v1alpha1/selector.cue
@@ -38,5 +38,5 @@ import "strings"
 	matchLabels: #SelectorLabels
 
 	// Add the standard component label
-	matchLabels: "\(#stdLabelComponent)": #Component
+	matchLabels: "\(#StdLabelComponent)": #Component
 }


### PR DESCRIPTION
This PR adds a generator for Kubernetes object selectors that will inject the `app.kubernetes.io/component` label to the selector. The example below makes use of the `#MetaComponent` introduce in #270.

Example:

```cue
#Deployment: appsv1.#Deployment & {
        _config:    #Config
        _component: "test"

        apiVersion: "apps/v1"
        kind:       "Deployment"

        _metadata: timoniv1.#MetaComponent & {
                #Meta:      _config.metadata
                #Component: _component
        }

        metadata: _metadata

        spec: appsv1.#DeploymentSpec & {
                replicas: _config.replicaCount
                selector: timoniv1.#MatchLabelsComponent & {
                        #SelectorLabels: _config.selector.labels
                        #Component:      _component
                }

                template: {
                        metadata: labels: _metadata.labels

                        if _metadata.annotations != _|_ {
                                metadata: annotations: _metadata.annotations
                        }
                }
        }
}
```