### PR TITLE
Add `--name` flag to `timoni mod vet` command

### DIFF
--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 	"time"
 
@@ -93,16 +92,6 @@ func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
 		return "", err
 	}
 
-	if args[0] == "mod" && args[1] == "vet" {
-		if !slices.Contains(args, "--name") {
-			args = append(args, []string{"--name", "default"}...)
-		}
-
-		if !slices.Contains(args, "--namespace") {
-			args = append(args, []string{"--namespace", "default"}...)
-		}
-	}
-
 	buf := new(bytes.Buffer)
 
 	rootCmd.SetOut(buf)
@@ -135,7 +124,9 @@ func resetCmdArgs() {
 	inspectModuleArgs = inspectModuleFlags{}
 	inspectResourcesArgs = inspectResourcesFlags{}
 	inspectValuesArgs = inspectValuesFlags{}
-	vetModArgs = vetModFlags{}
+	vetModArgs = vetModFlags{
+		name: "default",
+	}
 	listArgs = listFlags{}
 	pullModArgs = pullModFlags{}
 	pushModArgs = pushModFlags{}

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -90,6 +91,16 @@ func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
 	args, err := shellwords.Parse(cmd)
 	if err != nil {
 		return "", err
+	}
+
+	if args[0] == "mod" && args[1] == "vet" {
+		if !slices.Contains(args, "--name") {
+			args = append(args, []string{"--name", "default"}...)
+		}
+
+		if !slices.Contains(args, "--namespace") {
+			args = append(args, []string{"--namespace", "default"}...)
+		}
 	}
 
 	buf := new(bytes.Buffer)

--- a/cmd/timoni/mod_vet.go
+++ b/cmd/timoni/mod_vet.go
@@ -53,11 +53,13 @@ type vetModFlags struct {
 	path  string
 	pkg   flags.Package
 	debug bool
+	name  string
 }
 
 var vetModArgs vetModFlags
 
 func init() {
+	vetModCmd.Flags().StringVar(&vetModArgs.name, "name", "default", "Vet the module using the name provided")
 	vetModCmd.Flags().VarP(&vetModArgs.pkg, vetModArgs.pkg.Type(), vetModArgs.pkg.Shorthand(), vetModArgs.pkg.Description())
 	vetModCmd.Flags().BoolVar(&vetModArgs.debug, "debug", false,
 		"Use debug_values.cue if found in the module root instead of the default values.")
@@ -118,7 +120,7 @@ func runVetModCmd(cmd *cobra.Command, args []string) error {
 
 	builder := engine.NewModuleBuilder(
 		cuectx,
-		"default",
+		vetModArgs.name,
 		*kubeconfigArgs.Namespace,
 		fetcher.GetModuleRoot(),
 		vetModArgs.pkg.String(),

--- a/cmd/timoni/mod_vet.go
+++ b/cmd/timoni/mod_vet.go
@@ -59,7 +59,7 @@ type vetModFlags struct {
 var vetModArgs vetModFlags
 
 func init() {
-	vetModCmd.Flags().StringVar(&vetModArgs.name, "name", "default", "Vet the module using the name provided")
+	vetModCmd.Flags().StringVar(&vetModArgs.name, "name", "default", "Name of the instance used to build the module")
 	vetModCmd.Flags().VarP(&vetModArgs.pkg, vetModArgs.pkg.Type(), vetModArgs.pkg.Shorthand(), vetModArgs.pkg.Description())
 	vetModCmd.Flags().BoolVar(&vetModArgs.debug, "debug", false,
 		"Use debug_values.cue if found in the module root instead of the default values.")

--- a/cmd/timoni/mod_vet_test.go
+++ b/cmd/timoni/mod_vet_test.go
@@ -48,3 +48,30 @@ func TestModVet(t *testing.T) {
 		g.Expect(err.Error()).To(ContainSubstring("cannot find package"))
 	})
 }
+
+func TestModVetSetName(t *testing.T) {
+	modPath := "testdata/module"
+
+	t.Run("vets module with default values", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"mod vet %s -p main --name my-mod",
+			modPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(output).To(ContainSubstring("timoni:latest-dev@sha256:"))
+		g.Expect(output).To(ContainSubstring("timoni.sh/test valid"))
+		g.Expect(output).To(ContainSubstring("my-mod"))
+	})
+
+	t.Run("fails to vet with undefined package", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"mod vet %s -p test --name my-mod",
+			modPath,
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("cannot find package"))
+	})
+}

--- a/cmd/timoni/mod_vet_test.go
+++ b/cmd/timoni/mod_vet_test.go
@@ -36,6 +36,7 @@ func TestModVet(t *testing.T) {
 
 		g.Expect(output).To(ContainSubstring("timoni:latest-dev@sha256:"))
 		g.Expect(output).To(ContainSubstring("timoni.sh/test valid"))
+		g.Expect(output).To(ContainSubstring("default/default"))
 	})
 
 	t.Run("fails to vet with undefined package", func(t *testing.T) {
@@ -62,13 +63,67 @@ func TestModVetSetName(t *testing.T) {
 
 		g.Expect(output).To(ContainSubstring("timoni:latest-dev@sha256:"))
 		g.Expect(output).To(ContainSubstring("timoni.sh/test valid"))
-		g.Expect(output).To(ContainSubstring("my-mod"))
+		g.Expect(output).To(ContainSubstring("default/my-mod"))
 	})
 
 	t.Run("fails to vet with undefined package", func(t *testing.T) {
 		g := NewWithT(t)
 		_, err := executeCommand(fmt.Sprintf(
 			"mod vet %s -p test --name my-mod",
+			modPath,
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("cannot find package"))
+	})
+}
+
+func TestModVetSetNamespace(t *testing.T) {
+	modPath := "testdata/module"
+
+	t.Run("vets module with default values", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"mod vet %s -p main --namespace my-mod",
+			modPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(output).To(ContainSubstring("timoni:latest-dev@sha256:"))
+		g.Expect(output).To(ContainSubstring("timoni.sh/test valid"))
+		g.Expect(output).To(ContainSubstring("my-mod/default"))
+	})
+
+	t.Run("fails to vet with undefined package", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"mod vet %s -p test --namespace my-mod",
+			modPath,
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("cannot find package"))
+	})
+}
+
+func TestModVetSetNamespaceName(t *testing.T) {
+	modPath := "testdata/module"
+
+	t.Run("vets module with default values", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"mod vet %s -p main --namespace my-mod --name my-mod",
+			modPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(output).To(ContainSubstring("timoni:latest-dev@sha256:"))
+		g.Expect(output).To(ContainSubstring("timoni.sh/test valid"))
+		g.Expect(output).To(ContainSubstring("my-mod/my-mod"))
+	})
+
+	t.Run("fails to vet with undefined package", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"mod vet %s -p test --namespace my-mod --name my-mod",
 			modPath,
 		))
 		g.Expect(err).To(HaveOccurred())

--- a/cmd/timoni/mod_vet_test.go
+++ b/cmd/timoni/mod_vet_test.go
@@ -36,7 +36,7 @@ func TestModVet(t *testing.T) {
 
 		g.Expect(output).To(ContainSubstring("timoni:latest-dev@sha256:"))
 		g.Expect(output).To(ContainSubstring("timoni.sh/test valid"))
-		g.Expect(output).To(ContainSubstring("default/default"))
+		g.Expect(output).To(ContainSubstring("/default"))
 	})
 
 	t.Run("fails to vet with undefined package", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestModVetSetName(t *testing.T) {
 
 		g.Expect(output).To(ContainSubstring("timoni:latest-dev@sha256:"))
 		g.Expect(output).To(ContainSubstring("timoni.sh/test valid"))
-		g.Expect(output).To(ContainSubstring("default/my-mod"))
+		g.Expect(output).To(ContainSubstring("/my-mod"))
 	})
 
 	t.Run("fails to vet with undefined package", func(t *testing.T) {


### PR DESCRIPTION
Running `timoni mod vet --name cert-manager --namespace cert-manager` will result in the the following output where the module name is `cert-manager` instead of `default`.

```
9:49AM INF vetting with default values
9:49AM INF Namespace/cert-manager valid resource
9:49AM INF Deployment/cert-manager/cert-manager-controller valid resource
9:49AM INF Deployment/cert-manager/cert-manager-webhook valid resource
9:49AM INF quay.io/jetstack/cert-manager-acmesolver:v1.13.2@sha256:7057fd605f530ab2198ebdf1cb486818cce20682632be37c90522a09b95271b1 valid image
9:49AM INF quay.io/jetstack/cert-manager-cainjector:v1.13.2@sha256:858fee0c4af069d0e87c08fd0943f0091434e05f945d222875fc1f3d36c41616 valid image
9:49AM INF quay.io/jetstack/cert-manager-controller:v1.13.2@sha256:9c67cf8c92d8693f9b726bec79c2a84d2cebeb217af6947355601dec4acfa966 valid image
9:49AM INF quay.io/jetstack/cert-manager-ctl:v1.13.2@sha256:4d9fce2c050eaadabedac997d9bd4a003341e9172c3f48fae299d94fa5f03435 valid image
9:49AM INF quay.io/jetstack/cert-manager-webhook:v1.13.2@sha256:0a9470447ebf1d3ff1c172e19268be12dc26125ff83320d456f6826c677c0ed2 valid image
9:49AM INF timoni.sh/cert-manager valid module
```

Closes #269 