### PR TITLE
Fix `x-kubernetes-preserve-unknown-fields` path mismatch

### DIFF
--- a/internal/engine/importer.go
+++ b/internal/engine/importer.go
@@ -252,7 +252,8 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 		// all the way to the file root
 		err = walkfn(defpath.Selectors(), rootosch)
 
-		// First pass of astutil.Apply to remove ellipses for fields not marked with x-kubernetes-embedded-resource: true
+		// First pass of astutil.Apply to remove ellipses for fields not marked with
+		// 'x-kubernetes-preserve-unknown-fields: true'.
 		// Note that this implementation is only correct for CUE inputs that do not contain references.
 		// It is safe to use in this context because CRDs already have that invariant.
 		var stack []ast.Node
@@ -278,6 +279,7 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 				}
 				stack = append(stack[:i], pc.Node())
 				pathstack = append(pathstack[:i], psel)
+
 				if !preserve[cue.MakePath(pathstack...).String()] {
 					newlist := make([]ast.Decl, 0, len(x.Elts))
 					for _, elt := range x.Elts {
@@ -366,7 +368,7 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 //   - *ast.ListLit (index is the path)
 //   - *ast.Field (label is the path)
 //
-// If the there exceptions for the above two items, or the list should properly
+// If there are exceptions for the above two items, or the list should properly
 // have more items, this func will be buggy
 func parentPath(c astutil.Cursor) (cue.Selector, astutil.Cursor) {
 	p, prior := c.Parent(), c

--- a/internal/engine/importer_test.go
+++ b/internal/engine/importer_test.go
@@ -334,7 +334,9 @@ func TestConvertCRD(t *testing.T) {
 	spec?: {
 		template?: {
 			// Preserve unknown fields.
-			values?: {}
+			values?: {
+				...
+			}
 		}
 	}
 }`,

--- a/internal/engine/importer_test.go
+++ b/internal/engine/importer_test.go
@@ -295,6 +295,50 @@ func TestConvertCRD(t *testing.T) {
 	...
 }`,
 		},
+		{
+			name: "array-xk-preserve",
+			spec: `type: "object"
+			properties: {
+				resources: {
+					properties: claims: {
+						items: {
+							properties: name: type: "string"
+							required: ["name"]
+							type: "object"
+						}
+						type: "array"
+						"x-kubernetes-list-map-keys": ["name"]
+						"x-kubernetes-list-type": "map"
+					}
+					type: "object"
+				}
+				spec: {
+					properties: template: {
+						properties: values: {
+							description:                            "Preserve unknown fields."
+							type:                                   "object"
+							"x-kubernetes-preserve-unknown-fields": true
+						}
+						type: "object"
+					}
+					type: "object"
+				}
+			}
+			`,
+			expect: `{
+	resources?: {
+		claims?: [...{
+			name: string
+		}]
+	}
+	spec?: {
+		template?: {
+			// Preserve unknown fields.
+			values?: {}
+		}
+	}
+}`,
+		},
 	}
 
 	for _, item := range table {
@@ -314,6 +358,9 @@ func TestConvertCRD(t *testing.T) {
 			// remove the _#def injected by CUE's syntax formatter
 			fn, err := format.Node(specNode.(*ast.StructLit).Elts[1].(*ast.Field).Value)
 			g.Expect(err).ToNot(HaveOccurred())
+
+			t.Log(string(fn))
+
 			diff := cmp.Diff(tt.expect, string(fn), multiline)
 			if diff != "" {
 				t.Fatal(diff)


### PR DESCRIPTION
For CRDs with arrays the `parentPath` function doesn't walk back to the spec, as a workaround, to not miss `x-kubernetes-preserve-unknown-fields` we do partial matching which could open more fields than desired if the field names overlap. 

Fix: #278 