### PR TITLE
Add `timoni artifact tag` command

### DIFF
--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -78,7 +78,7 @@ func init() {
 		"Path to local file or directory.")
 	pushArtifactCmd.Flags().Var(&pushArtifactArgs.creds, pushArtifactArgs.creds.Type(), pushArtifactArgs.creds.Description())
 	pushArtifactCmd.Flags().StringArrayVarP(&pushArtifactArgs.tags, "tag", "t", nil,
-		"TagArtifact of the artifact.")
+		"Tag of the artifact.")
 	pushArtifactCmd.Flags().StringArrayVarP(&pushArtifactArgs.annotations, "annotation", "a", nil,
 		"Annotation in the format '<key>=<value>'.")
 	pushArtifactCmd.Flags().StringVar(&pushArtifactArgs.contentType, "content-type", "generic",

--- a/cmd/timoni/artifact_tag.go
+++ b/cmd/timoni/artifact_tag.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stefanprodan/timoni/internal/flags"
+	"github.com/stefanprodan/timoni/internal/oci"
+)
+
+var tagArtifactCmd = &cobra.Command{
+	Use:   "tag [ARTIFACT URL]",
+	Short: "Tag an OCI artifact in the upstream registry",
+	Long:  `The tag command allows adding tags to an existing artifact.`,
+	Example: `  # Tag an existing artifact with a new tags
+  echo $DOCKER_PAT | docker login --username timoni --password-stdin
+  timoni artifact tag oci://docker.io/org/app:1.0.0 -t 1.0 -t latest
+`,
+	RunE: tagArtifactCmdRun,
+}
+
+type tagArtifactFlags struct {
+	creds flags.Credentials
+	tags  []string
+}
+
+var tagArtifactArgs tagArtifactFlags
+
+func init() {
+	tagArtifactCmd.Flags().Var(&tagArtifactArgs.creds, tagArtifactArgs.creds.Type(), tagArtifactArgs.creds.Description())
+	tagArtifactCmd.Flags().StringArrayVarP(&tagArtifactArgs.tags, "tag", "t", nil,
+		"Tag of the artifact.")
+
+	artifactCmd.AddCommand(tagArtifactCmd)
+}
+
+func tagArtifactCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("artifact URL is required")
+	}
+	ociURL := args[0]
+
+	if len(tagArtifactArgs.tags) == 0 {
+		return fmt.Errorf("at least one tag is required")
+	}
+
+	spin := StartSpinner("tagging artifact")
+	defer spin.Stop()
+
+	log := LoggerFrom(cmd.Context())
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	opts := oci.Options(ctx, tagArtifactArgs.creds.String())
+
+	for _, tag := range tagArtifactArgs.tags {
+		if err := oci.TagArtifact(ociURL, tag, opts); err != nil {
+			spin.Stop()
+			return fmt.Errorf("tagging artifact with %s failed: %w", tag, err)
+		}
+	}
+
+	spin.Stop()
+
+	baseURL, err := oci.ParseRepositoryURL(ociURL)
+	if err != nil {
+		return err
+	}
+
+	for _, tag := range tagArtifactArgs.tags {
+		log.Info(fmt.Sprintf("tagged: %s", colorizeSubject(fmt.Sprintf("%s:%s", baseURL, tag))))
+	}
+
+	return nil
+}

--- a/cmd/timoni/artifact_tag_test.go
+++ b/cmd/timoni/artifact_tag_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	. "github.com/onsi/gomega"
+)
+
+func Test_TagArtifact(t *testing.T) {
+	aPath := "testdata/module-values"
+
+	g := NewWithT(t)
+	aURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-artifact", 5))
+	aTag := "1.0.0"
+
+	// Push the artifact to registry
+	output, err := executeCommand(fmt.Sprintf(
+		"artifact push oci://%s -f %s -t %s --content-type=generic",
+		aURL,
+		aPath,
+		aTag,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Tag the artifact
+	output, err = executeCommand(fmt.Sprintf(
+		"artifact tag oci://%s:%s -t 2.0 -t 3 -t latest",
+		aURL,
+		aTag,
+	))
+	g.Expect(output).To(ContainSubstring("3"))
+	g.Expect(output).To(ContainSubstring("2.0"))
+	g.Expect(output).To(ContainSubstring("latest"))
+
+	// List the artifacts
+	output, err = executeCommand(fmt.Sprintf(
+		"artifact list oci://%s",
+		aURL,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(ContainSubstring(aTag))
+	g.Expect(output).To(ContainSubstring("3"))
+	g.Expect(output).To(ContainSubstring("2.0"))
+	g.Expect(output).To(ContainSubstring("latest"))
+
+	// Pull the latest artifact from registry
+	_, err = crane.Pull(fmt.Sprintf("%s", aURL))
+	g.Expect(err).ToNot(HaveOccurred())
+}

--- a/docs/bundle-distribution.md
+++ b/docs/bundle-distribution.md
@@ -67,6 +67,14 @@ timoni artifact push oci://docker.io/my-org/my-app-bundle \
   --annotation='org.opencontainers.image.source=https://github.com/my-org/my-app'
 ```
 
+Add extra tags to the artifact with:
+
+```shell
+timoni artifact tag oci://docker.io/my-org/my-app-bundle:1.0.0 \
+  --tag=1.0 \
+  --tag=1
+```
+
 ## Using bundles from container registries
 
 Timoni offers commands for listing, verifying and extracting bundles

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
           - cmd/timoni_artifact_list.md
           - cmd/timoni_artifact_push.md
           - cmd/timoni_artifact_pull.md
+          - cmd/timoni_artifact_tag.md
       - Completion:
           - cmd/timoni_completion.md
           - cmd/timoni_completion_bash.md


### PR DESCRIPTION
Allow adding extra tags to OCI artifacts after publishing. This command can be used to move the latest tag for modules, in case the latest version needs to be retracted.