### PR TITLE
Allow connecting to insecure container registries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 examples/**/templates/*.cue -linguist-documentation
 examples/bundles -linguist-documentation
-blueprint linguist-documentation
+blueprints linguist-documentation

--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -170,6 +170,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 		tmpDir,
 		rootArgs.cacheDir,
 		applyArgs.creds.String(),
+		rootArgs.registryInsecure,
 	)
 	mod, err := fetcher.Fetch()
 	if err != nil {

--- a/cmd/timoni/artifact_list.go
+++ b/cmd/timoni/artifact_list.go
@@ -70,7 +70,7 @@ func listArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
-	opts := oci.Options(ctx, listArtifactArgs.creds.String())
+	opts := oci.Options(ctx, listArtifactArgs.creds.String(), rootArgs.registryInsecure)
 	list, err := oci.ListArtifactTags(ociURL, listArtifactArgs.withDigest, opts)
 	if err != nil {
 		return err

--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -131,7 +131,7 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	opts := oci.Options(ctx, pullArtifactArgs.creds.String())
+	opts := oci.Options(ctx, pullArtifactArgs.creds.String(), rootArgs.registryInsecure)
 	err := oci.PullArtifact(ociURL, pullArtifactArgs.output, pullArtifactArgs.contentType, opts)
 	if err != nil {
 		return err

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -131,7 +131,7 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	spin := StartSpinner("pushing artifact")
 	defer spin.Stop()
 
-	opts := oci.Options(ctx, pushArtifactArgs.creds.String())
+	opts := oci.Options(ctx, pushArtifactArgs.creds.String(), rootArgs.registryInsecure)
 	ociURL := fmt.Sprintf("%s:%s", args[0], pushArtifactArgs.tags[0])
 	digestURL, err := oci.PushArtifact(ociURL,
 		pushArtifactArgs.path,

--- a/cmd/timoni/artifact_tag.go
+++ b/cmd/timoni/artifact_tag.go
@@ -69,7 +69,7 @@ func tagArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	opts := oci.Options(ctx, tagArtifactArgs.creds.String())
+	opts := oci.Options(ctx, tagArtifactArgs.creds.String(), rootArgs.registryInsecure)
 
 	for _, tag := range tagArtifactArgs.tags {
 		if err := oci.TagArtifact(ociURL, tag, opts); err != nil {

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -121,6 +121,7 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 		tmpDir,
 		rootArgs.cacheDir,
 		buildArgs.creds.String(),
+		rootArgs.registryInsecure,
 	)
 	mod, err := fetcher.Fetch()
 	if err != nil {

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -260,6 +260,7 @@ func fetchBundleInstanceModule(ctx context.Context, instance *engine.BundleInsta
 		modDir,
 		rootArgs.cacheDir,
 		bundleApplyArgs.creds.String(),
+		rootArgs.registryInsecure,
 	)
 	mod, err := fetcher.Fetch()
 	if err != nil {

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -55,10 +55,11 @@ var rootCmd = &cobra.Command{
 }
 
 type rootFlags struct {
-	timeout    time.Duration
-	prettyLog  bool
-	coloredLog bool
-	cacheDir   string
+	timeout          time.Duration
+	prettyLog        bool
+	coloredLog       bool
+	cacheDir         string
+	registryInsecure bool
 }
 
 var (
@@ -80,6 +81,8 @@ func init() {
 		"Adds colorized output to the logs. (defaults to false when no tty)")
 	rootCmd.PersistentFlags().StringVar(&rootArgs.cacheDir, "cache-dir", "",
 		"Artifacts cache dir, can be disable with 'TIMONI_CACHING=false' env var. (defaults to \"$HOME/.timoni/cache\")")
+	rootCmd.PersistentFlags().BoolVar(&rootArgs.registryInsecure, "registry-insecure", false,
+		"If true, allows connecting to a container registry without TLS or with a self-signed certificate.")
 
 	addKubeConfigFlags(rootCmd)
 

--- a/cmd/timoni/mod_init.go
+++ b/cmd/timoni/mod_init.go
@@ -89,7 +89,7 @@ func runInitModCmd(cmd *cobra.Command, args []string) error {
 	spin := StartSpinner(fmt.Sprintf("pulling template from %s", modTemplateURL))
 	defer spin.Stop()
 
-	opts := oci.Options(ctx, "")
+	opts := oci.Options(ctx, "", rootArgs.registryInsecure)
 	err = oci.PullArtifact(modTemplateURL, tmpDir, apiv1.AnyContentType, opts)
 	if err != nil {
 		return err

--- a/cmd/timoni/mod_list.go
+++ b/cmd/timoni/mod_list.go
@@ -70,7 +70,7 @@ func listModCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
-	opts := oci.Options(ctx, listModArgs.creds.String())
+	opts := oci.Options(ctx, listModArgs.creds.String(), rootArgs.registryInsecure)
 	list, err := oci.ListModuleVersions(ociURL, listModArgs.withDigest, opts)
 	if err != nil {
 		return err

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -142,7 +142,7 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	spin := StartSpinner(fmt.Sprintf("pulling %s", ociURL))
-	opts := oci.Options(ctx, pullModArgs.creds.String())
+	opts := oci.Options(ctx, pullModArgs.creds.String(), rootArgs.registryInsecure)
 	err := oci.PullArtifact(ociURL, pullModArgs.output, apiv1.AnyContentType, opts)
 	spin.Stop()
 	if err != nil {

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -145,7 +145,7 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	spin := StartSpinner("pushing module")
 	defer spin.Stop()
 
-	opts := oci.Options(ctx, pushModArgs.creds.String())
+	opts := oci.Options(ctx, pushModArgs.creds.String(), rootArgs.registryInsecure)
 	digestURL, err := oci.PushModule(ociURL, pushModArgs.module, pushModArgs.ignorePaths, annotations, opts)
 	if err != nil {
 		return err

--- a/cmd/timoni/mod_vendor_k8s.go
+++ b/cmd/timoni/mod_vendor_k8s.go
@@ -81,7 +81,7 @@ func runVendorK8sCmd(cmd *cobra.Command, args []string) error {
 	spin := StartSpinner(fmt.Sprintf("importing schemas from %s", ociURL))
 	defer spin.Stop()
 
-	opts := oci.Options(ctx, "")
+	opts := oci.Options(ctx, "", rootArgs.registryInsecure)
 	err := oci.PullArtifact(ociURL, path.Join(cueModDir, "gen"), apiv1.CueModGenContentType, opts)
 	if err != nil {
 		return err

--- a/cmd/timoni/mod_vet.go
+++ b/cmd/timoni/mod_vet.go
@@ -96,6 +96,7 @@ func runVetModCmd(cmd *cobra.Command, args []string) error {
 		tmpDir,
 		rootArgs.cacheDir,
 		"",
+		rootArgs.registryInsecure,
 	)
 	mod, err := fetcher.Fetch()
 	if err != nil {

--- a/internal/engine/fetcher.go
+++ b/internal/engine/fetcher.go
@@ -36,10 +36,11 @@ type Fetcher struct {
 	cacheDir string
 	version  string
 	creds    string
+	insecure bool
 }
 
 // NewFetcher creates a Fetcher for the given module.
-func NewFetcher(ctx context.Context, src, version, dst, cacheDir, creds string) *Fetcher {
+func NewFetcher(ctx context.Context, src, version, dst, cacheDir, creds string, insecure bool) *Fetcher {
 	return &Fetcher{
 		ctx:      ctx,
 		src:      src,
@@ -47,6 +48,7 @@ func NewFetcher(ctx context.Context, src, version, dst, cacheDir, creds string) 
 		version:  version,
 		cacheDir: cacheDir,
 		creds:    creds,
+		insecure: insecure,
 	}
 }
 
@@ -104,6 +106,6 @@ func (f *Fetcher) fetchRemoteModule(dstDir string) (*apiv1.ModuleReference, erro
 		return nil, err
 	}
 
-	opts := oci.Options(f.ctx, f.creds)
+	opts := oci.Options(f.ctx, f.creds, f.insecure)
 	return oci.PullModule(ociURL, dstDir, f.cacheDir, opts)
 }

--- a/internal/oci/artifact_test.go
+++ b/internal/oci/artifact_test.go
@@ -44,7 +44,7 @@ func TestArtifactOperations(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	AppendGitMetadata(srcPath, annotations)
 
-	opts := Options(ctx, "")
+	opts := Options(ctx, "", false)
 	digestURL, err := PushArtifact(imgVersionURL, srcPath, imgIgnore, imgContentType, annotations, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/internal/oci/module_test.go
+++ b/internal/oci/module_test.go
@@ -45,7 +45,7 @@ func TestModuleOperations(t *testing.T) {
 	annotations[apiv1.VersionAnnotation] = imgVersion
 	AppendGitMetadata(srcPath, annotations)
 
-	opts := Options(ctx, "")
+	opts := Options(ctx, "", false)
 	digestURL, err := PushModule(imgVersionURL, srcPath, imgIgnore, annotations, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/internal/oci/options.go
+++ b/internal/oci/options.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Options returns the crane options for the given context.
-func Options(ctx context.Context, credentials string) []crane.Option {
+func Options(ctx context.Context, credentials string, insecure bool) []crane.Option {
 	var opts []crane.Option
 	opts = append(opts, crane.WithUserAgent(apiv1.UserAgent), crane.WithContext(ctx))
 
@@ -44,5 +44,8 @@ func Options(ctx context.Context, credentials string) []crane.Option {
 		opts = append(opts, crane.WithAuth(authn.FromConfig(authConfig)))
 	}
 
+	if insecure {
+		opts = append(opts, crane.Insecure)
+	}
 	return opts
 }


### PR DESCRIPTION
Add `--registry-insecure` flag to allow push/pull operations for container registries without TLS or with self-signed certs.