### PR TITLE
Generate a Markdown Table from a Module Configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,6 @@ jobs:
       - name: Check if working tree is dirty
         run: |
           if [[ $(git diff --stat) != '' ]]; then
-            echo 'run "make test lint-samples" and commit changes'
+            echo 'run "make test cue-vet" and commit changes'
             exit 1
           fi

--- a/cmd/timoni/mod_config.go
+++ b/cmd/timoni/mod_config.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/flags"
+)
+
+var configModCmd = &cobra.Command{
+	Use:   "config [MODULE PATH]",
+	Short: "Output the #Config structure of a local module",
+	Long:  `The config command parses the local module configuration structure and outputs the information to stdout.`,
+	Example: `  # print the config of a module in the current directory
+  timoni mod config
+
+  # print the config of a module in a specific directory
+  timoni mod config ./path/to/module
+`,
+	RunE: runConfigModCmd,
+}
+
+type configModFlags struct {
+	path string
+	pkg  flags.Package
+	name string
+}
+
+var configModArgs = configModFlags{
+	name: "timoni",
+}
+
+func init() {
+	modCmd.AddCommand(configModCmd)
+}
+
+func runConfigModCmd(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		configModArgs.path = "."
+	} else {
+		configModArgs.path = args[0]
+	}
+
+	if fs, err := os.Stat(configModArgs.path); err != nil || !fs.IsDir() {
+		return fmt.Errorf("module not found at path %s", configModArgs.path)
+	}
+
+	//log := LoggerFrom(cmd.Context())
+	cuectx := cuecontext.New()
+
+	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ctxPull, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	fetcher := engine.NewFetcher(
+		ctxPull,
+		configModArgs.path,
+		apiv1.LatestVersion,
+		tmpDir,
+		rootArgs.cacheDir,
+		"",
+		rootArgs.registryInsecure,
+	)
+	mod, err := fetcher.Fetch()
+	if err != nil {
+		return err
+	}
+
+	builder := engine.NewModuleBuilder(
+		cuectx,
+		configModArgs.name,
+		*kubeconfigArgs.Namespace,
+		fetcher.GetModuleRoot(),
+		configModArgs.pkg.String(),
+	)
+
+	if err := builder.WriteSchemaFile(); err != nil {
+		return err
+	}
+
+	mod.Name, err = builder.GetModuleName()
+	if err != nil {
+		return fmt.Errorf("build failed: %w", err)
+	}
+
+	buildResult, err := builder.Build()
+	if err != nil {
+		return describeErr(fetcher.GetModuleRoot(), "validation failed", err)
+	}
+
+	rows, err := builder.GetConfigStructure(buildResult)
+	if err != nil {
+		return describeErr(fetcher.GetModuleRoot(), "failed to get config structure", err)
+	}
+
+	printMarkDownTable(os.Stdout, []string{"Field", "Type", "Default", "Description"}, rows)
+
+	return nil
+}
+
+func printMarkDownTable(writer io.Writer, header []string, rows [][]string) {
+	table := tablewriter.NewWriter(writer)
+	table.SetHeader(header)
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("|")
+	table.SetColumnSeparator("|")
+	table.SetRowSeparator("-")
+	table.SetHeaderLine(true)
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetTablePadding("\t")
+	table.SetNoWhiteSpace(false)
+	table.AppendBulk(rows)
+	table.Render()
+}

--- a/cmd/timoni/mod_show.go
+++ b/cmd/timoni/mod_show.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Stefan Prodan
+Copyright 2024 Stefan Prodan
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/timoni/mod_show.go
+++ b/cmd/timoni/mod_show.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var showModCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Commands for showing module information",
+}
+
+func init() {
+	modCmd.AddCommand(showModCmd)
+}

--- a/cmd/timoni/mod_show_config.go
+++ b/cmd/timoni/mod_show_config.go
@@ -125,7 +125,7 @@ func runConfigShowModCmd(cmd *cobra.Command, args []string) error {
 		return describeErr(fetcher.GetModuleRoot(), "validation failed", err)
 	}
 
-	rows, err := builder.GetConfigStructure(buildResult)
+	rows, err := builder.GetConfigDoc(buildResult)
 	if err != nil {
 		return describeErr(fetcher.GetModuleRoot(), "failed to get config structure", err)
 	}
@@ -218,7 +218,11 @@ func writeFile(readFile string, header []string, rows [][]string, fetcher *engin
 		outputWriter.WriteString("\n" + tableBuffer.String())
 	}
 
-	outputWriter.Flush()
+	err = outputWriter.Flush()
+	if err != nil {
+		return "", describeErr(fetcher.GetModuleRoot(), "Failed to Flush Writer", err)
+	}
+
 	return tmpFileName, nil
 }
 

--- a/cmd/timoni/mod_show_config.go
+++ b/cmd/timoni/mod_show_config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Stefan Prodan
+Copyright 2024 Stefan Prodan
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/timoni/mod_show_config_test.go
+++ b/cmd/timoni/mod_show_config_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_ShowConfig(t *testing.T) {
+	modPath := "testdata/module"
+
+	g := NewWithT(t)
+
+	// Push the module to registry
+	output, err := executeCommand(fmt.Sprintf(
+		"mod show config %s",
+		modPath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(output).To(ContainSubstring("`client: enabled:`"))
+	g.Expect(output).To(ContainSubstring("`client: image: repository:`"))
+	g.Expect(output).To(ContainSubstring("`server: enabled:`"))
+}
+
+func Test_ShowConfigOutput(t *testing.T) {
+	modPath := "testdata/module"
+
+	g := NewWithT(t)
+
+	// Push the module to registry
+	_, err := executeCommand(fmt.Sprintf(
+		"mod show config %s --output %s/README.md",
+		modPath,
+		modPath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	rmFile, err := os.ReadFile(fmt.Sprintf("%s/README.md", modPath))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	strContent := string(rmFile)
+
+	g.Expect(strContent).To(ContainSubstring("`client: enabled:`"))
+	g.Expect(strContent).To(ContainSubstring("`client: image: repository:`"))
+	g.Expect(strContent).To(ContainSubstring("`server: enabled:`"))
+
+	err = os.Remove(fmt.Sprintf("%s/README.md", modPath))
+	g.Expect(err).ToNot(HaveOccurred())
+}

--- a/cmd/timoni/mod_show_config_test.go
+++ b/cmd/timoni/mod_show_config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Stefan Prodan
+Copyright 2024 Stefan Prodan
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/timoni/mod_show_config_test.go
+++ b/cmd/timoni/mod_show_config_test.go
@@ -73,7 +73,7 @@ func Test_ShowConfigOutput(t *testing.T) {
 
 func Test_ShowConfigOutputNewFile(t *testing.T) {
 	modPath := "testdata/module"
-	filePath := fmt.Sprintf("%s/testing.md", modPath)
+	filePath := fmt.Sprintf("%s/testing.md", t.TempDir())
 
 	g := NewWithT(t)
 
@@ -93,7 +93,4 @@ func Test_ShowConfigOutputNewFile(t *testing.T) {
 	g.Expect(strContent).To(ContainSubstring("`client: enabled:`"))
 	g.Expect(strContent).To(ContainSubstring("`client: image: repository:`"))
 	g.Expect(strContent).To(ContainSubstring("`server: enabled:`"))
-
-	err = os.Remove(filePath)
-	g.Expect(err).ToNot(HaveOccurred())
 }

--- a/cmd/timoni/mod_show_config_test.go
+++ b/cmd/timoni/mod_show_config_test.go
@@ -43,18 +43,49 @@ func Test_ShowConfig(t *testing.T) {
 
 func Test_ShowConfigOutput(t *testing.T) {
 	modPath := "testdata/module"
+	filePath := fmt.Sprintf("%s/README.md", modPath)
 
 	g := NewWithT(t)
 
 	// Push the module to registry
 	_, err := executeCommand(fmt.Sprintf(
-		"mod show config %s --output %s/README.md",
+		"mod show config %s --output %s",
 		modPath,
-		modPath,
+		filePath,
 	))
 	g.Expect(err).ToNot(HaveOccurred())
 
-	rmFile, err := os.ReadFile(fmt.Sprintf("%s/README.md", modPath))
+	rmFile, err := os.ReadFile(filePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	strContent := string(rmFile)
+
+	g.Expect(strContent).To(ContainSubstring("# module"))
+	g.Expect(strContent).To(ContainSubstring("## Install"))
+	g.Expect(strContent).To(ContainSubstring("## Uninstall"))
+	g.Expect(strContent).To(ContainSubstring("## Configuration"))
+	g.Expect(strContent).To(ContainSubstring("`client: enabled:`"))
+	g.Expect(strContent).To(ContainSubstring("`client: image: repository:`"))
+	g.Expect(strContent).To(ContainSubstring("`server: enabled:`"))
+
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func Test_ShowConfigOutputNewFile(t *testing.T) {
+	modPath := "testdata/module"
+	filePath := fmt.Sprintf("%s/testing.md", modPath)
+
+	g := NewWithT(t)
+
+	// Push the module to registry
+	_, err := executeCommand(fmt.Sprintf(
+		"mod show config %s --output %s",
+		modPath,
+		filePath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	rmFile, err := os.ReadFile(filePath)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	strContent := string(rmFile)
@@ -63,6 +94,6 @@ func Test_ShowConfigOutput(t *testing.T) {
 	g.Expect(strContent).To(ContainSubstring("`client: image: repository:`"))
 	g.Expect(strContent).To(ContainSubstring("`server: enabled:`"))
 
-	err = os.Remove(fmt.Sprintf("%s/README.md", modPath))
+	err = os.Remove(filePath)
 	g.Expect(err).ToNot(HaveOccurred())
 }

--- a/cmd/timoni/testdata/module/README.md
+++ b/cmd/timoni/testdata/module/README.md
@@ -1,0 +1,55 @@
+# module
+
+A [timoni.sh](http://timoni.sh) module for deploying blueprint to Kubernetes clusters.
+
+## Install
+
+To create an instance using the default values:
+
+```shell
+timoni -n module apply module oci://<container-registry-url>
+```
+
+To change the [default configuration](#configuration),
+create one or more `values.cue` files and apply them to the instance.
+
+For example, create a file `my-values.cue` with the following content:
+
+```cue
+values: {
+    team: "timoni"
+    metadata: labels: testing: "true"
+    domain: "example.com"
+    ns: enabled: true
+}
+```
+
+And apply the values with:
+
+```shell
+timoni -n module apply module oci://<container-registry-url> \
+--values ./my-values.cue
+```
+
+## Uninstall
+
+To uninstall an instance and delete all its Kubernetes resources:
+
+```shell
+timoni -n module delete module
+```
+
+## Configuration
+
+| KEY                          | TYPE     | DEFAULT                                                                                                                                                    | DESCRIPTION                                                                                                                                                                                                                                   |
+|------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `metadata: labels:`          | `struct` | `{"app.kubernetes.io/name": "module-name","app.kubernetes.io/kube": "1.27.5","app.kubernetes.io/version": "0.0.0-devel","app.kubernetes.io/team": "test"}` | Map of string keys and values that can be used to organize and categorize (scope and select) objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels Standard Kubernetes labels: app name and version.   |
+| `client: enabled:`           | `bool`   | `true`                                                                                                                                                     |                                                                                                                                                                                                                                               |
+| `client: image: repository:` | `string` | `"cgr.dev/chainguard/timoni"`                                                                                                                              | Repository is the address of a container registry repository. An image repository is made up of slash-separated name components, optionally prefixed by a registry hostname and port in the format [HOST[:PORT_NUMBER]/]PATH.                 |
+| `client: image: tag:`        | `string` | `"latest-dev"`                                                                                                                                             | Tag identifies an image in the repository. A tag name may contain lowercase and uppercase characters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.  |
+| `client: image: digest:`     | `string` | `"sha256:b49fbaac0eedc22c1cfcd26684707179cccbed0df205171bae3e1bae61326a10"`                                                                                | Digest uniquely and immutably identifies an image in the repository. Spec: https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests.                                                                                      |
+| `server: enabled:`           | `bool`   | `true`                                                                                                                                                     |                                                                                                                                                                                                                                               |
+| `domain:`                    | `string` | `"example.internal"`                                                                                                                                       |                                                                                                                                                                                                                                               |
+| `ns: enabled:`               | `bool`   | `false`                                                                                                                                                    |                                                                                                                                                                                                                                               |
+| `team:`                      | `string` | `"test"`                                                                                                                                                   |                                                                                                                                                                                                                                               |
+

--- a/cmd/timoni/testdata/module/cue.mod/pkg/timoni.sh/core/v1alpha1/image.cue
+++ b/cmd/timoni/testdata/module/cue.mod/pkg/timoni.sh/core/v1alpha1/image.cue
@@ -24,6 +24,7 @@ import "strings"
 
 	// Reference is the image address computed from repository, tag and digest
 	// in the format [REPOSITORY]:[TAG]@[DIGEST].
+	// +nodoc
 	reference: string
 
 	if digest != "" && tag != "" {

--- a/cmd/timoni/testdata/module/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
+++ b/cmd/timoni/testdata/module/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
@@ -30,7 +30,9 @@ import "strings"
 
 	// Standard Kubernetes labels: app name and version.
 	labels: {
-		"app.kubernetes.io/name":    name
+		// +nodoc
+		"app.kubernetes.io/name": name
+		// +nodoc
 		"app.kubernetes.io/version": #Version
 	}
 }

--- a/cmd/timoni/testdata/module/templates/config.cue
+++ b/cmd/timoni/testdata/module/templates/config.cue
@@ -8,24 +8,37 @@ import (
 	moduleVersion!: string
 	kubeVersion!:   string
 
+	// Common metadata for all objects
 	metadata: timoniv1.#Metadata & {#Version: moduleVersion}
 	metadata: labels: {
+		// +nodoc
 		"app.kubernetes.io/kube": kubeVersion
+		// +nodoc
 		"app.kubernetes.io/team": team
 	}
 
-	client: enabled: *true | bool
+	// +nodoc
+	client: {
+		enabled: *true | bool
 
-	client: image: timoniv1.#Image & {
-		repository: *"cgr.dev/chainguard/timoni" | string
-		tag:        *"latest-dev" | string
-		digest:     *"sha256:b49fbaac0eedc22c1cfcd26684707179cccbed0df205171bae3e1bae61326a10" | string
+		// +nodoc
+		image: timoniv1.#Image & {
+			repository: *"cgr.dev/chainguard/timoni" | string
+			tag:        *"latest-dev" | string
+			digest:     *"sha256:b49fbaac0eedc22c1cfcd26684707179cccbed0df205171bae3e1bae61326a10" | string
+		}
 	}
 
-	server: enabled: *true | bool
+	// +nodoc
+	server: {
+		enabled: *true | bool
+	}
 	domain: *"example.internal" | string
 
-	ns: enabled: *false | bool
+	// +nodoc
+	ns: {
+		enabled: *false | bool
+	}
 
 	team!: string
 }

--- a/cmd/timoni/testdata/module/timoni.cue
+++ b/cmd/timoni/testdata/module/timoni.cue
@@ -27,15 +27,21 @@ timoni: {
 	instance: templates.#Instance & {
 		// The user-supplied values are merged with the
 		// default values at runtime by Timoni.
+		// +nodoc
 		config: values
 		// These values are injected at runtime by Timoni.
 		config: {
+			// +nodoc
 			metadata: {
-				name:      string @tag(name)
+				// +nodoc
+				name: string @tag(name)
+				// +nodoc
 				namespace: string @tag(namespace)
 			}
+			// +nodoc
 			moduleVersion: string @tag(mv, var=moduleVersion)
-			kubeVersion:   string @tag(kv, var=kubeVersion)
+			// +nodoc
+			kubeVersion: string @tag(kv, var=kubeVersion)
 		}
 	}
 
@@ -45,5 +51,5 @@ timoni: {
 
 	// Pass Kubernetes resources outputted by the instance
 	// to Timoni's multi-step apply.
-	apply: all: [ for obj in instance.objects {obj}]
+	apply: all: [for obj in instance.objects {obj}]
 }

--- a/internal/engine/module_builder.go
+++ b/internal/engine/module_builder.go
@@ -320,11 +320,16 @@ func (b *ModuleBuilder) GetConfigStructure(value cue.Value) ([][]string, error) 
 
 		if v.Kind().String() != "struct" && !v.IsConcrete() {
 			defaultVal, _ := v.Default()
-			value, _ := defaultVal.MarshalJSON()
+			valueBytes, _ := defaultVal.MarshalJSON()
+			valueType := strings.ReplaceAll(v.IncompleteKind().String(), "|", "\\|")
+			value := strings.ReplaceAll(string(valueBytes), "\":", "\": ")
+			value = strings.ReplaceAll(value, "\":[", "\": [")
+			value = strings.ReplaceAll(value, "},", "}, ")
+			value = strings.ReplaceAll(value, "|", "\\|")
 
 			row = append(row, fmt.Sprintf("`%s:`", strings.ReplaceAll(strings.Replace(v.Path().String(), "timoni.instance.config.", "", 1), ".", ": ")))
-			row = append(row, fmt.Sprintf("`%s`", v.IncompleteKind()))
-			row = append(row, fmt.Sprintf("`%s`", strings.ReplaceAll(string(value), "\":\"", "\": \"")))
+			row = append(row, fmt.Sprintf("`%s`", valueType))
+			row = append(row, fmt.Sprintf("`%s`", value))
 
 			var doc string
 			for _, d := range v.Doc() {


### PR DESCRIPTION
This adds support for creating a markdown table generated from the configuration cue structure in a module with `timoni mod show config`.

Fix: https://github.com/stefanprodan/timoni/issues/168

The command will output the table to `os.Stdout` by default, however you can provide a file name to the flag `-o` or `--output` where the table will be written to. If the file is markdown (i.e. has the file extention `.md` or `.markdown`) we look for the heading `## Configuration` and then a table within this heading which will be replaced. If the file is not markdown the table will be appended to the file.

The below is an example of output generated from the [blueprint](https://github.com/stefanprodan/timoni/tree/main/blueprints/starter) module and you can look at the [cert-manager-module README](https://github.com/nalum/cert-manager-module) for an example of something with more complexity.

| KEY                                                 | TYPE     | DEFAULT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | DESCRIPTION                                                                                                                                                                                                                                                                                                                                                                                                                                     |
|-----------------------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `timoni: instance: config:`                         | `struct` | `{"kubeVersion": "1.27.5","clusterVersion": {"major": 1,"minor": 27}, "moduleVersion": "0.0.0-devel","metadata": {"name": "module-name","namespace": "default","labels": {"app.kubernetes.io/name": "module-name","app.kubernetes.io/version": "0.0.0-devel","app.kubernetes.io/managed-by": "timoni"}}, "selector": {"labels": {"app.kubernetes.io/name": "module-name"}}, "image": {"repository": "docker.io/nginx","tag": "1-alpine","digest": "","pullPolicy": "IfNotPresent","reference": "docker.io/nginx:1-alpine"}, "pod": {"affinity": {"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms": [{"matchExpressions": [{"key": "kubernetes.io/os","operator": "In","values": ["linux"]}]}]}}}}, "resources": {"requests": {"cpu": "10m","memory": "32Mi"}}, "replicas": 1,"securityContext": {"capabilities": {"drop": ["ALL"],"add": ["CHOWN","NET_BIND_SERVICE","SETGID","SETUID"]}, "privileged": false,"allowPrivilegeEscalation": false}, "service": {"port": 80}}` | The user-supplied values are merged with the default values at runtime by Timoni. These values are injected at runtime by Timoni.                                                                                                                                                                                                                                                                                                               |
| `kubeVersion:`                                      | `string` | `"1.27.5"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | The kubeVersion is a required field, set at apply-time via timoni.cue by querying the user's Kubernetes API.                                                                                                                                                                                                                                                                                                                                    |
| `clusterVersion:`                                   | `struct` | `{"major": 1,"minor": 27}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Using the kubeVersion you can enforce a minimum Kubernetes minor version. By default, the minimum Kubernetes version is set to 1.20.                                                                                                                                                                                                                                                                                                            |
| `clusterVersion: major:`                            | `int`    | `1`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `clusterVersion: minor:`                            | `int`    | `27`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `moduleVersion:`                                    | `string` | `"0.0.0-devel"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | The moduleVersion is set from the user-supplied module version. This field is used for the `app.kubernetes.io/version` label.                                                                                                                                                                                                                                                                                                                   |
| `metadata:`                                         | `struct` | `{"name": "module-name","namespace": "default","labels": {"app.kubernetes.io/name": "module-name","app.kubernetes.io/version": "0.0.0-devel","app.kubernetes.io/managed-by": "timoni"}}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | The Kubernetes metadata common to all resources. The `metadata.name` and `metadata.namespace` fields are set from the user-supplied instance name and namespace.                                                                                                                                                                                                                                                                                |
| `metadata: name:`                                   | `string` | `"module-name"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Name must be unique within a namespace. Is required when creating resources. Name is primarily intended for creation idempotence and configuration definition. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names                                                                                                                                                                                         |
| `metadata: namespace:`                              | `string` | `"default"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Namespace defines the space within which each name must be unique. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces                                                                                                                                                                                                                                                                                      |
| `metadata: labels:`                                 | `struct` | `{"app.kubernetes.io/name": "module-name","app.kubernetes.io/version": "0.0.0-devel","app.kubernetes.io/managed-by": "timoni"}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Map of string keys and values that can be used to organize and categorize (scope and select) objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels Standard Kubernetes labels: app name, version and managed-by. The labels allows adding `metadata.labels` to all resources. The `app.kubernetes.io/name` and `app.kubernetes.io/version` labels are automatically generated and can't be overwritten.  |
| `metadata: labels: "app.kubernetes.io/name":`       | `string` | `"module-name"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `metadata: labels: "app.kubernetes.io/version":`    | `string` | `"0.0.0-devel"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `metadata: labels: "app.kubernetes.io/managed-by":` | `string` | `"timoni"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `selector:`                                         | `struct` | `{"labels": {"app.kubernetes.io/name": "module-name"}}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | The selector allows adding label selectors to Deployments and Services. The `app.kubernetes.io/name` label selector is automatically generated from the instance name and can't be overwritten.                                                                                                                                                                                                                                                 |
| `selector: labels:`                                 | `struct` | `{"app.kubernetes.io/name": "module-name"}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Map of string keys and values that can be used to organize and categorize (scope and select) objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels Standard Kubernetes label: app name.                                                                                                                                                                                                                  |
| `selector: labels: "app.kubernetes.io/name":`       | `string` | `"module-name"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `image:`                                            | `struct` | `{"repository": "docker.io/nginx","tag": "1-alpine","digest": "","pullPolicy": "IfNotPresent","reference": "docker.io/nginx:1-alpine"}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | The image allows setting the container image repository, tag, digest and pull policy.                                                                                                                                                                                                                                                                                                                                                           |
| `image: repository:`                                | `string` | `"docker.io/nginx"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Repository is the address of a container registry repository. An image repository is made up of slash-separated name components, optionally prefixed by a registry hostname and port in the format [HOST[:PORT_NUMBER]/]PATH.                                                                                                                                                                                                                   |
| `image: tag:`                                       | `string` | `"1-alpine"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Tag identifies an image in the repository. A tag name may contain lowercase and uppercase characters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.                                                                                                                                                                                                    |
| `image: digest:`                                    | `string` | `""`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Digest uniquely and immutably identifies an image in the repository. Spec: https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests.                                                                                                                                                                                                                                                                                        |
| `image: pullPolicy:`                                | `string` | `"IfNotPresent"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | PullPolicy defines the pull policy for the image. By default, it is set to IfNotPresent.                                                                                                                                                                                                                                                                                                                                                        |
| `image: reference:`                                 | `string` | `"docker.io/nginx:1-alpine"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Reference is the image address computed from repository, tag and digest in the format [REPOSITORY]:[TAG]@[DIGEST].                                                                                                                                                                                                                                                                                                                              |
| `pod:`                                              | `struct` | `{"affinity": {"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms": [{"matchExpressions": [{"key": "kubernetes.io/os","operator": "In","values": ["linux"]}]}]}}}}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | The pod allows setting the Kubernetes Pod annotations, image pull secrets, affinity and anti-affinity rules. By default, pods are scheduled on Linux nodes.                                                                                                                                                                                                                                                                                     |
| `pod: affinity:`                                    | `struct` | `{"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms": [{"matchExpressions": [{"key": "kubernetes.io/os","operator": "In","values": ["linux"]}]}]}}}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `resources:`                                        | `struct` | `{"requests": {"cpu": "10m","memory": "32Mi"}}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | The resources allows setting the container resource requirements. By default, the container requests 10m CPU and 32Mi memory.                                                                                                                                                                                                                                                                                                                   |
| `resources: requests:`                              | `struct` | `{"cpu": "10m","memory": "32Mi"}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Requests describes the minimum amount of compute resources required. Requests cannot exceed Limits.                                                                                                                                                                                                                                                                                                                                             |
| `resources: requests: cpu:`                         | `string` | `"10m"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `resources: requests: memory:`                      | `string` | `"32Mi"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `replicas:`                                         | `int`    | `1`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | The number of pods replicas. By default, the number of replicas is 1.                                                                                                                                                                                                                                                                                                                                                                           |
| `securityContext:`                                  | `struct` | `{"capabilities": {"drop": ["ALL"],"add": ["CHOWN","NET_BIND_SERVICE","SETGID","SETUID"]}, "privileged": false,"allowPrivilegeEscalation": false}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | The securityContext allows setting the container security context. By default, the container is denined privilege escalation.                                                                                                                                                                                                                                                                                                                   |
| `securityContext: capabilities:`                    | `struct` | `{"drop": ["ALL"],"add": ["CHOWN","NET_BIND_SERVICE","SETGID","SETUID"]}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.                                                                                                                                                                                                                                            |
| `securityContext: capabilities: drop:`              | `list`   | `["ALL"]`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Removed capabilities                                                                                                                                                                                                                                                                                                                                                                                                                            |
| `securityContext: capabilities: add:`               | `list`   | `["CHOWN","NET_BIND_SERVICE","SETGID","SETUID"]`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Added capabilities                                                                                                                                                                                                                                                                                                                                                                                                                              |
| `securityContext: privileged:`                      | `bool`   | `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.                                                                                                                                                                                                                                        |
| `securityContext: allowPrivilegeEscalation:`        | `bool`   | `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.                                                                      |
| `service:`                                          | `struct` | `{"port": 80}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | The service allows setting the Kubernetes Service annotations and port. By default, the HTTP port is 80.                                                                                                                                                                                                                                                                                                                                        |
| `service: port:`                                    | `int`    | `80`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |                                                                                                                                                                                                                                                                                                                                                                                                                                                 |