### PR TITLE
doc/fix cue command parameter order

### DIFF
--- a/docs/cue/module/import-resources.md
+++ b/docs/cue/module/import-resources.md
@@ -11,7 +11,7 @@ run the following command in the module's root directory:
 
 ```shell
 cue import /path/to/manifests.yaml \
-  -o -f templates/manifests.cue -p templates \
+  -f -o templates/manifests.cue -p templates \
   -l 'strings.ToLower(kind)' -l 'metadata.name'
 ```
 


### PR DESCRIPTION
fix the parameter order
from: 
`cue import /path/to/manifests.yaml  -o -f templates/manifests.cue -p templates -l 'strings.ToLower(kind)' -l 'metadata.name'`
to 
`cue import /path/to/manifests.yaml -f -o templates/manifests.cue -p templates -l 'strings.ToLower(kind)' -l 'metadata.name'`