### PR TITLE
Use shorter syntax for string keys in CUE schemas

### DIFF
--- a/examples/redis/templates/master/deployment.cue
+++ b/examples/redis/templates/master/deployment.cue
@@ -10,7 +10,7 @@ import (
 #MasterDeployment: appsv1.#Deployment & {
 	#config: config.#Config
 	_selectorLabel: {
-		"\(timoniv1.#StdLabelName)": "\(#config.metadata.name)-master"
+		(timoniv1.#StdLabelName): "\(#config.metadata.name)-master"
 	}
 	apiVersion: "apps/v1"
 	kind:       "Deployment"

--- a/examples/redis/templates/master/service.cue
+++ b/examples/redis/templates/master/service.cue
@@ -9,7 +9,7 @@ import (
 #MasterService: corev1.#Service & {
 	#config: config.#Config
 	_selectorLabel: {
-		"\(timoniv1.#StdLabelName)": "\(#config.metadata.name)-master"
+		(timoniv1.#StdLabelName): "\(#config.metadata.name)-master"
 	}
 	apiVersion: "v1"
 	kind:       "Service"

--- a/examples/redis/templates/replica/deployment.cue
+++ b/examples/redis/templates/replica/deployment.cue
@@ -10,7 +10,7 @@ import (
 #ReplicaDeployment: appsv1.#Deployment & {
 	#config: config.#Config
 	_selectorLabel: {
-		"\(timoniv1.#StdLabelName)": "\(#config.metadata.name)-replica"
+		(timoniv1.#StdLabelName): "\(#config.metadata.name)-replica"
 	}
 	apiVersion: "apps/v1"
 	kind:       "Deployment"

--- a/examples/redis/templates/replica/service.cue
+++ b/examples/redis/templates/replica/service.cue
@@ -9,7 +9,7 @@ import (
 #ReplicaService: corev1.#Service & {
 	#config: config.#Config
 	_selectorLabel: {
-		"\(timoniv1.#StdLabelName)": "\(#config.metadata.name)-replica"
+		(timoniv1.#StdLabelName): "\(#config.metadata.name)-replica"
 	}
 	apiVersion: "v1"
 	kind:       "Service"

--- a/schemas/timoni.sh/core/v1alpha1/metadata.cue
+++ b/schemas/timoni.sh/core/v1alpha1/metadata.cue
@@ -43,14 +43,14 @@ import "strings"
 
 	// Standard Kubernetes labels: app name, version and managed-by.
 	labels: {
-		"\(#StdLabelName)":      name
-		"\(#StdLabelVersion)":   #Version
-		"\(#StdLabelManagedBy)": "timoni"
+		(#StdLabelName):      name
+		(#StdLabelVersion):   #Version
+		(#StdLabelManagedBy): "timoni"
 	}
 
 	// LabelSelector selects Pods based on the app.kubernetes.io/name label.
 	#LabelSelector: #Labels & {
-		"\(#StdLabelName)": name
+		(#StdLabelName): name
 	}
 }
 
@@ -69,7 +69,7 @@ import "strings"
 	namespace: #Meta.namespace
 
 	labels: #Meta.labels
-	labels: "\(#StdLabelComponent)": #Component
+	labels: (#StdLabelComponent): #Component
 
 	annotations?: #Annotations
 	if #Meta.annotations != _|_ {
@@ -79,8 +79,8 @@ import "strings"
 	// LabelSelector selects Pods based on the app.kubernetes.io/name
 	// and app.kubernetes.io/component labels.
 	#LabelSelector: #Labels & {
-		"\(#StdLabelComponent)": #Component
-		"\(#StdLabelName)":      #Meta.name
+		(#StdLabelComponent): #Component
+		(#StdLabelName):      #Meta.name
 	}
 }
 
@@ -99,7 +99,7 @@ import "strings"
 	name: #Meta.name + "-" + #Component
 
 	labels: #Meta.labels
-	labels: "\(#StdLabelComponent)": #Component
+	labels: (#StdLabelComponent): #Component
 
 	annotations?: #Annotations
 	if #Meta.annotations != _|_ {
@@ -109,7 +109,7 @@ import "strings"
 	// LabelSelector selects Pods based on the app.kubernetes.io/name
 	// and app.kubernetes.io/component labels.
 	#LabelSelector: #Labels & {
-		"\(#StdLabelComponent)": #Component
-		"\(#StdLabelName)":      #Meta.name
+		(#StdLabelComponent): #Component
+		(#StdLabelName):      #Meta.name
 	}
 }

--- a/schemas/timoni.sh/core/v1alpha1/selector.cue
+++ b/schemas/timoni.sh/core/v1alpha1/selector.cue
@@ -15,5 +15,5 @@ package v1alpha1
 	labels: #Labels
 
 	// Standard Kubernetes label: app name.
-	labels: "\(#StdLabelName)": #Name
+	labels: (#StdLabelName): #Name
 }


### PR DESCRIPTION
This avoid uncessary interpolation, which makes for longer syntax, but it is generally just uncessary.