### PR TITLE
chore: add proto plugin

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -62,6 +62,18 @@ The AMD64 and ARM64 binaries can be downloaded from GitHub [releases](https://gi
     zypper install timoni-fish-completion
     zypper install timoni-zsh-completion
     ```
+=== "proto"
+
+    Manage multiple versions with [proto](https://moonrepo.dev/proto) for all supported systems:
+
+    ```toml
+    # .prototools file
+
+    timoni = "0.19.0"
+
+    [plugins]
+    timoni = "source:https://raw.githubusercontent.com/stefanprodan/timoni/main/proto-plugin.toml"
+    ```
 
 === "from source"
 

--- a/proto-plugin.toml
+++ b/proto-plugin.toml
@@ -1,0 +1,25 @@
+name = "timoni"
+type = "cli"
+
+[platform.linux]
+bin-path = "timoni"
+download-file = "timoni_{version}_linux_{arch}.tar.gz"
+
+[platform.macos]
+bin-path = "timoni"
+download-file = "timoni_{version}_darwin_{arch}.tar.gz"
+
+[platform.windows]
+bin-path = "timoni.exe"
+download-file = "timoni_{version}_windows_{arch}.zip"
+
+[install]
+checksum-url = "https://github.com/stefanprodan/timoni/releases/download/v{version}/timoni_{version}_checksums.txt"
+download-url = "https://github.com/stefanprodan/timoni/releases/download/v{version}/{download_file}"
+
+[install.arch]
+aarch64 = "arm64"
+x86_64 = "amd64"
+
+[resolve]
+git-url = "https://github.com/stefanprodan/timoni"


### PR DESCRIPTION
This PR adds a plugin file to be able to install `timoni` in a [proto](https://moonrepo.dev/docs/proto) toolchain. It follows [toml plugin](https://moonrepo.dev/docs/proto/toml-plugin) format.

This is the file I'm currently using locally, but I thought it would be nice to add it here directly so we can reference timoni [here](https://moonrepo.dev/docs/proto/tools).