### PR TITLE
Allow runtime definition to be coupled with a bundle

### DIFF
--- a/internal/engine/runtime_builder.go
+++ b/internal/engine/runtime_builder.go
@@ -130,10 +130,6 @@ func (b *RuntimeBuilder) Build() (cue.Value, error) {
 		return value, v.Err()
 	}
 
-	if err := v.Validate(cue.Concrete(true)); err != nil {
-		return value, err
-	}
-
 	return v, nil
 }
 


### PR DESCRIPTION
Remove the concrete validation to allow runtime to be part of the same file as the bundle.