### PR TITLE
Add finalizers to `#Metadata` definition

### DIFF
--- a/blueprints/starter/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
+++ b/blueprints/starter/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
@@ -52,6 +52,11 @@ import "strings"
 	#LabelSelector: #Labels & {
 		(#StdLabelName): name
 	}
+
+	// Finalizers are namespaced keys that tell Kubernetes to wait until specific conditions
+	// are met before it fully deletes resources marked for deletion.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
+	finalizers?: [...string]
 }
 
 // MetaComponent generates the Kubernetes object metadata for a module namespaced component.

--- a/examples/minimal/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
+++ b/examples/minimal/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
@@ -52,6 +52,11 @@ import "strings"
 	#LabelSelector: #Labels & {
 		(#StdLabelName): name
 	}
+
+	// Finalizers are namespaced keys that tell Kubernetes to wait until specific conditions
+	// are met before it fully deletes resources marked for deletion.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
+	finalizers?: [...string]
 }
 
 // MetaComponent generates the Kubernetes object metadata for a module namespaced component.

--- a/examples/redis/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
+++ b/examples/redis/cue.mod/pkg/timoni.sh/core/v1alpha1/metadata.cue
@@ -52,6 +52,11 @@ import "strings"
 	#LabelSelector: #Labels & {
 		(#StdLabelName): name
 	}
+
+	// Finalizers are namespaced keys that tell Kubernetes to wait until specific conditions
+	// are met before it fully deletes resources marked for deletion.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
+	finalizers?: [...string]
 }
 
 // MetaComponent generates the Kubernetes object metadata for a module namespaced component.

--- a/schemas/timoni.sh/core/v1alpha1/metadata.cue
+++ b/schemas/timoni.sh/core/v1alpha1/metadata.cue
@@ -52,6 +52,11 @@ import "strings"
 	#LabelSelector: #Labels & {
 		(#StdLabelName): name
 	}
+
+	// Finalizers are namespaced keys that tell Kubernetes to wait until specific conditions
+	// are met before it fully deletes resources marked for deletion.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
+	finalizers?: [...string]
 }
 
 // MetaComponent generates the Kubernetes object metadata for a module namespaced component.


### PR DESCRIPTION
Add optional `finalizers` field to the `#Metadata` definition part of the Timoni's CUE schemas.

Fix: #375