### PR TITLE
fix: fix slice init length

### DIFF
--- a/internal/runtime/storage.go
+++ b/internal/runtime/storage.go
@@ -201,7 +201,7 @@ func (s *StorageManager) ListNamespaces(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	res := make([]string, len(nsList.Items))
+	res := make([]string, 0, len(nsList.Items))
 	for _, ns := range nsList.Items {
 		res = append(res, ns.Name)
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of  `len(nsList.Items)`   rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW