### PR TITLE
Honor the log related cli parameters

### DIFF
--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -49,7 +49,7 @@ var rootCmd = &cobra.Command{
 		// a command only if one wasn't provided. This allows other
 		// callers (e.g. unit tests) to inject their own logger ahead of time.
 		if cliLogger.IsZero() {
-			cliLogger = logger.NewConsoleLogger(true, true)
+			cliLogger = logger.NewConsoleLogger(rootArgs.coloredLog, rootArgs.prettyLog)
 		}
 
 		// Inject the logger in the command context.


### PR DESCRIPTION
When `timoni` cli is used in automation, color formatting presents challenges in parsing the output.
Unfortunately, log parameters are ignored.

Currently when logger is initialized, the (true, true) pair as passed as parameters.
This results in following command line parameters being ignored:
- `--log-color`
- `--log-pretty`

This simple fix resolve logger initialization.

Fix: #436