### PR TITLE
Fix CLI autocompletion on ZSH when installed with Homebrew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,7 +69,7 @@ brews:
       bash_output = Utils.safe_popen_read(bin/"timoni", "completion", "bash")
       (bash_completion/"timoni").write bash_output
       zsh_output = Utils.safe_popen_read(bin/"timoni", "completion", "zsh")
-      (zsh_completion/"timoni").write zsh_output
+      (zsh_completion/"_timoni").write zsh_output
       fish_output = Utils.safe_popen_read(bin/"timoni", "completion", "fish")
       (fish_completion/"timoni.fish").write fish_output
     test: |


### PR DESCRIPTION
## Summary

Prior to this, when installing Timoni using Homebrew on a Mac with ZSH,
CLI autocompletion would not work.

After this change, CLI autocompletion works after installation or
reinstallation via Homebrew.

The problem is that the completion function that Homebrew wrote to
`/opt/homebrew/share/zsh/site-functions/` did not start with an
underscore, `_`.

By convention, completion function names (and the files containing them)
should start with an underscore followed by the name of the command they
provide completions for. When ZSH's completion system is initialized
(usually through the compinit function), it automatically looks for
files in the fpath directories that start with an underscore.

## Before this change

Autocompletion on MacOS with ZSH did not work:
![broken](https://github.com/user-attachments/assets/c9785f72-f57a-46bb-bf80-b4e7ceff53a6)

## After this change

Autocompletion on MacOS with ZSH works. To test this, I just renamed `/opt/homebrew/share/zsh/site-functions/timoni` to `/opt/homebrew/share/zsh/site-functions/_timoni` then opened a new shell.
![fixed](https://github.com/user-attachments/assets/18c5399b-cf7b-4f83-b5df-117c62eacaa3)
