### PR TITLE
Bumps CUE to version 0.11.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup CUE
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # main
         with:
-          version: v0.9.2
+          version: v0.11.0
       - name: Run tests
         run: make test
       - name: Run linter

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -35,7 +35,7 @@ import (
 
 var (
 	VERSION     = "0.0.0-dev.0"
-	CUE_VERSION = "0.9.2"
+	CUE_VERSION = "0.11.0"
 )
 
 var rootCmd = &cobra.Command{

--- a/internal/engine/importer_test.go
+++ b/internal/engine/importer_test.go
@@ -114,8 +114,8 @@ func TestConvertCRD(t *testing.T) {
 										metadata: {
 												type: "object"
 										}
-										spec: { 
-											%s 
+										spec: {
+											%s
 										}
 									}
 							}


### PR DESCRIPTION
Fixes #457. 

There was a lot of work done on the JSON Schema decoder in v0.11.0. The primary difference, in the case of Timoni, is that generated CRDs now properly use `!` where the spec marks a field as required. As a result, I had to update a few tests to reflect this change.

Other than that, all other tests passed.