### PR TITLE
Add TIMONI_CACHE_DIR variable as another method to set the cache location

### DIFF
--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -118,11 +118,17 @@ func setCacheDir() {
 		return
 	}
 	if rootArgs.cacheDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return
+		cacheDir := os.Getenv("TIMONI_CACHE_DIR")
+
+		if cacheDir == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return
+			}
+			rootArgs.cacheDir = path.Join(home, ".timoni/cache")
+		} else {
+			rootArgs.cacheDir = cacheDir
 		}
-		rootArgs.cacheDir = path.Join(home, ".timoni/cache")
 	}
 
 	if err := os.MkdirAll(rootArgs.cacheDir, os.ModePerm); err != nil {

--- a/docs/install.md
+++ b/docs/install.md
@@ -183,7 +183,9 @@ Timoni maintains a local cache of modules pulled from remote container registrie
 Cashing is meant to reduce network traffic for sequential pull operations and speeds up
 applying bundles which refer to modules with identical layers.
 
-The default cache location is `$HOME/.timoni/cache` and be changed with the `--cache-dir` global flag.
+The default cache location is `$HOME/.timoni/cache` and can be changed with either the
+`--cache-dir` global flag or `TIMONI_CACHE_DIR` environment variable. The global flag
+takes precedence over the environment variable.
 
 If the home directory is not writable, caching can be disabled by
 setting the `TIMONI_CACHING=false` environment variable.


### PR DESCRIPTION
This is useful in CI/CD environment, where one can set the variable globally to a custom location inside the project directory. The cache directory then can be cached as an artifact to be reused by later jobs.

This approach is cleaner than appending `--cache-dir` flag into every timoni command within the CI config file.