### PR TITLE
Update `cuelang.org/go` to v0.12.0

### DIFF
--- a/cmd/timoni/bundle_vet_test.go
+++ b/cmd/timoni/bundle_vet_test.go
@@ -257,14 +257,14 @@ bundle:
 			}
 			namespace: "podinfo"
 			values: {
+				autoscaling: {
+					enabled: true
+				}
 				caching: {
 					enabled:  true
 					redisURL: "tcp://:password@test.host:6379"
 				}
 				monitoring: {
-					enabled: true
-				}
-				autoscaling: {
 					enabled: true
 				}
 			}
@@ -362,11 +362,11 @@ runtime: {
 			}
 			namespace: "fleet-test"
 			values: {
-				message:  "Hello from cluster staging"
-				replicas: 2
+				message: "Hello from cluster staging"
 				test: {
 					enabled: true
 				}
+				replicas: 2
 			}
 		}
 	}
@@ -382,11 +382,11 @@ runtime: {
 			}
 			namespace: "fleet-test"
 			values: {
-				message:  "Hello from cluster production"
-				replicas: 3
+				message: "Hello from cluster production"
 				test: {
 					enabled: true
 				}
+				replicas: 3
 			}
 		}
 	}

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -35,7 +35,7 @@ import (
 
 var (
 	VERSION     = "0.0.0-dev.0"
-	CUE_VERSION = "0.11.0"
+	CUE_VERSION = "0.12.0"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/timoni/testdata/crd/golden/cue.mod/gen/acme.cert-manager.io/challenge/v1/types_gen.cue
+++ b/cmd/timoni/testdata/crd/golden/cue.mod/gen/acme.cert-manager.io/challenge/v1/types_gen.cue
@@ -408,14 +408,18 @@ import "strings"
 					// group (such as for a "Service" kind referent), Group must be
 					// explicitly set to "" (empty string).
 					// Support: Core
-					group?: strings.MaxRunes(253) & =~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" | *"gateway.networking.k8s.io"
+					group?: strings.MaxRunes(253) & {
+						=~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+					}
 
 					// Kind is kind of the referent.
 					// There are two kinds of parent resources with "Core" support:
 					// * Gateway (Gateway conformance profile) * Service (Mesh
 					// conformance profile, experimental, ClusterIP Services only)
 					// Support for other resources is Implementation-Specific.
-					kind?: strings.MaxRunes(63) & strings.MinRunes(1) & =~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$" | *"Gateway"
+					kind?: strings.MaxRunes(63) & strings.MinRunes(1) & {
+						=~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+					}
 
 					// Name is the name of the referent.
 					// Support: Core

--- a/cmd/timoni/testdata/crd/golden/cue.mod/gen/cert-manager.io/clusterissuer/v1/types_gen.cue
+++ b/cmd/timoni/testdata/crd/golden/cue.mod/gen/cert-manager.io/clusterissuer/v1/types_gen.cue
@@ -492,14 +492,18 @@ import "strings"
 						// group (such as for a "Service" kind referent), Group must be
 						// explicitly set to "" (empty string).
 						// Support: Core
-						group?: strings.MaxRunes(253) & =~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" | *"gateway.networking.k8s.io"
+						group?: strings.MaxRunes(253) & {
+							=~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+						}
 
 						// Kind is kind of the referent.
 						// There are two kinds of parent resources with "Core" support:
 						// * Gateway (Gateway conformance profile) * Service (Mesh
 						// conformance profile, experimental, ClusterIP Services only)
 						// Support for other resources is Implementation-Specific.
-						kind?: strings.MaxRunes(63) & strings.MinRunes(1) & =~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$" | *"Gateway"
+						kind?: strings.MaxRunes(63) & strings.MinRunes(1) & {
+							=~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+						}
 
 						// Name is the name of the referent.
 						// Support: Core

--- a/cmd/timoni/testdata/crd/golden/cue.mod/gen/cert-manager.io/issuer/v1/types_gen.cue
+++ b/cmd/timoni/testdata/crd/golden/cue.mod/gen/cert-manager.io/issuer/v1/types_gen.cue
@@ -491,14 +491,18 @@ import "strings"
 						// group (such as for a "Service" kind referent), Group must be
 						// explicitly set to "" (empty string).
 						// Support: Core
-						group?: strings.MaxRunes(253) & =~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" | *"gateway.networking.k8s.io"
+						group?: strings.MaxRunes(253) & {
+							=~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+						}
 
 						// Kind is kind of the referent.
 						// There are two kinds of parent resources with "Core" support:
 						// * Gateway (Gateway conformance profile) * Service (Mesh
 						// conformance profile, experimental, ClusterIP Services only)
 						// Support for other resources is Implementation-Specific.
-						kind?: strings.MaxRunes(63) & strings.MinRunes(1) & =~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$" | *"Gateway"
+						kind?: strings.MaxRunes(63) & strings.MinRunes(1) & {
+							=~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+						}
 
 						// Name is the name of the referent.
 						// Support: Core

--- a/cmd/timoni/testdata/crd/golden/cue.mod/gen/flagger.app/canary/v1beta1/types_gen.cue
+++ b/cmd/timoni/testdata/crd/golden/cue.mod/gen/flagger.app/canary/v1beta1/types_gen.cue
@@ -201,7 +201,7 @@ import (
 
 			// MaxAge indicates the number of seconds until the session
 			// affinity cookie will expire.
-			maxAge?: number | *86400
+			maxAge?: number
 		}
 
 		// Incremental traffic step weight for the analysis phase
@@ -343,9 +343,13 @@ import (
 
 		// The list of parent Gateways for a HTTPRoute
 		gatewayRefs?: list.MaxItems(32) & [...{
-			group?: strings.MaxRunes(253) & =~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" | *"gateway.networking.k8s.io"
-			kind?:  strings.MaxRunes(63) & strings.MinRunes(1) & =~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$" | *"Gateway"
-			name!:  strings.MaxRunes(253) & strings.MinRunes(1)
+			group?: strings.MaxRunes(253) & {
+				=~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+			}
+			kind?: strings.MaxRunes(63) & strings.MinRunes(1) & {
+				=~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+			}
+			name!: strings.MaxRunes(253) & strings.MinRunes(1)
 			namespace?: strings.MaxRunes(63) & strings.MinRunes(1) & {
 				=~"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
 			}
@@ -564,9 +568,13 @@ import (
 		// Mirror defines a schema for a filter that mirrors requests.
 		mirror?: [...{
 			backendRef?: {
-				group?: strings.MaxRunes(253) & =~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" | *""
-				kind?:  strings.MaxRunes(63) & strings.MinRunes(1) & =~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$" | *"Service"
-				name!:  strings.MaxRunes(253) & strings.MinRunes(1)
+				group?: strings.MaxRunes(253) & {
+					=~"^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+				}
+				kind?: strings.MaxRunes(63) & strings.MinRunes(1) & {
+					=~"^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+				}
+				name!: strings.MaxRunes(253) & strings.MinRunes(1)
 				namespace?: strings.MaxRunes(63) & strings.MinRunes(1) & {
 					=~"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
 				}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/stefanprodan/timoni
 go 1.23.0
 
 require (
-	cuelang.org/go v0.11.0
+	cuelang.org/go v0.12.0
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/briandowns/spinner v1.23.2
 	github.com/distribution/distribution/v3 v3.0.0-rc.2
@@ -38,7 +38,7 @@ require (
 )
 
 require (
-	cuelabs.dev/go/oci/ociregistry v0.0.0-20240906074133-82eb438dd565 // indirect
+	cuelabs.dev/go/oci/ociregistry v0.0.0-20241125120445-2c00c104c6e1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
@@ -62,7 +62,7 @@ require (
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
-	github.com/emicklei/proto v1.13.2 // indirect
+	github.com/emicklei/proto v1.13.4 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -131,12 +131,12 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/protocolbuffers/txtpbfmt v0.0.0-20240823084532-8e6b51fa9bef // indirect
+	github.com/protocolbuffers/txtpbfmt v0.0.0-20241112170944-20d2c9ebc01d // indirect
 	github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5 // indirect
 	github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 // indirect
 	github.com/redis/go-redis/v9 v9.1.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/rogpeppe/go-internal v1.13.1 // indirect
+	github.com/rogpeppe/go-internal v1.13.2-0.20241226121412-a5dc8ff20d0a // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-cuelabs.dev/go/oci/ociregistry v0.0.0-20240906074133-82eb438dd565 h1:R5wwEcbEZSBmeyg91MJZTxfd7WpBo2jPof3AYjRbxwY=
-cuelabs.dev/go/oci/ociregistry v0.0.0-20240906074133-82eb438dd565/go.mod h1:5A4xfTzHTXfeVJBU6RAUf+QrlfTCW+017q/QiW+sMLg=
-cuelang.org/go v0.11.0 h1:2af2nhipqlUHtXk2dtOP5xnMm1ObGvKqIsJUJL1sRE4=
-cuelang.org/go v0.11.0/go.mod h1:PBY6XvPUswPPJ2inpvUozP9mebDVTXaeehQikhZPBz0=
+cuelabs.dev/go/oci/ociregistry v0.0.0-20241125120445-2c00c104c6e1 h1:mRwydyTyhtRX2wXS3mqYWzR2qlv6KsmoKXmlz5vInjg=
+cuelabs.dev/go/oci/ociregistry v0.0.0-20241125120445-2c00c104c6e1/go.mod h1:5A4xfTzHTXfeVJBU6RAUf+QrlfTCW+017q/QiW+sMLg=
+cuelang.org/go v0.12.0 h1:q4W5I+RtDIA27rslQyyt6sWkXX0YS9qm43+U1/3e0kU=
+cuelang.org/go v0.12.0/go.mod h1:B4+kjvGGQnbkz+GuAv1dq/R308gTkp0sO28FdMrJ2Kw=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
@@ -71,8 +71,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/emicklei/proto v1.13.2 h1:z/etSFO3uyXeuEsVPzfl56WNgzcvIr42aQazXaQmFZY=
-github.com/emicklei/proto v1.13.2/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
+github.com/emicklei/proto v1.13.4 h1:myn1fyf8t7tAqIzV91Tj9qXpvyXXGXk8OS2H6IBSc9g=
+github.com/emicklei/proto v1.13.4/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ2tG6yudJd8LBksgI=
 github.com/evanphx/json-patch v5.7.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
@@ -312,8 +312,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/protocolbuffers/txtpbfmt v0.0.0-20240823084532-8e6b51fa9bef h1:ej+64jiny5VETZTqcc1GFVAPEtaSk6U1D0kKC2MS5Yc=
-github.com/protocolbuffers/txtpbfmt v0.0.0-20240823084532-8e6b51fa9bef/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20241112170944-20d2c9ebc01d h1:HWfigq7lB31IeJL8iy7jkUmU/PG1Sr8jVGhS749dbUA=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20241112170944-20d2c9ebc01d/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5 h1:EaDatTxkdHG+U3Bk4EUr+DZ7fOGwTfezUiUJMaIcaho=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5/go.mod h1:fyalQWdtzDBECAQFBJuQe5bzQ02jGd5Qcbgb97Flm7U=
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb27yVE+gIAfeqp8LUCc=
@@ -324,8 +324,8 @@ github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
-github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/rogpeppe/go-internal v1.13.2-0.20241226121412-a5dc8ff20d0a h1:w3tdWGKbLGBPtR/8/oO74W6hmz0qE5q0z9aqSAewaaM=
+github.com/rogpeppe/go-internal v1.13.2-0.20241226121412-a5dc8ff20d0a/go.mod h1:S8kfXMp+yh77OxPD4fdM6YUknrZpQxLhvxzS4gDHENY=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/internal/engine/testdata/module-golden/overlay.cue
+++ b/internal/engine/testdata/module-golden/overlay.cue
@@ -7,7 +7,7 @@ objects: [{
 	}
 	data: {
 		url:           "https://test.internal"
-		kubeVersion:   "1.25.3"
 		moduleVersion: "0.0.0-devel"
+		kubeVersion:   "1.25.3"
 	}
 }]

--- a/internal/engine/testdata/values/golden.cue
+++ b/internal/engine/testdata/values/golden.cue
@@ -1,14 +1,14 @@
 values: {
 	securityContext: {
-		seccompProfile: {
-			type: "RuntimeDefault"
-		}
-		readOnlyRootFilesystem:   false
 		allowPrivilegeEscalation: false
-		runAsNonRoot:             true
 		capabilities: {
 			add: ["NET_BIND_SERVICE"]
 			drop: ["ALL"]
+		}
+		readOnlyRootFilesystem: false
+		runAsNonRoot:           true
+		seccompProfile: {
+			type: "RuntimeDefault"
 		}
 	}
 	resources: {


### PR DESCRIPTION
Update CUE to v0.12.0 and adapt tests to the new format.