### PR TITLE
fix: use `list.Concat()` to concatenate lists

### DIFF
--- a/examples/minimal/debug_tool.cue
+++ b/examples/minimal/debug_tool.cue
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"list"
 	"tool/cli"
 	"encoding/yaml"
 	"text/tabwriter"
 )
 
-_resources: timoni.apply.app + timoni.apply.test
+_resources: list.Concat([timoni.apply.app, timoni.apply.test])
 
 // The build command generates the Kubernetes manifests and prints the multi-docs YAML to stdout.
 // Example 'cue cmd -t debug -t name=test -t namespace=test -t mv=1.0.0 -t kv=1.28.0 build'.

--- a/examples/redis/debug_tool.cue
+++ b/examples/redis/debug_tool.cue
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"list"
 	"tool/cli"
 	"encoding/yaml"
 	"text/tabwriter"
 )
 
-_resources: timoni.apply.master + timoni.apply.replica + timoni.apply.test
+_resources: list.Concat([timoni.apply.master, timoni.apply.replica, timoni.apply.test])
 
 // The build command generates the Kubernetes manifests and prints the multi-docs YAML to stdout.
 // Example 'cue cmd -t debug -t name=redis -t namespace=test -t mv=1.0.0 -t kv=1.28.0 build'.


### PR DESCRIPTION
cue v0.11 removed support for using the + and * operators on lists, causing the `cue cmd` flags listed in the doc strings to fail. Update the examples to use `list.Concat()` instead.