### PR TITLE
Expose Bundle, Runtime and Instance CUE schemas

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 examples/**/templates/*.cue -linguist-documentation
 examples/bundles -linguist-documentation
 blueprints/**/cue.mod/** linguist-vendored
+
+# Pin CUE schemas to LF so embedded files parse consistently across platforms.
+*.cue text eol=lf

--- a/api/v1alpha1/bundle.go
+++ b/api/v1alpha1/bundle.go
@@ -47,28 +47,6 @@ const (
 	BundleNameLabelKey = "bundle.timoni.sh/name"
 )
 
-// BundleSchema defines the v1alpha1 CUE schema for Timoni's bundle API.
-// TODO: switch to go:embed when this is available https://github.com/cue-lang/cue/issues/607
-const BundleSchema = `
-import "strings"
-
-#Bundle: {
-	apiVersion: string & =~"^v1alpha1$"
-	name:       string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
-	instances: [string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
-		module: close({
-			url:     string & =~"^(oci|file)://.*$"
-			version: *"latest" | string
-			digest?: string
-		})
-		namespace: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
-		values: {...}
-	}
-}
-
-bundle: #Bundle
-`
-
 // Bundle holds the information about the bundle name and the list of instances.
 // +k8s:deepcopy-gen=false
 type Bundle struct {

--- a/api/v1alpha1/instance.go
+++ b/api/v1alpha1/instance.go
@@ -35,18 +35,6 @@ const (
 	ValuesSelector Selector = "values"
 )
 
-// InstanceSchema defines the v1alpha1 CUE schema for Timoni's instance API.
-const InstanceSchema = `
-#Timoni: {
-	apiVersion: string & =~"^v1alpha1$"
-	instance: {...}
-	apply: [string]: [...]
-	kubeMinorVersion?: int
-}
-
-timoni: #Timoni
-`
-
 // Instance holds the information about the module, values
 // and the list of the managed Kubernetes resources.
 type Instance struct {

--- a/api/v1alpha1/runtime.go
+++ b/api/v1alpha1/runtime.go
@@ -46,29 +46,6 @@ const (
 	RuntimeValuesSelector Selector = "runtime.values"
 )
 
-// RuntimeSchema defines the v1alpha1 CUE schema for Timoni's runtime API.
-const RuntimeSchema = `
-import "strings"
-
-#RuntimeValue: {
-	query: string
-	for: {[string & =~"^(([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: string}
-	optional: *false | bool
-}
-
-#Runtime: {
-	apiVersion: string & =~"^v1alpha1$"
-	name:       string & =~"^(([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
-
-	clusters?: [string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
-		group!:       string
-		kubeContext!: string
-	}
-	
-	values?: [...#RuntimeValue]
-}
-`
-
 // RuntimeAttribute holds the runtime var name and type.
 type RuntimeAttribute struct {
 	Name string

--- a/api/v1alpha1/schema.go
+++ b/api/v1alpha1/schema.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/stefanprodan/timoni/schemas"
+)
+
+// pkgClauseRegex matches the 'package v1alpha1' clause line.
+var pkgClauseRegex = regexp.MustCompile(`(?m)^package ` + schemaPackage + `\b.*\n`)
+
+// The Timoni CUE schemas are defined once under
+// schemas/timoni.sh/core/v1alpha1 where they are published as the
+// importable 'timoni.sh/core/v1alpha1' package. The schema strings
+// below are derived from those embedded files at startup, so that
+// the Go API and the CUE package never drift apart.
+
+var (
+	// BundleSchema defines the v1alpha1 CUE schema for Timoni's bundle API.
+	BundleSchema = mustInlineSchema("bundle.cue", "bundle: #Bundle")
+
+	// RuntimeSchema defines the v1alpha1 CUE schema for Timoni's runtime API.
+	RuntimeSchema = mustInlineSchema("runtime.cue", "")
+
+	// InstanceSchema defines the v1alpha1 CUE schema for Timoni's instance API.
+	InstanceSchema = mustInlineSchema("timoni.cue", "timoni: #Timoni")
+)
+
+// mustInlineSchema reads an embedded core schema file and returns its
+// content as an anonymous-package CUE snippet: the 'package v1alpha1'
+// clause is stripped so the definitions can be loaded into Timoni's
+// internal '_' package, and the given root binding is appended when set.
+func mustInlineSchema(file, binding string) string {
+	data, err := schemas.FS.ReadFile(schemaDir + "/" + file)
+	if err != nil {
+		panic(fmt.Sprintf("failed to load schema %s: %v", file, err))
+	}
+
+	content := string(data)
+	loc := pkgClauseRegex.FindStringIndex(content)
+	if loc == nil {
+		panic(fmt.Sprintf("schema %s: missing 'package %s' clause", file, schemaPackage))
+	}
+
+	schema := content[loc[1]:]
+	if binding != "" {
+		schema += "\n" + binding + "\n"
+	}
+	return schema
+}
+
+const (
+	// schemaPackage is the CUE package name of the published schemas.
+	schemaPackage = "v1alpha1"
+
+	// schemaDir is the embedded path of the published schemas.
+	schemaDir = "timoni.sh/core/v1alpha1"
+)

--- a/api/v1alpha1/schema_test.go
+++ b/api/v1alpha1/schema_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+)
+
+// TestSchemas verifies that the schema strings derived from the embedded
+// timoni.sh/core/v1alpha1 CUE files are loaded as anonymous-package
+// snippets (no leftover package clause), expose their root definition,
+// carry the expected root binding, and compile.
+func TestSchemas(t *testing.T) {
+	tests := []struct {
+		name    string
+		schema  string
+		def     string
+		binding string
+	}{
+		{"bundle", BundleSchema, "#Bundle", "bundle: #Bundle"},
+		{"runtime", RuntimeSchema, "#Runtime", ""},
+		{"instance", InstanceSchema, "#Timoni", "timoni: #Timoni"},
+	}
+
+	ctx := cuecontext.New()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.schema == "" {
+				t.Fatal("schema is empty")
+			}
+			if strings.Contains(tt.schema, "package "+schemaPackage) {
+				t.Errorf("schema still contains the %q clause", "package "+schemaPackage)
+			}
+			if !strings.Contains(tt.schema, tt.def) {
+				t.Errorf("schema does not define %s", tt.def)
+			}
+			if tt.binding != "" && !strings.Contains(tt.schema, tt.binding) {
+				t.Errorf("schema does not bind %q", tt.binding)
+			}
+			if v := ctx.CompileString(tt.schema); v.Err() != nil {
+				t.Errorf("schema does not compile: %v", v.Err())
+			}
+		})
+	}
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -49,6 +49,20 @@ The Timoni's CUE schemas are included in the modules generated with `timoni mod 
 - `#SemVer` - Schema for validating semantic versions and enforcing
   a minimum major and/or minor version.
 
+### Timoni API
+
+These schemas describe Timoni's own APIs and are the single source of truth
+used by the `timoni` CLI to validate bundles, runtimes and instances.
+They are exposed here so that they can be imported and reused in CUE projects.
+
+- `#Bundle` - Schema for validating a Timoni [Bundle](https://timoni.sh/bundle/),
+  i.e. the set of instances applied to a cluster.
+- `#Runtime` - Schema for validating a Timoni [Runtime](https://timoni.sh/bundle-runtime/),
+  i.e. the target clusters and the values fetched from their resources.
+- `#RuntimeValue` - Schema for a single Runtime value query.
+- `#Timoni` - Schema for a module's instance, holding the instance
+  configuration and the Kubernetes resources to apply.
+
 ## Vendoring
 
 To update a module's schemas to the latest version,

--- a/schemas/embed.go
+++ b/schemas/embed.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package schemas embeds the Timoni CUE schemas so that they can be
+// consumed by the Go API as the single source of truth, while also
+// being published as the importable 'timoni.sh/core/v1alpha1' package.
+package schemas
+
+import "embed"
+
+// FS embeds the published Timoni CUE schema tree (all API groups and
+// versions under timoni.sh/). Consumers read their own subpath, e.g.
+// "timoni.sh/core/v1alpha1/bundle.cue".
+//
+//go:embed timoni.sh
+var FS embed.FS

--- a/schemas/timoni.sh/core/v1alpha1/bundle.cue
+++ b/schemas/timoni.sh/core/v1alpha1/bundle.cue
@@ -1,0 +1,22 @@
+// Copyright 2026 Stefan Prodan
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import "strings"
+
+// Bundle defines the schema for a Timoni bundle that describes
+// a set of instances to be applied to a cluster.
+#Bundle: {
+	apiVersion: string & =~"^v1alpha1$"
+	name:       string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
+	instances: [string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
+		module: close({
+			url:     string & =~"^(oci|file)://.*$"
+			version: *"latest" | string
+			digest?: string
+		})
+		namespace: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
+		values: {...}
+	}
+}

--- a/schemas/timoni.sh/core/v1alpha1/runtime.cue
+++ b/schemas/timoni.sh/core/v1alpha1/runtime.cue
@@ -1,0 +1,28 @@
+// Copyright 2026 Stefan Prodan
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import "strings"
+
+// RuntimeValue defines the schema for a Timoni runtime value
+// fetched from the in-cluster Kubernetes resources.
+#RuntimeValue: {
+	query: string
+	for: {[string & =~"^(([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: string}
+	optional: *false | bool
+}
+
+// Runtime defines the schema for a Timoni runtime that describes
+// the target clusters and the values fetched from their resources.
+#Runtime: {
+	apiVersion: string & =~"^v1alpha1$"
+	name:       string & =~"^(([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
+
+	clusters?: [string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
+		group!:       string
+		kubeContext!: string
+	}
+
+	values?: [...#RuntimeValue]
+}

--- a/schemas/timoni.sh/core/v1alpha1/timoni.cue
+++ b/schemas/timoni.sh/core/v1alpha1/timoni.cue
@@ -1,0 +1,13 @@
+// Copyright 2026 Stefan Prodan
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+// Timoni defines the schema for a module's instance, holding the
+// instance configuration and the Kubernetes resources to apply.
+#Timoni: {
+	apiVersion: string & =~"^v1alpha1$"
+	instance: {...}
+	apply: [string]: [...]
+	kubeMinorVersion?: int
+}


### PR DESCRIPTION
Define Timoni's Bundle, Runtime and Instance schemas as first-class .cue files under `schemas/timoni.sh/core/v1alpha1` so they can be imported and reused from CUE projects, instead of living only as Go string constants.

The schemas package embeds the `timoni.sh` tree and the `api/v1alpha1` package derives the inline BundleSchema/RuntimeSchema/InstanceSchema strings from the embedded files, making the .cue files the single source of truth shared by the CLI and the published schemas artifact.

Closes #513