### PR TITLE
Restrict instance and runtime names to lowercase

### DIFF
--- a/cmd/timoni/bundle_build_test.go
+++ b/cmd/timoni/bundle_build_test.go
@@ -278,3 +278,60 @@ func getObjectByName(objs []*unstructured.Unstructured, name string) (*unstructu
 	}
 	return nil, fmt.Errorf("object with name '%s' does not exist", name)
 }
+
+func Test_BundleBuild_RejectsUppercaseNames(t *testing.T) {
+	// Each bundle is valid except for a single uppercase identifier, so the
+	// only reason the build can fail is the rejected name.
+	tests := map[string]string{
+		"uppercase instance name": `
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "my-bundle"
+	instances: {
+		"Frontend": {
+			module: url: "file://testdata/module"
+			namespace: "apps"
+			values: team: "test"
+		}
+	}
+}`,
+		"uppercase namespace": `
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "my-bundle"
+	instances: {
+		"frontend": {
+			module: url: "file://testdata/module"
+			namespace: "Apps"
+			values: team: "test"
+		}
+	}
+}`,
+		"uppercase bundle name": `
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "My-Bundle"
+	instances: {
+		"frontend": {
+			module: url: "file://testdata/module"
+			namespace: "apps"
+			values: team: "test"
+		}
+	}
+}`,
+	}
+
+	for name, bundleCue := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			wd := t.TempDir()
+			cuePath := filepath.Join(wd, "bundle.cue")
+			g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
+			g.Expect(engine.CopyModule("testdata/module", filepath.Join(wd, "testdata/module"))).ToNot(HaveOccurred())
+
+			_, err := executeCommand(fmt.Sprintf("bundle build -f %s -p main", cuePath))
+			g.Expect(err).To(HaveOccurred())
+		})
+	}
+}

--- a/docs/bundle-runtime.md
+++ b/docs/bundle-runtime.md
@@ -159,12 +159,18 @@ Currently, the only supported value is `v1alpha1`.
 
 The `name` is a required field used to identify the Runtime.
 
+The name must be a lowercase identifier (alphanumeric characters, `-` and `_`,
+starting and ending with an alphanumeric character) of at most 63 characters.
+
 ### Clusters
 
 The `clusters` field is for defining the target clusters and
 environments (group of clusters) where a Bundle is applied.
 
 A cluster entry must specify the `group` and `kubeContext` fields.
+The cluster name (the `clusters` map key) must be a lowercase identifier
+(alphanumeric characters, `-`, `_` and `.`, starting and ending with an
+alphanumeric character) of at most 63 characters.
 The `kubeContext` value must match a context name from the `.kube/config` file.
 
 !!! tip "Default cluster"

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -213,12 +213,19 @@ Currently, the only supported value is `v1alpha1`.
 
 The `name` is a required field used to track the ownership of instances deployed to a Kubernetes cluster.
 
+The name must be a lowercase identifier (alphanumeric characters, `-`, `_` and `.`,
+starting and ending with an alphanumeric character) of at most 63 characters.
+
 Note that Bundles should have unique names per cluster, using the same name for different bundles
 will result in [ownership conflict](#transfer-ownership).
 
 ### Instances
 
 The `instances` array is a required field that specifies the list of Instances part of this Bundle.
+
+Each instance name (the `instances` map key) must be a lowercase identifier
+(alphanumeric characters, `-`, `_` and `.`, starting and ending with an alphanumeric
+character) of at most 63 characters, as it is used to name the instance's Kubernetes resources.
 
 A Bundle must contain at least one instance with the following required fields:
 
@@ -299,6 +306,9 @@ and will pull the module by its OCI digest.
 ### Instance Namespace
 
 The `instance.namespace` is a required field that specifies the Kubernetes namespace where the instance is created.
+
+The namespace must be a lowercase identifier (alphanumeric characters, `-`, `_` and `.`,
+starting and ending with an alphanumeric character) of at most 63 characters.
 
 If the specified namespace does not exist, Timoni will first create the namespace,
 then it will apply the instance's resources in that namespace.

--- a/schemas/timoni.sh/core/v1alpha1/bundle.cue
+++ b/schemas/timoni.sh/core/v1alpha1/bundle.cue
@@ -9,14 +9,14 @@ import "strings"
 // a set of instances to be applied to a cluster.
 #Bundle: {
 	apiVersion: string & =~"^v1alpha1$"
-	name:       string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
-	instances: [string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
+	name:       string & =~"^(([a-z0-9][-a-z0-9_.]*)?[a-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
+	instances: [string & =~"^(([a-z0-9][-a-z0-9_.]*)?[a-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
 		module: close({
 			url:     string & =~"^(oci|file)://.*$"
 			version: *"latest" | string
 			digest?: string
 		})
-		namespace: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
+		namespace: string & =~"^(([a-z0-9][-a-z0-9_.]*)?[a-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
 		values: {...}
 	}
 }

--- a/schemas/timoni.sh/core/v1alpha1/instance.cue
+++ b/schemas/timoni.sh/core/v1alpha1/instance.cue
@@ -6,12 +6,14 @@ package v1alpha1
 import "strings"
 
 // InstanceName defines the schema for the name of a Timoni instance.
-// The instance name is used as a Kubernetes label value and must be 63 characters or less.
-#InstanceName: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MinRunes(1) & strings.MaxRunes(63)
+// The instance name is used to name Kubernetes resources and as a label value,
+// so it must be lowercase and 63 characters or less.
+#InstanceName: string & =~"^(([a-z0-9][-a-z0-9_.]*)?[a-z0-9])?$" & strings.MinRunes(1) & strings.MaxRunes(63)
 
 // InstanceNamespace defines the schema for the namespace of a Timoni instance.
-// The instance namespace is used as a Kubernetes label value and must be 63 characters or less.
-#InstanceNamespace: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MinRunes(1) & strings.MaxRunes(63)
+// The instance namespace is used as a Kubernetes namespace and label value,
+// so it must be lowercase and 63 characters or less.
+#InstanceNamespace: string & =~"^(([a-z0-9][-a-z0-9_.]*)?[a-z0-9])?$" & strings.MinRunes(1) & strings.MaxRunes(63)
 
 // InstanceOwnerReference defines the schema for Kubernetes labels used to denote ownership.
 #InstanceOwnerReference: {

--- a/schemas/timoni.sh/core/v1alpha1/runtime.cue
+++ b/schemas/timoni.sh/core/v1alpha1/runtime.cue
@@ -17,9 +17,9 @@ import "strings"
 // the target clusters and the values fetched from their resources.
 #Runtime: {
 	apiVersion: string & =~"^v1alpha1$"
-	name:       string & =~"^(([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
+	name:       string & =~"^(([a-z0-9][-a-z0-9_]*)?[a-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)
 
-	clusters?: [string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
+	clusters?: [string & =~"^(([a-z0-9][-a-z0-9_.]*)?[a-z0-9])?$" & strings.MaxRunes(63) & strings.MinRunes(1)]: {
 		group!:       string
 		kubeContext!: string
 	}


### PR DESCRIPTION
Tighten the v1alpha1 schema so that bundle names, instance names, instance namespaces, runtime names and cluster names must be lowercase (alphanumeric, '-', '_' and '.', starting and ending with an alphanumeric character, max 63 characters).

These identifiers are used to name Kubernetes resources and Timoni's inventory storage Secret, which the API server rejects when they contain uppercase characters. 