### PR TITLE
Add `bundle build --output-dir` for manifests export

### DIFF
--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -45,20 +46,25 @@ var bundleBuildCmd = &cobra.Command{
 	Short:   "Build and print the resulting Kubernetes resources for all instances from a Bundle",
 	Long: `The bundle build command builds and prints the resulting Kubernetes resources for all instances defined in a Bundle.
 `,
-	Example: `  # Build all instances from a bundle
+	Example: `  # Build all instances from a bundle and print the manifests to stdout
   timoni bundle build -f bundle.cue
 
   # Pass secret values from stdin
   cat ./bundle_secrets.cue | timoni bundle build -f ./bundle.cue -f -
+
+  # Write the manifests as a directory tree, one directory per instance
+  # and one file per resource, named like 'kustomize build -o <dir>'
+  timoni bundle build -f bundle.cue --output-dir ./manifests
 `,
 	Args: cobra.NoArgs,
 	RunE: runBundleBuildCmd,
 }
 
 type bundleBuildFlags struct {
-	pkg   flags.Package
-	files []string
-	creds flags.Credentials
+	pkg       flags.Package
+	files     []string
+	creds     flags.Credentials
+	outputDir string
 }
 
 var bundleBuildArgs bundleBuildFlags
@@ -68,6 +74,8 @@ func init() {
 	bundleBuildCmd.Flags().StringSliceVarP(&bundleBuildArgs.files, "file", "f", nil,
 		"The local path to bundle.cue files.")
 	bundleBuildCmd.Flags().Var(&bundleBuildArgs.creds, bundleBuildArgs.creds.Type(), bundleBuildArgs.creds.Description())
+	bundleBuildCmd.Flags().StringVar(&bundleBuildArgs.outputDir, "output-dir", "",
+		"The path to a directory where the manifests are written as a tree, one directory per instance and one file per resource.")
 	bundleCmd.AddCommand(bundleBuildCmd)
 }
 
@@ -155,8 +163,6 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	var sb strings.Builder
-
 	ctxPull, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
@@ -166,17 +172,26 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	for i, instance := range bundle.Instances {
-		sb.WriteString("---\n")
-		sb.WriteString(fmt.Sprintf("# Instance: %s\n", instance.Name))
-		sb.WriteString("---\n")
+	if bundleBuildArgs.outputDir != "" {
+		return writeBundleInstancesToDir(cmd, ctx, bundle.Instances, tmpDir)
+	}
 
-		instance, err := buildBundleInstance(ctx, instance, tmpDir)
+	var sb strings.Builder
+	for i, instance := range bundle.Instances {
+		objects, err := buildBundleInstanceObjects(ctx, instance, tmpDir)
 		if err != nil {
 			return err
 		}
 
-		sb.WriteString(instance)
+		manifests, err := marshalObjectsToYAML(objects)
+		if err != nil {
+			return err
+		}
+
+		sb.WriteString("---\n")
+		sb.WriteString(fmt.Sprintf("# Instance: %s\n", instance.Name))
+		sb.WriteString("---\n")
+		sb.WriteString(manifests)
 		if i < len(bundle.Instances)-1 {
 			sb.WriteString("\n")
 		}
@@ -187,7 +202,90 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func buildBundleInstance(cuectx *cue.Context, instance *apiv1.BundleInstance, rootDir string) (string, error) {
+// writeBundleInstancesToDir writes the resources of each instance to the
+// output directory as a tree: one directory per instance and one file per
+// resource, named with the same convention as 'kustomize build -o <dir>'.
+func writeBundleInstancesToDir(cmd *cobra.Command, cuectx *cue.Context, instances []*apiv1.BundleInstance, rootDir string) error {
+	outputDir := bundleBuildArgs.outputDir
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	log := LoggerFrom(cmd.Context())
+	for _, instance := range instances {
+		objects, err := buildBundleInstanceObjects(cuectx, instance, rootDir)
+		if err != nil {
+			return err
+		}
+
+		instanceDir := filepath.Join(outputDir, instance.Name)
+		if err := os.MkdirAll(instanceDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create instance directory: %w", err)
+		}
+
+		// Prefix the file names with the namespace only when the instance's
+		// namespaced resources span more than one namespace, matching the
+		// behaviour of kustomize.
+		//
+		// The resource scope is approximated by the presence of
+		// metadata.namespace rather than the true cluster/namespaced scope
+		// (kustomize resolves this from type info). A cluster-scoped object
+		// that carries a stray namespace is therefore counted here and can
+		// enable the prefix for the whole instance. This is acceptable for
+		// Timoni's offline builds, where no REST mapper is available to
+		// resolve resource scopes.
+		namespaces := make(map[string]struct{})
+		for _, obj := range objects {
+			if ns := obj.GetNamespace(); ns != "" {
+				namespaces[ns] = struct{}{}
+			}
+		}
+		withNamespace := len(namespaces) > 1
+
+		for _, obj := range objects {
+			data, err := yaml.Marshal(obj)
+			if err != nil {
+				return fmt.Errorf("converting objects failed: %w", err)
+			}
+
+			fileName := resourceFileName(obj, withNamespace && obj.GetNamespace() != "")
+			if err := os.WriteFile(filepath.Join(instanceDir, fileName), data, 0o644); err != nil {
+				return fmt.Errorf("failed to write manifest: %w", err)
+			}
+		}
+
+		log.Info(fmt.Sprintf("exported %d resources to %s", len(objects), instanceDir))
+	}
+
+	return nil
+}
+
+// resourceFileName returns the manifest file name for an object using the
+// same convention as 'kustomize build -o <dir>':
+// '<group>_<version>_<kind>_<name>.yaml', lowercased, with empty GVK fields
+// omitted and an optional '<namespace>_' prefix.
+func resourceFileName(obj *unstructured.Unstructured, withNamespace bool) string {
+	gvk := obj.GroupVersionKind()
+
+	parts := make([]string, 0, 3)
+	if gvk.Group != "" {
+		parts = append(parts, gvk.Group)
+	}
+	if gvk.Version != "" {
+		parts = append(parts, gvk.Version)
+	}
+	parts = append(parts, gvk.Kind)
+
+	fileName := strings.ToLower(strings.Join(parts, "_")) + "_" + strings.ToLower(obj.GetName()) + ".yaml"
+	if withNamespace {
+		fileName = strings.ToLower(obj.GetNamespace()) + "_" + fileName
+	}
+	return fileName
+}
+
+// buildBundleInstanceObjects builds an instance and returns its sorted
+// Kubernetes objects.
+func buildBundleInstanceObjects(cuectx *cue.Context, instance *apiv1.BundleInstance, rootDir string) ([]*unstructured.Unstructured, error) {
 	modDir := path.Join(rootDir, instance.Name, "module")
 
 	builder := engine.NewModuleBuilder(
@@ -199,30 +297,29 @@ func buildBundleInstance(cuectx *cue.Context, instance *apiv1.BundleInstance, ro
 	)
 
 	if err := builder.WriteSchemaFile(); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	modName, err := builder.GetModuleName()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	instance.Module.Name = modName
 
-	err = builder.WriteValuesFileWithDefaults(instance.Values)
-	if err != nil {
-		return "", err
+	if err := builder.WriteValuesFileWithDefaults(instance.Values); err != nil {
+		return nil, err
 	}
 
 	builder.SetVersionInfo(instance.Module.Version, "")
 
 	buildResult, err := builder.Build()
 	if err != nil {
-		return "", describeErr(modDir, "build failed for "+instance.Name, err)
+		return nil, describeErr(modDir, "build failed for "+instance.Name, err)
 	}
 
 	bundleBuildSets, err := builder.GetApplySets(buildResult)
 	if err != nil {
-		return "", fmt.Errorf("failed to extract objects: %w", err)
+		return nil, fmt.Errorf("failed to extract objects: %w", err)
 	}
 
 	var objects []*unstructured.Unstructured
@@ -231,8 +328,12 @@ func buildBundleInstance(cuectx *cue.Context, instance *apiv1.BundleInstance, ro
 	}
 	sort.Sort(ssa.SortableUnstructureds(objects))
 
-	var sb strings.Builder
+	return objects, nil
+}
 
+// marshalObjectsToYAML marshals the objects to a multi-document YAML string.
+func marshalObjectsToYAML(objects []*unstructured.Unstructured) (string, error) {
+	var sb strings.Builder
 	for i, r := range objects {
 		data, err := yaml.Marshal(r)
 		if err != nil {

--- a/cmd/timoni/bundle_build_test.go
+++ b/cmd/timoni/bundle_build_test.go
@@ -335,3 +335,194 @@ bundle: {
 		})
 	}
 }
+
+func Test_BundleBuild_OutputDir(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := "testdata/module"
+	namespace := rnd("my-namespace", 5)
+
+	bundleCue := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "my-bundle"
+	instances: {
+		backend: {
+			module: {
+				url: "file://%[1]s"
+			}
+			namespace: "%[2]s"
+			values: team: "test"
+		}
+		frontend: {
+			module: {
+				url: "file://%[1]s"
+			}
+			namespace: "%[2]s"
+			values: {
+				team: "test"
+				server: enabled: false
+			}
+		}
+	}
+}
+`, modPath, namespace)
+
+	wd := t.TempDir()
+	cuePath := filepath.Join(wd, "bundle.cue")
+	g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
+	g.Expect(engine.CopyModule(modPath, filepath.Join(wd, modPath))).ToNot(HaveOccurred())
+
+	outDir := filepath.Join(wd, "out")
+	_, err := executeCommand(fmt.Sprintf(
+		"bundle build -f %s -p main --output-dir %s",
+		cuePath, outDir,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// One directory per instance.
+	for _, instance := range []string{"backend", "frontend"} {
+		info, err := os.Stat(filepath.Join(outDir, instance))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(info.IsDir()).To(BeTrue())
+	}
+
+	// One file per resource, named like 'kustomize build -o <dir>'.
+	// The backend instance has both the client and server enabled.
+	backendNames, err := manifestFileNames(filepath.Join(outDir, "backend"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(backendNames).To(ConsistOf(
+		"v1_configmap_backend-client.yaml",
+		"v1_configmap_backend-server.yaml",
+	))
+
+	// The frontend instance has the server disabled.
+	frontendNames, err := manifestFileNames(filepath.Join(outDir, "frontend"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(frontendNames).To(ConsistOf("v1_configmap_frontend-client.yaml"))
+
+	// The written manifest parses and carries the instance namespace.
+	data, err := os.ReadFile(filepath.Join(outDir, "backend", "v1_configmap_backend-client.yaml"))
+	g.Expect(err).ToNot(HaveOccurred())
+	objects, err := ssautil.ReadObjects(strings.NewReader(string(data)))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(objects).To(HaveLen(1))
+	g.Expect(objects[0].GetKind()).To(Equal("ConfigMap"))
+	g.Expect(objects[0].GetName()).To(Equal("backend-client"))
+	g.Expect(objects[0].GetNamespace()).To(ContainSubstring(namespace))
+}
+
+func Test_BundleBuild_OutputDir_MultiNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := "testdata/module"
+	namespace := "apps"
+
+	// Enabling globals makes the module emit a cluster-scoped Namespace and a
+	// ClusterRole pinned to the 'default' namespace, so the instance spans more
+	// than one namespace and the file names get a namespace prefix.
+	bundleCue := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "my-bundle"
+	instances: {
+		backend: {
+			module: {
+				url: "file://%[1]s"
+			}
+			namespace: "%[2]s"
+			values: {
+				team: "test"
+				globals: enabled: true
+			}
+		}
+	}
+}
+`, modPath, namespace)
+
+	wd := t.TempDir()
+	cuePath := filepath.Join(wd, "bundle.cue")
+	g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
+	g.Expect(engine.CopyModule(modPath, filepath.Join(wd, modPath))).ToNot(HaveOccurred())
+
+	outDir := filepath.Join(wd, "out")
+	_, err := executeCommand(fmt.Sprintf(
+		"bundle build -f %s -p main --output-dir %s",
+		cuePath, outDir,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	names, err := manifestFileNames(filepath.Join(outDir, "backend"))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Namespaced resources are prefixed with their namespace (the instance
+	// namespace for the ConfigMaps, 'default' for the ClusterRole), while the
+	// cluster-scoped Namespace stays unprefixed.
+	g.Expect(names).To(ConsistOf(
+		"apps_v1_configmap_backend-client.yaml",
+		"apps_v1_configmap_backend-server.yaml",
+		"default_rbac.authorization.k8s.io_v1_clusterrole_backend-readonly.yaml",
+		"v1_namespace_backend-ns.yaml",
+	))
+}
+
+func Test_resourceFileName(t *testing.T) {
+	newObj := func(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		obj.SetAPIVersion(apiVersion)
+		obj.SetKind(kind)
+		if namespace != "" {
+			obj.SetNamespace(namespace)
+		}
+		obj.SetName(name)
+		return obj
+	}
+
+	tests := []struct {
+		name          string
+		obj           *unstructured.Unstructured
+		withNamespace bool
+		want          string
+	}{
+		{
+			name: "core group omits the empty group and lowercases",
+			obj:  newObj("v1", "ConfigMap", "apps", "My-CM"),
+			want: "v1_configmap_my-cm.yaml",
+		},
+		{
+			name: "named group",
+			obj:  newObj("apps/v1", "Deployment", "apps", "web"),
+			want: "apps_v1_deployment_web.yaml",
+		},
+		{
+			name: "dotted group is preserved",
+			obj:  newObj("rbac.authorization.k8s.io/v1", "ClusterRole", "", "admin"),
+			want: "rbac.authorization.k8s.io_v1_clusterrole_admin.yaml",
+		},
+		{
+			name:          "namespace prefix is added when requested",
+			obj:           newObj("v1", "Service", "prod", "api"),
+			withNamespace: true,
+			want:          "prod_v1_service_api.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(resourceFileName(tt.obj, tt.withNamespace)).To(Equal(tt.want))
+		})
+	}
+}
+
+func manifestFileNames(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -437,6 +437,9 @@ Example:
 timoni bundle build -f bundle.cue
 ```
 
+To write the generated manifests to disk as a directory tree instead of printing them
+to stdout, see [Export manifests to directory](#export-manifests-to-directory).
+
 ### Use values from JSON and YAML files
 
 A bundle can be defined in multiple files of different formats:
@@ -589,3 +592,58 @@ Note that when using local modules, the module's version and digest are ignored,
 are only relevant when pulling modules from a container registry.
 All instances created from modules referenced with local paths have
 the module version set to `0.0.0-devel`.
+
+### Export manifests to directory
+
+By default, `timoni bundle build` prints the resulting Kubernetes resources of all
+instances to stdout. To write the manifests as files on disk, use the `--output-dir` flag.
+
+For example, given a bundle with two instances:
+
+```cue
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "podinfo"
+	instances: {
+		frontend: {
+			module: url: "oci://ghcr.io/stefanprodan/modules/podinfo"
+			namespace: "frontend"
+		}
+		backend: {
+			module: url: "oci://ghcr.io/stefanprodan/modules/podinfo"
+			namespace: "backend"
+		}
+	}
+}
+```
+
+Build the bundle to a directory:
+
+```shell
+timoni bundle build -f podinfo.cue --output-dir ./manifests
+```
+
+Timoni writes the manifests as a directory tree with one subdirectory per instance,
+and inside each, one file per Kubernetes resource:
+
+```text
+manifests
+├── backend
+│   ├── apps_v1_deployment_backend.yaml
+│   ├── v1_service_backend.yaml
+│   └── v1_serviceaccount_backend.yaml
+└── frontend
+    ├── apps_v1_deployment_frontend.yaml
+    ├── v1_service_frontend.yaml
+    └── v1_serviceaccount_frontend.yaml
+```
+
+The file names follow the same convention as `kustomize build -o <dir>`:
+`<group>_<version>_<kind>_<name>.yaml`, lowercased, with the group omitted for
+core resources (e.g. `v1_service_backend.yaml`). When an instance's resources
+span more than one namespace, the file name is prefixed with the namespace
+(`<namespace>_<group>_<version>_<kind>_<name>.yaml`) to avoid collisions.
+
+The output directory is created if it does not exist. Existing files with the same
+name are overwritten, but files that are no longer generated are not removed,
+so you may want to point `--output-dir` at a clean directory.


### PR DESCRIPTION
By default, `timoni bundle build` prints the resulting Kubernetes resources of all instances to stdout.
To write the manifests as files on disk, use the `--output-dir` flag.

For example, given a bundle with two instances:

```cue
bundle: {
	apiVersion: "v1alpha1"
	name:       "podinfo"
	instances: {
		frontend: {
			module: url: "oci://ghcr.io/stefanprodan/modules/podinfo"
			namespace: "frontend"
		}
		backend: {
			module: url: "oci://ghcr.io/stefanprodan/modules/podinfo"
			namespace: "backend"
		}
	}
}
```

Build the bundle to a directory:

```shell
timoni bundle build -f podinfo.cue --output-dir ./manifests
```

Timoni writes the manifests as a directory tree with one subdirectory per instance,
and inside each, one file per Kubernetes resource:

```text
manifests
├── backend
│   ├── apps_v1_deployment_backend.yaml
│   ├── v1_service_backend.yaml
│   └── v1_serviceaccount_backend.yaml
└── frontend
    ├── apps_v1_deployment_frontend.yaml
    ├── v1_service_frontend.yaml
    └── v1_serviceaccount_frontend.yaml
```

The file names follow the same convention as `kustomize build -o <dir>`:
`<group>_<version>_<kind>_<name>.yaml`, lowercased, with the group omitted for
core resources (e.g. `v1_service_backend.yaml`). When an instance's resources
span more than one namespace, the file name is prefixed with the namespace
(`<namespace>_<group>_<version>_<kind>_<name>.yaml`) to avoid collisions.

The output directory is created if it does not exist. Existing files with the same
name are overwritten, but files that are no longer generated are not removed,
so you may want to point `--output-dir` at a clean directory.

Closes: #432