### PR TITLE
fix: bump defaultKubeVersion

### DIFF
--- a/internal/engine/module_builder.go
+++ b/internal/engine/module_builder.go
@@ -41,7 +41,7 @@ const (
 	DefaultDevelVersion = "0.0.0-devel"
 
 	// The default Kubernetes version must be kept in sync with go.mod.
-	defaultKubeVersion = "1.27.5"
+	defaultKubeVersion = "1.36.2"
 )
 
 // ModuleBuilder compiles CUE definitions to Kubernetes objects.


### PR DESCRIPTION
I tried to add a test, but that requires parsing `go.mod`. Not sure if you want to, it's a bit ugly. But anyway. Here it is!