### PR TITLE
feat(oci): Add offline OCI artifact builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,6 @@ When you change behavior — flags, apply/prune/wait semantics, the `action.timo
 - Instance, namespace, and runtime names are restricted to lowercase (RFC 1123).
 - New code and tests should follow the patterns in existing siblings; commands almost always come with an envtest-backed `_test.go` using the `internal/testutils` helpers.
 - Code changes should be accompanied by a corresponding change to the docs.
+- Add Go doc comments for new functions and types.
+- After modifying a function or type, update its doc comment.
+- Add in-line comments for complex logic but don't comment obvious code.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To get started with Timoni please visit the documentation website at [timoni.sh]
 - [Module](https://timoni.sh/concepts/#module) - App definition containing Kubernetes CUE templates and configuration schema, distributed as OCI artifacts.
 - [Instance](https://timoni.sh/concepts/#instance) - App instantiation referencing the module and workloads deployed on a Kubernetes cluster.
 - [Bundle](https://timoni.sh/concepts/#bundle) - App composition bundling multiple modules and configurations into a deployable unit.
-- [OCI Artifact](https://timoni.sh/concepts/#artifact) - Packaging format used for distributing modules and bundles to container registries.
+- [OCI Artifact](https://timoni.sh/concepts/#artifact) - Packaging format used for distributing modules and bundles through registries or local OCI archives and layouts.
 
 > [!TIP]
 > If you are familiar with Helm, a Timoni **[module](https://timoni.sh/module/)** is the equivalent of a **chart**,
@@ -49,7 +49,24 @@ The app configuration packaged in a Module is
 [distributed](https://timoni.sh/cue/module/publishing/) as an
 Open Container Initiative (OCI) artifact, next to the app images,
 in a container registry. Timoni Modules are semantically versioned
-and cryptographically [signed](https://timoni.sh/cue/module/signing/).
+and can be cryptographically [signed](https://timoni.sh/cue/module/signing/) when pushed.
+Local build outputs are unsigned OCI archives or layouts for offline handoff.
+
+Module distribution:
+
+```shell
+timoni mod push ./my-app -v 1.0.0 oci://registry.example.com/my-app
+timoni mod build ./my-app -v 1.0.0 -o ./my-app-1.0.0.oci.tar
+```
+
+Generic artifacts transport bundle files, runtime files, and other content without module, instance, or deployment semantics:
+
+```shell
+timoni artifact push -f ./delivery -t 1.0.0 oci://registry.example.com/my-app
+timoni artifact build -f ./delivery -t 1.0.0 -o ./my-app-delivery-1.0.0.oci.tar
+```
+
+The timoni CLI consumes module artifacts; Kubernetes nodes consume separate workload images. Local OCI outputs are for transport, not `apply` inputs; use a module directory for registry-free apply.
 
 With Timoni, platform engineers can manage the lifecycle of Kubernetes
 controllers, including the upgrade of CRDs. Module authors can
@@ -67,6 +84,14 @@ With Timoni, users can bundle microservices and distributed monoliths into a dep
 The Timoni [Bundle](https://timoni.sh/bundle/) offers a declarative way of managing
 the app delivery across clusters, where secrets and other environment-specific config
 values are [dynamically loaded](https://timoni.sh/bundle-runtime/) during installation or upgrades.
+
+Bundle lifecycle:
+
+```shell
+timoni bundle build  -f ./bundle.cue # Render without applying (optional)
+timoni bundle apply  -f ./bundle.cue # Install or upgrade
+timoni bundle delete -f ./bundle.cue # Uninstall
+```
 
 ## License
 

--- a/cmd/timoni/artifact_build.go
+++ b/cmd/timoni/artifact_build.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/logger"
+	"github.com/stefanprodan/timoni/internal/oci"
+)
+
+var buildArtifactCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build an OCI artifact on the local filesystem",
+	Args:  cobra.NoArgs,
+	RunE:  buildArtifactCmdRun,
+}
+
+// buildArtifactFlags contains local artifact build inputs.
+type buildArtifactFlags struct {
+	path        string
+	output      string
+	format      string
+	tags        []string
+	annotations []string
+	contentType string
+}
+
+var buildArtifactArgs buildArtifactFlags
+
+func init() {
+	buildArtifactCmd.Flags().StringVarP(&buildArtifactArgs.path, "filepath", "f", ".",
+		"Path to a local file or directory.")
+	buildArtifactCmd.Flags().StringVarP(&buildArtifactArgs.output, "output", "o", "",
+		"Path to the OCI archive or OCI image layout.")
+	buildArtifactCmd.Flags().StringVar(&buildArtifactArgs.format, "format", string(oci.FormatArchive),
+		"Output format, either 'oci-archive' or 'oci-layout'.")
+	buildArtifactCmd.Flags().StringArrayVarP(&buildArtifactArgs.tags, "tag", "t", nil,
+		"Local descriptor reference name.")
+	buildArtifactCmd.Flags().StringArrayVarP(&buildArtifactArgs.annotations, "annotation", "a", nil,
+		"Annotation in the format '<key>=<value>'.")
+	buildArtifactCmd.Flags().StringVar(&buildArtifactArgs.contentType, "content-type", "generic",
+		"The content type of this artifact.")
+	artifactCmd.AddCommand(buildArtifactCmd)
+}
+
+// buildArtifactCmdRun validates, builds, and writes a local artifact.
+func buildArtifactCmdRun(cmd *cobra.Command, _ []string) error {
+	if buildArtifactArgs.output == "" {
+		return fmt.Errorf("output path is required")
+	}
+	format := oci.LocalFormat(buildArtifactArgs.format)
+	if err := format.Validate(); err != nil {
+		return err
+	}
+	info, err := os.Stat(buildArtifactArgs.path)
+	if err != nil {
+		return fmt.Errorf("file path not found %s", buildArtifactArgs.path)
+	}
+	if buildArtifactArgs.contentType == "" {
+		return fmt.Errorf("content type is required")
+	}
+
+	var ignorePaths []string
+	if info.IsDir() {
+		ignorePaths, err = engine.ReadIgnoreFile(buildArtifactArgs.path)
+		if err != nil {
+			return fmt.Errorf("reading %s failed: %w", apiv1.IgnoreFile, err)
+		}
+	}
+	annotations, err := oci.ParseAnnotations(buildArtifactArgs.annotations)
+	if err != nil {
+		return err
+	}
+	oci.AppendGitMetadata(buildArtifactArgs.path, annotations)
+
+	build, err := oci.BuildArtifactImage(buildArtifactArgs.path, ignorePaths, buildArtifactArgs.contentType, annotations)
+	if err != nil {
+		return err
+	}
+	defer build.Close()
+	if err := oci.WriteImage(build.Image, buildArtifactArgs.output, format, buildArtifactArgs.tags); err != nil {
+		return err
+	}
+
+	log := LoggerFrom(cmd.Context())
+	log.Info(fmt.Sprintf("artifact: %s", logger.ColorizeSubject(filepath.Clean(buildArtifactArgs.output))))
+	log.Info(fmt.Sprintf("digest: %s", logger.ColorizeSubject(build.Digest.String())))
+	return nil
+}

--- a/cmd/timoni/artifact_build_test.go
+++ b/cmd/timoni/artifact_build_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_BuildArtifact(t *testing.T) {
+	g := NewWithT(t)
+	output := filepath.Join(t.TempDir(), "artifact.tar")
+
+	result, err := executeCommand(fmt.Sprintf(
+		"artifact build -f testdata/module -o %s -t 1.0.0 -t latest -a org.opencontainers.image.created=2024-01-02T03:04:05Z",
+		output,
+	))
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(BeAnExistingFile())
+	g.Expect(result).To(ContainSubstring("digest: sha256:"))
+}
+
+func Test_BuildArtifactRequiresOutput(t *testing.T) {
+	g := NewWithT(t)
+	_, err := executeCommand("artifact build -f testdata/module")
+	g.Expect(err).To(MatchError(ContainSubstring("output path is required")))
+}
+
+func Test_BuildArtifactValidatesFormatBeforeSource(t *testing.T) {
+	g := NewWithT(t)
+	_, err := executeCommand("artifact build -f missing -o output --format invalid")
+	g.Expect(err).To(MatchError("unsupported OCI output format \"invalid\""))
+}

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -130,6 +130,7 @@ func resetCmdArgs() {
 	listArgs = listFlags{}
 	pullModArgs = pullModFlags{}
 	pushModArgs = pushModFlags{}
+	buildModArgs = buildModFlags{format: "oci-archive"}
 	bundleArgs = bundleFlags{}
 	bundleApplyArgs = bundleApplyFlags{}
 	bundleVetArgs = bundleVetFlags{}
@@ -138,6 +139,11 @@ func resetCmdArgs() {
 	vendorCrdArgs = vendorCrdFlags{}
 	vendorK8sArgs = vendorK8sFlags{}
 	pushArtifactArgs = pushArtifactFlags{}
+	buildArtifactArgs = buildArtifactFlags{
+		path:        ".",
+		format:      "oci-archive",
+		contentType: "generic",
+	}
 	pullArtifactArgs = pullArtifactFlags{}
 	runtimeBuildArgs = runtimeBuildFlags{}
 }

--- a/cmd/timoni/mod_build.go
+++ b/cmd/timoni/mod_build.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/spf13/cobra"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/logger"
+	"github.com/stefanprodan/timoni/internal/oci"
+)
+
+var buildModCmd = &cobra.Command{
+	Use:   "build MODULE",
+	Short: "Build a module OCI artifact on the local filesystem",
+	Args:  cobra.ExactArgs(1),
+	RunE:  buildModCmdRun,
+}
+
+// buildModFlags contains local module build inputs.
+type buildModFlags struct {
+	version     string
+	output      string
+	format      string
+	annotations []string
+}
+
+var buildModArgs buildModFlags
+
+func init() {
+	buildModCmd.Flags().StringVarP(&buildModArgs.version, "version", "v", "",
+		"Module version e.g. '1.0.0'; overrides the 'org.opencontainers.image.version' annotation.")
+	buildModCmd.Flags().StringVarP(&buildModArgs.output, "output", "o", "",
+		"Path to the OCI archive or OCI image layout.")
+	buildModCmd.Flags().StringVar(&buildModArgs.format, "format", string(oci.FormatArchive),
+		"Output format, either 'oci-archive' or 'oci-layout'.")
+	buildModCmd.Flags().StringArrayVarP(&buildModArgs.annotations, "annotation", "a", nil,
+		"Set custom OCI annotations in the format '<key>=<value>'.")
+	modCmd.AddCommand(buildModCmd)
+}
+
+// buildModCmdRun validates, builds, and writes a local module artifact.
+func buildModCmdRun(cmd *cobra.Command, args []string) error {
+	if buildModArgs.output == "" {
+		return fmt.Errorf("output path is required")
+	}
+	if buildModArgs.version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if strings.Contains(buildModArgs.version, "+") {
+		return fmt.Errorf("version build metadata is not supported")
+	}
+	if _, err := semver.StrictNewVersion(buildModArgs.version); err != nil {
+		return fmt.Errorf("version is not in semver format: %w", err)
+	}
+	format := oci.LocalFormat(buildModArgs.format)
+	if err := format.Validate(); err != nil {
+		return err
+	}
+	module := args[0]
+	if info, err := os.Stat(module); err != nil || !info.IsDir() {
+		return fmt.Errorf("module not found at path %s", module)
+	}
+
+	annotations, err := oci.ParseAnnotations(buildModArgs.annotations)
+	if err != nil {
+		return err
+	}
+	// The required flag owns the manifest version annotation.
+	annotations[apiv1.VersionAnnotation] = buildModArgs.version
+	oci.AppendGitMetadata(module, annotations)
+	ignorePaths, err := engine.ReadIgnoreFile(module)
+	if err != nil {
+		return fmt.Errorf("reading %s failed: %w", apiv1.IgnoreFile, err)
+	}
+
+	build, err := oci.BuildModuleImage(module, ignorePaths, annotations)
+	if err != nil {
+		return err
+	}
+	defer build.Close()
+	if err := oci.WriteImage(build.Image, buildModArgs.output, format, []string{buildModArgs.version}); err != nil {
+		return err
+	}
+
+	log := LoggerFrom(cmd.Context())
+	log.Info(fmt.Sprintf("artifact: %s", logger.ColorizeSubject(filepath.Clean(buildModArgs.output))))
+	log.Info(fmt.Sprintf("digest: %s", logger.ColorizeSubject(build.Digest.String())))
+	return nil
+}

--- a/cmd/timoni/mod_build_test.go
+++ b/cmd/timoni/mod_build_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+func Test_BuildMod(t *testing.T) {
+	g := NewWithT(t)
+	output := filepath.Join(t.TempDir(), "module.tar")
+
+	result, err := executeCommand(fmt.Sprintf(
+		"mod build testdata/module -v 1.0.0 -o %s -a org.opencontainers.image.created=2024-01-02T03:04:05Z",
+		output,
+	))
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(BeAnExistingFile())
+	g.Expect(result).To(ContainSubstring("digest: sha256:"))
+}
+
+func Test_BuildModVersionOverridesAnnotation(t *testing.T) {
+	g := NewWithT(t)
+	output := filepath.Join(t.TempDir(), "module")
+
+	_, err := executeCommand(fmt.Sprintf(
+		"mod build testdata/module -v 1.0.0 -o %s --format oci-layout -a %s=9.9.9",
+		output,
+		apiv1.VersionAnnotation,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	path, err := layout.FromPath(output)
+	g.Expect(err).ToNot(HaveOccurred())
+	index, err := path.ImageIndex()
+	g.Expect(err).ToNot(HaveOccurred())
+	indexManifest, err := index.IndexManifest()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(indexManifest.Manifests).To(HaveLen(1))
+	image, err := index.Image(indexManifest.Manifests[0].Digest)
+	g.Expect(err).ToNot(HaveOccurred())
+	manifest, err := image.Manifest()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(manifest.Annotations).To(HaveKeyWithValue(apiv1.VersionAnnotation, "1.0.0"))
+}
+
+func Test_BuildModRequiresVersion(t *testing.T) {
+	g := NewWithT(t)
+	output := filepath.Join(t.TempDir(), "module.tar")
+	_, err := executeCommand(fmt.Sprintf("mod build testdata/module -o %s", output))
+	g.Expect(err).To(MatchError(ContainSubstring("version is required")))
+}
+
+func Test_BuildModValidatesFormatBeforeSource(t *testing.T) {
+	g := NewWithT(t)
+	_, err := executeCommand("mod build missing -v 1.0.0 -o output --format invalid")
+	g.Expect(err).To(MatchError("unsupported OCI output format \"invalid\""))
+}

--- a/docs/bundle-distribution.md
+++ b/docs/bundle-distribution.md
@@ -18,8 +18,23 @@ The artifacts are annotated with OCI
 - `org.opencontainers.image.revision: <GIT COMMIT SHA>`
 - `org.opencontainers.image.created: <GIT COMMIT DATE>`
 
-To enable reproducible builds, Timoni tries to determine the 
-source, revision and created date from the Git metadata.
+For reproducible builds, Timoni preserves explicit annotations, then uses
+`SOURCE_DATE_EPOCH` or the Git commit time for the creation date. Git source
+and revision metadata are added when available.
+
+## Building artifacts without a registry
+
+[timoni artifact build](cmd/timoni_artifact_build.md) writes a deterministic
+OCI archive without registry or network access:
+
+```shell
+timoni artifact build -f ./my-app/bundles -t 1.0.0 -o ./bundle-1.0.0.oci.tar
+skopeo copy oci-archive:./bundle-1.0.0.oci.tar docker://ghcr.io/org/bundles:1.0.0
+```
+
+Use `--format=oci-layout` for directory output. Tags are optional and repeated
+`--tag` flags add reference names for the same manifest.
+Local outputs are unsigned; existing output paths are rejected.
 
 ## Publishing bundles to container registries
 

--- a/docs/cue/module/publishing.md
+++ b/docs/cue/module/publishing.md
@@ -20,8 +20,9 @@ The artifacts are annotated with OCI
 - `org.opencontainers.image.source: <MODULE GIT URL>`
 - `org.opencontainers.image.revision: <MODULE GIT SHA>`
 
-To enable reproducible builds, Timoni tries to determine the module's
-last modified date, the source URL and source revision from the Git metadata.
+For reproducible builds, Timoni preserves explicit creation, source and
+revision annotations, then uses `SOURCE_DATE_EPOCH` or the Git commit time for
+the creation date. Git source and revision metadata are added when available.
 
 ## Version format
 
@@ -39,6 +40,21 @@ The supported formats are:
 - `X.Y.Z-alpha.N` - denotes an alpha pre-release e.g. `2.0.0-alpha.1`
 - `X.Y.Z-beta.N` - denotes a beta pre-release e.g. `2.0.0-beta.1`
 - `X.Y.Z-rc.N` - denotes a releases candidate e.g. `2.0.0-rc.1`
+
+## Building modules without a registry
+
+[timoni mod build](../../cmd/timoni_mod_build.md) writes the same ordered
+vendor and module layers as `timoni mod push`, without registry or network
+access:
+
+```shell
+timoni mod build ./modules/my-app -v 1.0.0 -o ./my-app-1.0.0.oci.tar
+skopeo copy oci-archive:./my-app-1.0.0.oci.tar docker://ghcr.io/org/modules/app:1.0.0
+```
+
+The version is required and becomes the manifest version annotation and local
+reference name. Use `--format=oci-layout` for directory output.
+Local outputs are unsigned; existing output paths are rejected.
 
 ## Publishing module versions
 

--- a/internal/oci/build_image.go
+++ b/internal/oci/build_image.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/go-containerregistry/pkg/compression"
+	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+// ImageBuild owns a completed OCI image, its digest, and temporary layer files.
+type ImageBuild struct {
+	Image  gcrv1.Image
+	Digest gcrv1.Hash
+	tmpDir string
+}
+
+// Close removes the temporary layer files owned by the build.
+func (b *ImageBuild) Close() error {
+	return os.RemoveAll(b.tmpDir)
+}
+
+// contentLayer defines one ordered layer in an OCI image build.
+type contentLayer struct {
+	name        string
+	ignorePaths []string
+	contentType string
+}
+
+// buildImage packages the layers in order and computes the completed image digest.
+func buildImage(contentPath string, layers []contentLayer, annotations map[string]string) (_ *ImageBuild, err error) {
+	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			os.RemoveAll(tmpDir)
+		}
+	}()
+
+	img := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
+	img = mutate.ConfigMediaType(img, apiv1.ConfigMediaType)
+	img = mutate.Annotations(img, annotations).(gcrv1.Image)
+
+	for _, spec := range layers {
+		tgzFile := filepath.Join(tmpDir, spec.name+".tgz")
+		if err := BuildArtifact(tgzFile, contentPath, spec.ignorePaths); err != nil {
+			return nil, fmt.Errorf("packaging %s layer failed: %w", spec.name, err)
+		}
+
+		layer, err := tarball.LayerFromFile(tgzFile,
+			tarball.WithMediaType(apiv1.ContentMediaType),
+			tarball.WithCompression(compression.GZip),
+			tarball.WithCompressedCaching,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("creating %s layer failed: %w", spec.name, err)
+		}
+
+		img, err = mutate.Append(img, mutate.Addendum{
+			Layer: layer,
+			Annotations: map[string]string{
+				apiv1.ContentTypeAnnotation: spec.contentType,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("appending %s layer failed: %w", spec.name, err)
+		}
+	}
+
+	digest, err := img.Digest()
+	if err != nil {
+		return nil, fmt.Errorf("calculating artifact digest failed: %w", err)
+	}
+
+	return &ImageBuild{Image: img, Digest: digest, tmpDir: tmpDir}, nil
+}
+
+// BuildArtifactImage packages contentPath as a single-layer OCI image.
+func BuildArtifactImage(contentPath string, ignorePaths []string, contentType string, annotations map[string]string) (*ImageBuild, error) {
+	return buildImage(contentPath, []contentLayer{{
+		name:        "artifact",
+		ignorePaths: ignorePaths,
+		contentType: contentType,
+	}}, annotations)
+}
+
+// BuildModuleImage packages a module as ordered vendor and module layers.
+func BuildModuleImage(contentPath string, ignorePaths []string, annotations map[string]string) (*ImageBuild, error) {
+	// Copy caller rules before excluding vendored schemas from the module layer.
+	moduleIgnore := append(append([]string{}, ignorePaths...), "cue.mod/")
+	return buildImage(contentPath, []contentLayer{
+		{name: "vendor", ignorePaths: []string{"/*", "!/cue.mod"}, contentType: apiv1.TimoniModVendorContentType},
+		{name: "module", ignorePaths: moduleIgnore, contentType: apiv1.TimoniModContentType},
+	}, annotations)
+}

--- a/internal/oci/build_image_test.go
+++ b/internal/oci/build_image_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+func TestBuildImages(t *testing.T) {
+	g := NewWithT(t)
+	annotations := map[string]string{"example.com/key": "value"}
+
+	artifact, err := BuildArtifactImage("testdata/module", []string{"timoni.ignore"}, "generic", annotations)
+	g.Expect(err).ToNot(HaveOccurred())
+	defer artifact.Close()
+
+	manifest, err := artifact.Image.Manifest()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(manifest.Annotations).To(HaveKeyWithValue("example.com/key", "value"))
+	g.Expect(manifest.Layers).To(HaveLen(1))
+	g.Expect(manifest.Layers[0].Annotations).To(HaveKeyWithValue(apiv1.ContentTypeAnnotation, "generic"))
+	digest, err := artifact.Image.Digest()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(artifact.Digest).To(Equal(digest))
+
+	ignorePaths := make([]string, 1, 2)
+	ignorePaths[0] = "timoni.ignore"
+	backing := ignorePaths[:cap(ignorePaths)]
+	backing[1] = "preserve"
+	module, err := BuildModuleImage("testdata/module", ignorePaths, annotations)
+	g.Expect(err).ToNot(HaveOccurred())
+	defer module.Close()
+
+	manifest, err = module.Image.Manifest()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(manifest.Layers).To(HaveLen(2))
+	g.Expect(manifest.Layers[0].Annotations).To(HaveKeyWithValue(apiv1.ContentTypeAnnotation, apiv1.TimoniModVendorContentType))
+	g.Expect(manifest.Layers[1].Annotations).To(HaveKeyWithValue(apiv1.ContentTypeAnnotation, apiv1.TimoniModContentType))
+	g.Expect(backing[1]).To(Equal("preserve"))
+}

--- a/internal/oci/metadata.go
+++ b/internal/oci/metadata.go
@@ -19,7 +19,9 @@ package oci
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -27,54 +29,63 @@ import (
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
-// ParseAnnotations parses the command args in the format key=value
-// and returns the OpenContainers annotations.
+// ParseAnnotations parses key=value pairs and preserves additional equals signs
+// in values.
 func ParseAnnotations(args []string) (map[string]string, error) {
 	annotations := map[string]string{}
 	for _, annotation := range args {
-		kv := strings.Split(annotation, "=")
-		if len(kv) != 2 {
+		key, value, found := strings.Cut(annotation, "=")
+		if !found {
 			return annotations, fmt.Errorf("invalid annotation %s, must be in the format key=value", annotation)
 		}
-		annotations[kv[0]] = kv[1]
+		annotations[key] = value
 	}
 
 	return annotations, nil
 }
 
-// AppendGitMetadata sets the OpenContainers source, revision and created annotations
-// from the Git metadata. If the git binary or the .git dir are missing, the created
-// date is set to the current UTC date, and the source and revision are not appended.
+// AppendGitMetadata fills missing creation, source, and revision annotations.
+// Creation uses SOURCE_DATE_EPOCH before Git commit time; Git failures are ignored.
 func AppendGitMetadata(repoPath string, annotations map[string]string) {
+	if info, err := os.Stat(repoPath); err == nil && !info.IsDir() {
+		repoPath = filepath.Dir(repoPath)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	tsCmd := exec.CommandContext(ctx, "git", "--no-pager", "log", "-1", `--format=%ct`)
-	tsCmd.Dir = repoPath
-	if ts, err := tsCmd.Output(); err == nil && len(ts) > 1 {
-		if i, err := strconv.ParseInt(strings.TrimSuffix(string(ts), "\n"), 10, 64); err == nil {
-			d := time.Unix(i, 0)
-			annotations[apiv1.CreatedAnnotation] = d.Format(time.RFC3339)
+	if _, found := annotations[apiv1.CreatedAnnotation]; !found {
+		if epoch := os.Getenv("SOURCE_DATE_EPOCH"); epoch != "" {
+			if seconds, err := strconv.ParseInt(epoch, 10, 64); err == nil {
+				annotations[apiv1.CreatedAnnotation] = time.Unix(seconds, 0).UTC().Format(time.RFC3339)
+			}
 		}
-	} else {
-		ct := time.Now().UTC()
-		annotations[apiv1.CreatedAnnotation] = ct.Format(time.RFC3339)
-		return
+		if _, found := annotations[apiv1.CreatedAnnotation]; !found {
+			if ts, err := gitOutput(ctx, repoPath, "--no-pager", "log", "-1", "--format=%ct"); err == nil {
+				if seconds, err := strconv.ParseInt(ts, 10, 64); err == nil {
+					annotations[apiv1.CreatedAnnotation] = time.Unix(seconds, 0).UTC().Format(time.RFC3339)
+				}
+			}
+		}
 	}
 
 	if _, found := annotations[apiv1.SourceAnnotation]; !found {
-		urlCmd := exec.CommandContext(ctx, "git", "config", "--get", "remote.origin.url")
-		urlCmd.Dir = repoPath
-		if repo, err := urlCmd.Output(); err == nil && len(repo) > 1 {
-			annotations[apiv1.SourceAnnotation] = strings.TrimSuffix(string(repo), "\n")
+		if repo, err := gitOutput(ctx, repoPath, "config", "--get", "remote.origin.url"); err == nil {
+			annotations[apiv1.SourceAnnotation] = repo
 		}
 	}
 
 	if _, found := annotations[apiv1.RevisionAnnotation]; !found {
-		shaCmd := exec.CommandContext(ctx, "git", "show", "-s", "--format=%H")
-		shaCmd.Dir = repoPath
-		if commit, err := shaCmd.Output(); err == nil && len(commit) > 1 {
-			annotations[apiv1.RevisionAnnotation] = strings.TrimSuffix(string(commit), "\n")
+		if commit, err := gitOutput(ctx, repoPath, "show", "-s", "--format=%H"); err == nil {
+			annotations[apiv1.RevisionAnnotation] = commit
 		}
 	}
+}
+
+// gitOutput runs Git in dir and returns trimmed standard output.
+func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
 }

--- a/internal/oci/metadata_test.go
+++ b/internal/oci/metadata_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+func TestParseAnnotationsPreservesEqualsInValue(t *testing.T) {
+	g := NewWithT(t)
+
+	annotations, err := ParseAnnotations([]string{"example.com/key=value=with=equals"})
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(annotations).To(HaveKeyWithValue("example.com/key", "value=with=equals"))
+}
+
+func TestAppendGitMetadataPrecedence(t *testing.T) {
+	t.Run("explicit created", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
+		annotations := map[string]string{apiv1.CreatedAnnotation: "2024-01-02T03:04:05Z"}
+
+		AppendGitMetadata(t.TempDir(), annotations)
+
+		g.Expect(annotations).To(HaveKeyWithValue(apiv1.CreatedAnnotation, "2024-01-02T03:04:05Z"))
+	})
+
+	t.Run("source date epoch", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
+		annotations := map[string]string{}
+
+		AppendGitMetadata(t.TempDir(), annotations)
+
+		g.Expect(annotations).To(HaveKeyWithValue(apiv1.CreatedAnnotation, "2023-11-14T22:13:20Z"))
+	})
+
+	t.Run("git commit", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("SOURCE_DATE_EPOCH", "")
+		repo := t.TempDir()
+		runGitTestCommand(t, repo, "init", "-q")
+		g.Expect(os.WriteFile(filepath.Join(repo, "file"), []byte("content"), 0o600)).To(Succeed())
+		runGitTestCommand(t, repo, "add", "file")
+		cmd := exec.Command("git", "-c", "user.name=Timoni", "-c", "user.email=timoni@example.com", "commit", "-qm", "test")
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_DATE=1700000000 +0000", "GIT_COMMITTER_DATE=1700000000 +0000")
+		g.Expect(cmd.Run()).To(Succeed())
+
+		annotations := map[string]string{}
+		AppendGitMetadata(repo, annotations)
+
+		g.Expect(annotations).To(HaveKeyWithValue(apiv1.CreatedAnnotation, "2023-11-14T22:13:20Z"))
+		g.Expect(annotations[apiv1.RevisionAnnotation]).To(HaveLen(40))
+	})
+
+	t.Run("outside git", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("SOURCE_DATE_EPOCH", "")
+		annotations := map[string]string{}
+
+		AppendGitMetadata(t.TempDir(), annotations)
+
+		g.Expect(annotations).ToNot(HaveKey(apiv1.CreatedAnnotation))
+	})
+}
+
+func runGitTestCommand(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v: %s", args, err, out)
+	}
+}

--- a/internal/oci/push_artifact.go
+++ b/internal/oci/push_artifact.go
@@ -18,77 +18,30 @@ package oci
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
-	"github.com/google/go-containerregistry/pkg/compression"
 	"github.com/google/go-containerregistry/pkg/crane"
-	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/empty"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
-// PushArtifact performs the following operations:
-// - packages the content in a tar+gzip layer
-// - annotates the layer with the given content type
-// - adds the layer to an OpenContainers artifact
-// - annotates the artifact with the given annotations
-// - uploads the artifact in the container registry
-// - returns the digest URL of the upstream artifact
+// PushArtifact builds and pushes a single-layer OCI artifact, then returns its
+// digest URL.
 func PushArtifact(ociURL, contentPath string, ignorePaths []string, contentType string, annotations map[string]string, opts []crane.Option) (string, error) {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return "", err
 	}
 
-	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+	build, err := BuildArtifactImage(contentPath, ignorePaths, contentType, annotations)
 	if err != nil {
 		return "", err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer build.Close()
 
-	tgzFile := filepath.Join(tmpDir, "artifact.tgz")
-
-	if err := BuildArtifact(tgzFile, contentPath, ignorePaths); err != nil {
-		return "", fmt.Errorf("packging content failed: %w", err)
-	}
-
-	img := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
-	img = mutate.ConfigMediaType(img, apiv1.ConfigMediaType)
-	img = mutate.Annotations(img, annotations).(gcrv1.Image)
-
-	layer, err := tarball.LayerFromFile(tgzFile,
-		tarball.WithMediaType(apiv1.ContentMediaType),
-		tarball.WithCompression(compression.GZip),
-		tarball.WithCompressedCaching,
-	)
-	if err != nil {
-		return "", fmt.Errorf("creating content layer failed: %w", err)
-	}
-
-	img, err = mutate.Append(img, mutate.Addendum{
-		Layer: layer,
-		Annotations: map[string]string{
-			apiv1.ContentTypeAnnotation: contentType,
-		},
-	})
-	if err != nil {
-		return "", fmt.Errorf("appending content to artifact failed: %w", err)
-	}
-
-	if err := crane.Push(img, ref.String(), opts...); err != nil {
+	if err := crane.Push(build.Image, ref.String(), opts...); err != nil {
 		return "", fmt.Errorf("pushing artifact failed: %w", err)
 	}
 
-	digest, err := img.Digest()
-	if err != nil {
-		return "", fmt.Errorf("parsing artifact digest failed: %w", err)
-	}
-
-	digestURL := ref.Context().Digest(digest.String()).String()
+	digestURL := ref.Context().Digest(build.Digest.String()).String()
 	return fmt.Sprintf("%s%s", apiv1.ArtifactPrefix, digestURL), nil
 }

--- a/internal/oci/push_module.go
+++ b/internal/oci/push_module.go
@@ -18,102 +18,30 @@ package oci
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
-	"github.com/google/go-containerregistry/pkg/compression"
 	"github.com/google/go-containerregistry/pkg/crane"
-	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/empty"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
-// PushModule performs the following operations:
-// - packages the Timoni module's vendored schemas in a dedicated tar+gzip layer
-// - packages the Timoni module's templates, values, etc in a 2nd tar+gzip layer
-// - adds both layers to an OpenContainers artifact
-// - annotates the artifact with the given annotations
-// - uploads the module's artifact in the container registry
-// - returns the digest URL of the upstream artifact
+// PushModule builds and pushes ordered vendor and module layers, then returns
+// the module's digest URL.
 func PushModule(ociURL, contentPath string, ignorePaths []string, annotations map[string]string, opts []crane.Option) (string, error) {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return "", err
 	}
 
-	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+	build, err := BuildModuleImage(contentPath, ignorePaths, annotations)
 	if err != nil {
 		return "", err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer build.Close()
 
-	img := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
-	img = mutate.ConfigMediaType(img, apiv1.ConfigMediaType)
-	img = mutate.Annotations(img, annotations).(gcrv1.Image)
-
-	tgzVendor := filepath.Join(tmpDir, "vendor.tgz")
-	vendorIgnorePaths := []string{"/*", "!/cue.mod"}
-	if err := BuildArtifact(tgzVendor, contentPath, vendorIgnorePaths); err != nil {
-		return "", fmt.Errorf("packging vendor layer failed: %w", err)
-	}
-
-	layerVendor, err := tarball.LayerFromFile(tgzVendor,
-		tarball.WithMediaType(apiv1.ContentMediaType),
-		tarball.WithCompression(compression.GZip),
-		tarball.WithCompressedCaching,
-	)
-	if err != nil {
-		return "", fmt.Errorf("creating vendor layer failed: %w", err)
-	}
-
-	img, err = mutate.Append(img, mutate.Addendum{
-		Layer: layerVendor,
-		Annotations: map[string]string{
-			apiv1.ContentTypeAnnotation: apiv1.TimoniModVendorContentType,
-		},
-	})
-	if err != nil {
-		return "", fmt.Errorf("appending vendor layer to artifact failed: %w", err)
-	}
-
-	tgzModule := filepath.Join(tmpDir, "module.tgz")
-	ignorePaths = append(ignorePaths, "cue.mod/")
-	if err := BuildArtifact(tgzModule, contentPath, ignorePaths); err != nil {
-		return "", fmt.Errorf("packging module layer failed: %w", err)
-	}
-
-	layerModule, err := tarball.LayerFromFile(tgzModule,
-		tarball.WithMediaType(apiv1.ContentMediaType),
-		tarball.WithCompression(compression.GZip),
-		tarball.WithCompressedCaching,
-	)
-	if err != nil {
-		return "", fmt.Errorf("creating module layer failed: %w", err)
-	}
-
-	img, err = mutate.Append(img, mutate.Addendum{
-		Layer: layerModule,
-		Annotations: map[string]string{
-			apiv1.ContentTypeAnnotation: apiv1.TimoniModContentType,
-		},
-	})
-	if err != nil {
-		return "", fmt.Errorf("appending module layer to artifact failed: %w", err)
-	}
-
-	if err := crane.Push(img, ref.String(), opts...); err != nil {
+	if err := crane.Push(build.Image, ref.String(), opts...); err != nil {
 		return "", fmt.Errorf("pushing artifact failed: %w", err)
 	}
 
-	digest, err := img.Digest()
-	if err != nil {
-		return "", fmt.Errorf("parsing artifact digest failed: %w", err)
-	}
-
-	digestURL := ref.Context().Digest(digest.String()).String()
+	digestURL := ref.Context().Digest(build.Digest.String()).String()
 	return fmt.Sprintf("%s%s", apiv1.ArtifactPrefix, digestURL), nil
 }

--- a/internal/oci/write_image.go
+++ b/internal/oci/write_image.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+)
+
+// LocalFormat identifies an OCI filesystem output format.
+type LocalFormat string
+
+const (
+	FormatArchive LocalFormat = "oci-archive"
+	FormatLayout  LocalFormat = "oci-layout"
+)
+
+// WriteImage writes an image to a new OCI layout or archive.
+// References become OCI layout descriptor names.
+func WriteImage(image gcrv1.Image, destination string, format LocalFormat, references []string) error {
+	if format != FormatLayout && format != FormatArchive {
+		return fmt.Errorf("unsupported OCI output format %q", format)
+	}
+	for _, ref := range references {
+		if ref == "" {
+			return fmt.Errorf("OCI reference cannot be empty")
+		}
+	}
+
+	if format == FormatLayout {
+		return writeLayout(destination, image, references)
+	}
+
+	// Archives are deterministic tar encodings of a temporary OCI layout.
+	tmpDir, err := os.MkdirTemp("", "timoni-layout-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	layoutPath := filepath.Join(tmpDir, "layout")
+	if err := writeLayout(layoutPath, image, references); err != nil {
+		return err
+	}
+	return writeArchive(layoutPath, destination)
+}
+
+// writeLayout creates a layout and removes it if writing fails.
+func writeLayout(destination string, image gcrv1.Image, references []string) (err error) {
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return fmt.Errorf("creating output parent: %w", err)
+	}
+	if err := os.Mkdir(destination, 0o755); err != nil {
+		return fmt.Errorf("creating output layout: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			os.RemoveAll(destination)
+		}
+	}()
+
+	path, err := layout.Write(destination, empty.Index)
+	if err != nil {
+		return err
+	}
+	if len(references) == 0 {
+		return path.AppendImage(image)
+	}
+	for _, ref := range references {
+		if err := path.AppendImage(image, layout.WithAnnotations(map[string]string{
+			"org.opencontainers.image.ref.name": ref,
+		})); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeArchive creates a deterministic archive and removes it if writing fails.
+func writeArchive(layoutPath, destination string) (err error) {
+	output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("creating output archive: %w", err)
+	}
+	defer func() {
+		if closeErr := output.Close(); err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			os.Remove(destination)
+		}
+	}()
+
+	tw := tar.NewWriter(output)
+	defer func() {
+		if closeErr := tw.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	var entries []string
+	if err := filepath.Walk(layoutPath, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path != layoutPath {
+			entries = append(entries, path)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	// Stable path order and normalized headers make archive bytes reproducible.
+	sort.Strings(entries)
+
+	for _, path := range entries {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() && !info.IsDir() {
+			return fmt.Errorf("unsupported layout entry %q", path)
+		}
+
+		name, err := filepath.Rel(layoutPath, path)
+		if err != nil {
+			return err
+		}
+		header := &tar.Header{
+			Name:     filepath.ToSlash(name),
+			Mode:     0o644,
+			Size:     info.Size(),
+			ModTime:  time.Unix(0, 0).UTC(),
+			Typeflag: tar.TypeReg,
+			Format:   tar.FormatPAX,
+		}
+		if info.IsDir() {
+			header.Name += "/"
+			header.Mode = 0o755
+			header.Size = 0
+			header.Typeflag = tar.TypeDir
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(tw, file)
+			closeErr := file.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+		}
+	}
+	return nil
+}

--- a/internal/oci/write_image.go
+++ b/internal/oci/write_image.go
@@ -38,11 +38,19 @@ const (
 	FormatLayout  LocalFormat = "oci-layout"
 )
 
-// WriteImage writes an image to a new OCI layout or archive.
+// Validate reports whether the local OCI output format is supported.
+func (f LocalFormat) Validate() error {
+	if f != FormatLayout && f != FormatArchive {
+		return fmt.Errorf("unsupported OCI output format %q", f)
+	}
+	return nil
+}
+
+// WriteImage validates and writes an image to a new OCI layout or archive.
 // References become OCI layout descriptor names.
 func WriteImage(image gcrv1.Image, destination string, format LocalFormat, references []string) error {
-	if format != FormatLayout && format != FormatArchive {
-		return fmt.Errorf("unsupported OCI output format %q", format)
+	if err := format.Validate(); err != nil {
+		return err
 	}
 	for _, ref := range references {
 		if ref == "" {

--- a/internal/oci/write_image_test.go
+++ b/internal/oci/write_image_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+func TestWriteImage(t *testing.T) {
+	g := NewWithT(t)
+	build, err := BuildArtifactImage("testdata/module", []string{"timoni.ignore"}, "generic", map[string]string{
+		apiv1.CreatedAnnotation: "2024-01-02T03:04:05Z",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	defer build.Close()
+
+	t.Run("layout with optional references", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "nested", "artifact")
+		g.Expect(WriteImage(build.Image, dst, FormatLayout, []string{"1.0.0", "latest"})).To(Succeed())
+
+		path, err := layout.FromPath(dst)
+		g.Expect(err).ToNot(HaveOccurred())
+		index, err := path.ImageIndex()
+		g.Expect(err).ToNot(HaveOccurred())
+		manifest, err := index.IndexManifest()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(manifest.Manifests).To(HaveLen(2))
+		for i, tag := range []string{"1.0.0", "latest"} {
+			g.Expect(manifest.Manifests[i].Digest).To(Equal(build.Digest))
+			g.Expect(manifest.Manifests[i].Annotations).To(HaveKeyWithValue("org.opencontainers.image.ref.name", tag))
+		}
+	})
+
+	t.Run("untagged deterministic archive", func(t *testing.T) {
+		g := NewWithT(t)
+		root := t.TempDir()
+		first := filepath.Join(root, "first.tar")
+		second := filepath.Join(root, "second.tar")
+		g.Expect(WriteImage(build.Image, first, FormatArchive, nil)).To(Succeed())
+		g.Expect(WriteImage(build.Image, second, FormatArchive, nil)).To(Succeed())
+
+		firstBytes, err := os.ReadFile(first)
+		g.Expect(err).ToNot(HaveOccurred())
+		secondBytes, err := os.ReadFile(second)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(bytes.Equal(firstBytes, secondBytes)).To(BeTrue())
+	})
+
+	t.Run("existing archive remains untouched", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "artifact.tar")
+		marker := []byte("existing archive")
+		g.Expect(os.WriteFile(dst, marker, 0o644)).To(Succeed())
+
+		err := WriteImage(build.Image, dst, FormatArchive, nil)
+		g.Expect(errors.Is(err, fs.ErrExist)).To(BeTrue())
+		g.Expect(os.ReadFile(dst)).To(Equal(marker))
+	})
+
+	t.Run("existing layout remains untouched", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "artifact")
+		g.Expect(os.Mkdir(dst, 0o755)).To(Succeed())
+		markerPath := filepath.Join(dst, "marker")
+		marker := []byte("existing layout")
+		g.Expect(os.WriteFile(markerPath, marker, 0o644)).To(Succeed())
+
+		err := WriteImage(build.Image, dst, FormatLayout, nil)
+		g.Expect(errors.Is(err, fs.ErrExist)).To(BeTrue())
+		g.Expect(os.ReadFile(markerPath)).To(Equal(marker))
+	})
+
+	t.Run("invalid references leave no output", func(t *testing.T) {
+		for _, format := range []LocalFormat{FormatArchive, FormatLayout} {
+			t.Run(string(format), func(t *testing.T) {
+				g := NewWithT(t)
+				dst := filepath.Join(t.TempDir(), "artifact")
+
+				err := WriteImage(build.Image, dst, format, []string{"valid", ""})
+				g.Expect(err).To(MatchError(ContainSubstring("OCI reference cannot be empty")))
+				_, statErr := os.Lstat(dst)
+				g.Expect(os.IsNotExist(statErr)).To(BeTrue())
+			})
+		}
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		g := NewWithT(t)
+		err := WriteImage(build.Image, filepath.Join(t.TempDir(), "artifact"), LocalFormat("invalid"), nil)
+		g.Expect(err).To(MatchError(ContainSubstring("unsupported OCI output format")))
+	})
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
           - cmd/timoni_status.md
       - Module:
           - cmd/timoni_mod.md
+          - cmd/timoni_mod_build.md
           - cmd/timoni_mod_init.md
           - cmd/timoni_mod_push.md
           - cmd/timoni_mod_pull.md
@@ -156,6 +157,7 @@ nav:
           - cmd/timoni_registry_logout.md
       - Artifact:
           - cmd/timoni_artifact.md
+          - cmd/timoni_artifact_build.md
           - cmd/timoni_artifact_list.md
           - cmd/timoni_artifact_push.md
           - cmd/timoni_artifact_pull.md


### PR DESCRIPTION
## What

- Add `artifact build` and `mod build` for writing OCI archives or OCI layout directories without a registry operation.
- Share completed image construction with the existing push paths, preserving Timoni's generic one-layer artifact and ordered two-layer module formats.
- Make archive bytes reproducible and preserve explicit creation metadata, with `SOURCE_DATE_EPOCH` and Git timestamps as deterministic fallbacks.
- Reject existing output paths without modifying them; generic artifact reference names such as `latest` are explicit and optional.
- Preserve `=` in annotation values and reject invalid output formats before source packaging.
- Document `mod push`, `mod build`, `artifact push`, and `artifact build`, plus `bundle build`, `bundle apply`, and `bundle delete` examples.

## Why

Deterministic and sandboxed builders such as Nix need to package Timoni artifacts without network access while producing stable output hashes. Previously, artifact construction was coupled to registry push commands.

Closes #527.

## Reproduction

```shell
make build

./bin/timoni artifact build -f ./examples/redis -o /tmp/redis-artifact.oci.tar

# verify stable-output requirement
backup_path="/tmp/redis-artifact-$(date +%y%m%d%H%M%S).oci.tar"
mv /tmp/redis-artifact.oci.tar "$backup_path"
./bin/timoni artifact build -f ./examples/redis -o /tmp/redis-artifact.oci.tar
cmp "$backup_path" /tmp/redis-artifact.oci.tar || echo "Warning: archives are NOT byte-identical" >&2
skopeo inspect --raw oci-archive:/tmp/redis-artifact.oci.tar

./bin/timoni mod build ./examples/redis -v 1.0.0 -o /tmp/redis-module-1.0.0.oci.tar

skopeo inspect --raw oci-archive:/tmp/redis-module-1.0.0.oci.tar
```

Use `--format=oci-layout` to write a directory instead of the default archive.

## Out of scope

- Overwrite or timestamped backup modes; existing outputs remain rejected.
- Crash-durable atomic publication, including fsync and directory swaps.
- Stricter local reference validation and invalid `SOURCE_DATE_EPOCH` errors.
- Cleanup-error reporting and network-filesystem guarantees.
- Passing local OCI archives or layouts directly to `apply`, `bundle apply`, `mod pull`, or `artifact pull`.

## Verification

- `make test` on macOS, including generation, formatting, vet, envtest, and all Go packages.
- Native Linux/arm64 writer tests on the final tip, plus the full Linux/arm64 suite before the final writer-only hardening.
- `CGO_ENABLED=0 go build ./...` for native Linux/arm64 and the Windows/amd64 target.
- The reproduction commands above on the final committed tip.
- README module, artifact and bundle syntax checked against exact CLI help; local module and generic artifact archive smokes passed.
- Deterministic archive comparison from independent temporary roots.
- Network-disabled artifact and module build smokes.
- Skopeo 1.23.0 raw inspection and digest-preserving archive-to-layout and layout-to-archive round trips.

The archive-to-layout transport check used:

```shell
skopeo --insecure-policy copy --preserve-digests oci-archive:/tmp/redis-module-1.0.0.oci.tar oci:/tmp/redis-module-layout:1.0.0
skopeo inspect --raw oci:/tmp/redis-module-layout:1.0.0
```

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>