### PR TITLE
fix(oci): Harden local OCI outputs

### DIFF
--- a/internal/oci/write_image.go
+++ b/internal/oci/write_image.go
@@ -22,7 +22,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
@@ -38,6 +40,9 @@ const (
 	FormatLayout  LocalFormat = "oci-layout"
 )
 
+// localReferenceName matches Timoni's local reference-name syntax.
+var localReferenceName = regexp.MustCompile(`^[A-Za-z0-9]+(?:(?:[-._:@/+]|--)[A-Za-z0-9]+)*$`)
+
 // Validate reports whether the local OCI output format is supported.
 func (f LocalFormat) Validate() error {
 	if f != FormatLayout && f != FormatArchive {
@@ -47,14 +52,17 @@ func (f LocalFormat) Validate() error {
 }
 
 // WriteImage validates and writes an image to a new OCI layout or archive.
-// References become OCI layout descriptor names.
+// References become OCI layout descriptor names and must use Timoni's local syntax.
 func WriteImage(image gcrv1.Image, destination string, format LocalFormat, references []string) error {
 	if err := format.Validate(); err != nil {
 		return err
 	}
 	for _, ref := range references {
-		if ref == "" {
+		if strings.TrimSpace(ref) == "" {
 			return fmt.Errorf("OCI reference cannot be empty")
+		}
+		if !localReferenceName.MatchString(ref) {
+			return fmt.Errorf("invalid local OCI reference %q", ref)
 		}
 	}
 
@@ -107,8 +115,11 @@ func writeLayout(destination string, image gcrv1.Image, references []string) (er
 	return nil
 }
 
-// writeArchive creates a deterministic archive and removes it if writing fails.
+// writeArchive creates parent directories, writes a deterministic archive, and removes it if writing fails.
 func writeArchive(layoutPath, destination string) (err error) {
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return fmt.Errorf("creating output parent: %w", err)
+	}
 	output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		return fmt.Errorf("creating output archive: %w", err)

--- a/internal/oci/write_image_test.go
+++ b/internal/oci/write_image_test.go
@@ -38,10 +38,11 @@ func TestWriteImage(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	defer build.Close()
 
-	t.Run("layout with optional references", func(t *testing.T) {
+	t.Run("layout with local references", func(t *testing.T) {
 		g := NewWithT(t)
 		dst := filepath.Join(t.TempDir(), "nested", "artifact")
-		g.Expect(WriteImage(build.Image, dst, FormatLayout, []string{"1.0.0", "latest"})).To(Succeed())
+		references := []string{"1.0.0", "latest", "release/1.0.0", "release+candidate", "release@candidate", "release:candidate", "release--candidate"}
+		g.Expect(WriteImage(build.Image, dst, FormatLayout, references)).To(Succeed())
 
 		path, err := layout.FromPath(dst)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -49,10 +50,10 @@ func TestWriteImage(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		manifest, err := index.IndexManifest()
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(manifest.Manifests).To(HaveLen(2))
-		for i, tag := range []string{"1.0.0", "latest"} {
+		g.Expect(manifest.Manifests).To(HaveLen(len(references)))
+		for i, reference := range references {
 			g.Expect(manifest.Manifests[i].Digest).To(Equal(build.Digest))
-			g.Expect(manifest.Manifests[i].Annotations).To(HaveKeyWithValue("org.opencontainers.image.ref.name", tag))
+			g.Expect(manifest.Manifests[i].Annotations).To(HaveKeyWithValue("org.opencontainers.image.ref.name", reference))
 		}
 	})
 
@@ -69,6 +70,14 @@ func TestWriteImage(t *testing.T) {
 		secondBytes, err := os.ReadFile(second)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(bytes.Equal(firstBytes, secondBytes)).To(BeTrue())
+	})
+
+	t.Run("archive creates missing parent", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "nested", "artifact.tar")
+
+		g.Expect(WriteImage(build.Image, dst, FormatArchive, nil)).To(Succeed())
+		g.Expect(dst).To(BeAnExistingFile())
 	})
 
 	t.Run("existing archive remains untouched", func(t *testing.T) {
@@ -98,13 +107,27 @@ func TestWriteImage(t *testing.T) {
 	t.Run("invalid references leave no output", func(t *testing.T) {
 		for _, format := range []LocalFormat{FormatArchive, FormatLayout} {
 			t.Run(string(format), func(t *testing.T) {
-				g := NewWithT(t)
-				dst := filepath.Join(t.TempDir(), "artifact")
+				for _, tc := range []struct {
+					reference string
+					expect    string
+				}{
+					{"", "OCI reference cannot be empty"},
+					{"  ", "OCI reference cannot be empty"},
+					{"release candidate", "invalid local OCI reference"},
+					{"release\ncandidate", "invalid local OCI reference"},
+					{"-release", "invalid local OCI reference"},
+					{"release-", "invalid local OCI reference"},
+					{"release..candidate", "invalid local OCI reference"},
+					{"release---candidate", "invalid local OCI reference"},
+				} {
+					g := NewWithT(t)
+					dst := filepath.Join(t.TempDir(), "nested", "artifact")
 
-				err := WriteImage(build.Image, dst, format, []string{"valid", ""})
-				g.Expect(err).To(MatchError(ContainSubstring("OCI reference cannot be empty")))
-				_, statErr := os.Lstat(dst)
-				g.Expect(os.IsNotExist(statErr)).To(BeTrue())
+					err := WriteImage(build.Image, dst, format, []string{"valid", tc.reference})
+					g.Expect(err).To(MatchError(ContainSubstring(tc.expect)))
+					_, statErr := os.Lstat(filepath.Dir(dst))
+					g.Expect(os.IsNotExist(statErr)).To(BeTrue())
+				}
 			})
 		}
 	})


### PR DESCRIPTION
## What

- Create missing parent directories for local OCI archive outputs.
- Require Timoni local reference-name syntax for descriptor references.

## Why

OCI Image Layout leaves local reference names unrestricted. This applies a narrower Timoni local-reference policy and supports nested archive output paths.

## Reproduction

```shell
  ./bin/timoni artifact build -t  release/1.0.0  -f ./examples/redis -o ./out/nested/redis.oci.tar
! ./bin/timoni artifact build -t 'release 1.0.0' -f ./examples/redis -o ./out/invalid.oci.tar
# invalid local OCI reference "release 1.0.0"
test ! -e ./out/invalid.oci.tar
```

## Verification

- `go test ./internal/oci -run TestWriteImage`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>