### PR TITLE
fix(oci): Preflight registry tags

### DIFF
--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -92,6 +92,7 @@ func init() {
 	artifactCmd.AddCommand(pushArtifactCmd)
 }
 
+// pushArtifactCmdRun validates tags, builds, and pushes an OCI artifact.
 func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("repository URL is required")
@@ -99,6 +100,12 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	if len(pushArtifactArgs.tags) == 0 {
 		return fmt.Errorf("at least one tag is required")
+	}
+
+	for _, tag := range pushArtifactArgs.tags {
+		if err := oci.ValidateTag(tag); err != nil {
+			return err
+		}
 	}
 
 	fi, err := os.Stat(pushArtifactArgs.path)

--- a/cmd/timoni/artifact_push_test.go
+++ b/cmd/timoni/artifact_push_test.go
@@ -79,3 +79,10 @@ func Test_PushArtifact(t *testing.T) {
 	g.Expect(manifest.Layers[0].MediaType).To(BeEquivalentTo(apiv1.ContentMediaType))
 	g.Expect(manifest.Layers[0].Annotations[apiv1.ContentTypeAnnotation]).To(BeEquivalentTo("generic"))
 }
+
+func TestPushArtifactRejectsInvalidTagsBeforeInput(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := executeCommand("artifact push oci://registry.example.com/org/artifact -f /does/not/exist -t 1.0.0 -t .invalid")
+	g.Expect(err).To(MatchError(ContainSubstring("invalid OCI tag")))
+}

--- a/cmd/timoni/artifact_tag.go
+++ b/cmd/timoni/artifact_tag.go
@@ -53,6 +53,7 @@ func init() {
 	artifactCmd.AddCommand(tagArtifactCmd)
 }
 
+// tagArtifactCmdRun validates tags and adds them to an OCI artifact.
 func tagArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("artifact URL is required")
@@ -61,6 +62,11 @@ func tagArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	if len(tagArtifactArgs.tags) == 0 {
 		return fmt.Errorf("at least one tag is required")
+	}
+	for _, tag := range tagArtifactArgs.tags {
+		if err := oci.ValidateTag(tag); err != nil {
+			return err
+		}
 	}
 
 	spin := logger.StartSpinner("tagging artifact")

--- a/cmd/timoni/artifact_tag_test.go
+++ b/cmd/timoni/artifact_tag_test.go
@@ -65,3 +65,10 @@ func Test_TagArtifact(t *testing.T) {
 	_, err = crane.Pull(fmt.Sprintf("%s", aURL))
 	g.Expect(err).ToNot(HaveOccurred())
 }
+
+func TestTagArtifactRejectsInvalidTagsBeforeRegistry(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := executeCommand("artifact tag oci://registry.example.com/org/artifact:1.0.0 -t 1.0.1 -t .invalid")
+	g.Expect(err).To(MatchError(ContainSubstring("invalid OCI tag")))
+}

--- a/docs/bundle-distribution.md
+++ b/docs/bundle-distribution.md
@@ -48,6 +48,8 @@ When publishing bundles with [timoni artifact push](cmd/timoni_artifact_push.md)
 - attach custom metadata such as licenses, Git source and documentation links using the `--annotation` flag
 - sign the artifact using either with a [Cosign](https://github.com/sigstore/cosign) static key or Cosign keyless using the `--sign` flag
 
+Registry tags must follow the OCI Distribution tag grammar.
+
 ### Push and sign example
 
 Login to the container registry:

--- a/internal/oci/tag_artifact_test.go
+++ b/internal/oci/tag_artifact_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Stefan Prodan
+Copyright 2026 Stefan Prodan
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,18 +17,14 @@ limitations under the License.
 package oci
 
 import (
-	"github.com/google/go-containerregistry/pkg/crane"
+	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
-// TagArtifact validates and adds the tag to the remote OpenContainers artifact.
-func TagArtifact(ociURL, tag string, opts []crane.Option) error {
-	if err := ValidateTag(tag); err != nil {
-		return err
-	}
-	ref, err := parseArtifactRef(ociURL)
-	if err != nil {
-		return err
-	}
+func TestTagArtifactRejectsInvalidTagBeforeURL(t *testing.T) {
+	g := NewWithT(t)
 
-	return crane.Tag(ref.String(), tag, opts...)
+	err := TagArtifact("not an OCI URL", ".invalid", nil)
+	g.Expect(err).To(MatchError(ContainSubstring("invalid OCI tag")))
 }

--- a/internal/oci/url.go
+++ b/internal/oci/url.go
@@ -18,12 +18,16 @@ package oci
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
+
+// ociTag matches the OCI Distribution tag grammar.
+var ociTag = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$`)
 
 // ParseArtifactURL validates the OpenContainers URL and returns the address of the artifact.
 func ParseArtifactURL(ociURL string) (string, error) {
@@ -55,6 +59,15 @@ func ParseDigest(ociURL string) (name.Digest, error) {
 	return name.NewDigest(ref.String())
 }
 
+// ValidateTag reports whether tag follows the OCI Distribution tag grammar.
+func ValidateTag(tag string) error {
+	if !ociTag.MatchString(tag) {
+		return fmt.Errorf("invalid OCI tag %q", tag)
+	}
+	return nil
+}
+
+// parseArtifactRef validates an OpenContainers artifact reference.
 func parseArtifactRef(ociURL string) (name.Reference, error) {
 	if !strings.HasPrefix(ociURL, apiv1.ArtifactPrefix) {
 		return nil, fmt.Errorf("URL must be in format 'oci://<domain>/<org>/<repo>'")
@@ -64,6 +77,11 @@ func parseArtifactRef(ociURL string) (name.Reference, error) {
 	ref, err := name.ParseReference(url)
 	if err != nil {
 		return nil, fmt.Errorf("'%s' invalid URL: %w", ociURL, err)
+	}
+	if tag, ok := ref.(name.Tag); ok {
+		if err := ValidateTag(tag.TagStr()); err != nil {
+			return nil, fmt.Errorf("'%s' invalid URL: %w", ociURL, err)
+		}
 	}
 
 	return ref, nil

--- a/internal/oci/url_test.go
+++ b/internal/oci/url_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestValidateTag(t *testing.T) {
+	g := NewWithT(t)
+
+	for _, tag := range []string{"1.0.0", "_release", strings.Repeat("a", 128)} {
+		g.Expect(ValidateTag(tag)).To(Succeed())
+	}
+
+	for _, tag := range []string{"", ".release", "-release", strings.Repeat("a", 129)} {
+		g.Expect(ValidateTag(tag)).To(MatchError(ContainSubstring("invalid OCI tag")))
+	}
+}
+
+func TestParseArtifactURLTags(t *testing.T) {
+	g := NewWithT(t)
+
+	for _, tag := range []string{"1.0.0", "_release", "release-1", "release..1"} {
+		_, err := ParseArtifactURL(fmt.Sprintf("oci://example.com/org/artifact:%s", tag))
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	for _, tag := range []string{".release", "-release"} {
+		_, err := ParseArtifactURL(fmt.Sprintf("oci://example.com/org/artifact:%s", tag))
+		g.Expect(err).To(MatchError(ContainSubstring("invalid OCI tag")))
+	}
+
+	for _, tag := range []string{"release/1", "release+1"} {
+		_, err := ParseArtifactURL(fmt.Sprintf("oci://example.com/org/artifact:%s", tag))
+		g.Expect(err).To(HaveOccurred())
+	}
+}


### PR DESCRIPTION
## What

- Validate OCI Distribution tag syntax in artifact references and tag values.
- Reject every invalid `--tag` before input processing or registry I/O.
- Document the requirement.

## Why

The go-containerregistry parser accepts leading `.` and `-` tags that OCI Distribution rejects. Preflight prevents invalid artifacts from being built or published.

## Reproduction

```shell
! ./bin/timoni artifact push oci://registry.example.com/org/artifact -f /does/not/exist -t 1.0.0 -t .invalid
# invalid OCI tag ".invalid"
```

## Verification

- `go test ./internal/oci -run 'Test(ValidateTag|ParseArtifactURLTags|TagArtifactRejectsInvalidTagBeforeURL)'`
- `go test ./cmd/timoni -run 'Test(TagArtifactRejectsInvalidTagsBeforeRegistry|PushArtifactRejectsInvalidTagsBeforeInput)'` (requires envtest)

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>