### PR TITLE
fix(mod): Centralize version validation

### DIFF
--- a/cmd/timoni/mod_build.go
+++ b/cmd/timoni/mod_build.go
@@ -20,13 +20,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/flags"
 	"github.com/stefanprodan/timoni/internal/logger"
 	"github.com/stefanprodan/timoni/internal/oci"
 )
@@ -60,19 +59,13 @@ func init() {
 	modCmd.AddCommand(buildModCmd)
 }
 
-// buildModCmdRun validates, builds, and writes a local module artifact.
+// buildModCmdRun validates the module version, builds, and writes a local module artifact.
 func buildModCmdRun(cmd *cobra.Command, args []string) error {
 	if buildModArgs.output == "" {
 		return fmt.Errorf("output path is required")
 	}
-	if buildModArgs.version == "" {
-		return fmt.Errorf("version is required")
-	}
-	if strings.Contains(buildModArgs.version, "+") {
-		return fmt.Errorf("version build metadata is not supported")
-	}
-	if _, err := semver.StrictNewVersion(buildModArgs.version); err != nil {
-		return fmt.Errorf("version is not in semver format: %w", err)
+	if err := flags.ValidateModuleVersion(buildModArgs.version); err != nil {
+		return err
 	}
 	format := oci.LocalFormat(buildModArgs.format)
 	if err := format.Validate(); err != nil {

--- a/cmd/timoni/mod_build_test.go
+++ b/cmd/timoni/mod_build_test.go
@@ -78,3 +78,13 @@ func Test_BuildModValidatesFormatBeforeSource(t *testing.T) {
 	_, err := executeCommand("mod build missing -v 1.0.0 -o output --format invalid")
 	g.Expect(err).To(MatchError("unsupported OCI output format \"invalid\""))
 }
+
+func Test_BuildModRejectsBuildMetadataVersion(t *testing.T) {
+	g := NewWithT(t)
+	output := filepath.Join(t.TempDir(), "module.tar")
+	_, err := executeCommand(fmt.Sprintf(
+		"mod build testdata/module -v 1.0.0+demo -o %s",
+		output,
+	))
+	g.Expect(err).To(MatchError(ContainSubstring("version build metadata is not supported")))
+}

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
@@ -107,6 +106,7 @@ func init() {
 	modCmd.AddCommand(pushModCmd)
 }
 
+// pushModCmdRun validates the module version, builds, and pushes a module artifact.
 func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return fmt.Errorf("module and URL are required")
@@ -114,8 +114,8 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	pushModArgs.module = args[0]
 
 	version := pushModArgs.version.String()
-	if _, err := semver.StrictNewVersion(version); err != nil {
-		return fmt.Errorf("version is not in semver format: %w", err)
+	if err := flags.ValidateModuleVersion(version); err != nil {
+		return err
 	}
 
 	ociURL := fmt.Sprintf("%s:%s", args[1], version)

--- a/cmd/timoni/mod_push_test.go
+++ b/cmd/timoni/mod_push_test.go
@@ -93,3 +93,16 @@ func Test_PushMod(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(manifest.Annotations[apiv1.VersionAnnotation]).To(BeEquivalentTo(newVer))
 }
+
+func Test_PushModRejectsBuildMetadataVersion(t *testing.T) {
+	g := NewWithT(t)
+	modPath := "testdata/module"
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
+
+	_, err := executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v 1.0.0+demo",
+		modPath,
+		modURL,
+	))
+	g.Expect(err).To(MatchError(ContainSubstring("version build metadata is not supported")))
+}

--- a/docs/bundle-distribution.md
+++ b/docs/bundle-distribution.md
@@ -124,7 +124,7 @@ If the artifact was signed using Cosign keyless, you can verify it with:
 timoni artifact pull oci://docker.io/org/app:latest \
   --verify cosign \
   --certificate-identity-regexp="^https://github.com/org/.*$" \
-  --certificate-oidc-issuer-regex="^https://token.actions.githubusercontent.com.*$"
+  --certificate-oidc-issuer-regexp="^https://token.actions.githubusercontent.com.*$"
 ```
 
 The above command will extract all the files from the remote artifact into the current directory.

--- a/internal/flags/version.go
+++ b/internal/flags/version.go
@@ -1,6 +1,9 @@
 package flags
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/Masterminds/semver/v3"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
@@ -12,6 +15,21 @@ func (f *Version) String() string {
 	return string(*f)
 }
 
+// ValidateModuleVersion validates a Timoni module version and OCI tag.
+func ValidateModuleVersion(version string) error {
+	if version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if strings.Contains(version, "+") {
+		return fmt.Errorf("version build metadata is not supported")
+	}
+	if _, err := semver.StrictNewVersion(version); err != nil {
+		return fmt.Errorf("version is not in semver format: %w", err)
+	}
+	return nil
+}
+
+// Set validates a generic semantic version flag.
 func (f *Version) Set(str string) error {
 	if str != "" && str != apiv1.LatestVersion {
 		if _, err := semver.StrictNewVersion(str); err != nil {

--- a/internal/flags/version_test.go
+++ b/internal/flags/version_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestValidateModuleVersion(t *testing.T) {
+	g := NewWithT(t)
+
+	for _, version := range []string{"1.0.0", "2.0.0-rc.1"} {
+		g.Expect(ValidateModuleVersion(version)).To(Succeed())
+	}
+
+	for version, expected := range map[string]string{
+		"":           "version is required",
+		"1.0":        "version is not in semver format",
+		"1.0.0+demo": "version build metadata is not supported",
+	} {
+		g.Expect(ValidateModuleVersion(version)).To(MatchError(ContainSubstring(expected)))
+	}
+}


### PR DESCRIPTION
## What

- Validate module versions through one shared check in `mod build` and `mod push`.
- Reject empty, malformed, and build-metadata versions before local output or publishing.
- Correct the OIDC issuer regexp flag name in the bundle distribution example.

## Why

A module version is also its OCI tag. Both commands reject build metadata before side effects.

## Reproduction

```shell
! ./bin/timoni mod build testdata/module -v 1.0.0+demo -o ./tmp/module.oci.tar
# version build metadata is not supported
! ./bin/timoni mod push /does/not/exist oci://localhost:5000/module -v 1.0.0+demo
# version build metadata is not supported
```

## Verification

- `go test ./internal/flags -run TestValidateModuleVersion`
- `go test ./cmd/timoni -run 'Test_(BuildMod|PushMod)RejectsBuildMetadataVersion'` (requires envtest)
- `rg --fixed-strings -- '--certificate-oidc-issuer-regexp' docs/bundle-distribution.md`
- `! rg --fixed-strings -- '--certificate-oidc-issuer-regex=' docs/bundle-distribution.md`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>