### PR TITLE
fix(engine): Preserve unknown CRD array fields

### DIFF
--- a/internal/engine/importer.go
+++ b/internal/engine/importer.go
@@ -127,7 +127,8 @@ type VersionedSchema struct {
 	Schema cue.Value
 }
 
-// convertCRD converts a CRD CUE value into its naming metadata and versioned CUE schemas.
+// convertCRD converts a CRD CUE value into naming metadata and versioned CUE
+// schemas, applying supported Kubernetes extensions.
 func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 	cc := &IntermediateCRD{
 		Schemas: make([]VersionedSchema, 0),
@@ -236,8 +237,8 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 
 		var walkfn func(path []cue.Selector, sch *openapi3.Schema) error
 		walkfn = func(path []cue.Selector, sch *openapi3.Schema) error {
-			_, has := sch.Extensions["x-kubernetes-preserve-unknown-fields"]
-			if has {
+			preserveUnknownFields, _ := sch.Extensions["x-kubernetes-preserve-unknown-fields"].(bool)
+			if preserveUnknownFields {
 				preserve = append(preserve, cue.MakePath(path...))
 			}
 			for name, prop := range sch.Properties {

--- a/internal/engine/importer.go
+++ b/internal/engine/importer.go
@@ -127,6 +127,7 @@ type VersionedSchema struct {
 	Schema cue.Value
 }
 
+// convertCRD converts a CRD CUE value into its naming metadata and versioned CUE schemas.
 func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 	cc := &IntermediateCRD{
 		Schemas: make([]VersionedSchema, 0),
@@ -215,7 +216,7 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 			panic("unreachable")
 		}
 
-		// construct a map of all the paths that have x-kubernetes-embedded-resource: true defined
+		// Collect all paths with x-kubernetes-preserve-unknown-fields: true.
 		yodoc, err := yaml.Encode(doc)
 		if err != nil {
 			return nil, fmt.Errorf("error encoding intermediate openapi doc to yaml bytes: %w", err)
@@ -225,7 +226,7 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 			return nil, fmt.Errorf("could not load openapi3 document for version %s: %w", ver, err)
 		}
 
-		preserve := make(map[string]bool)
+		preserve := make([]cue.Path, 0)
 		var rootosch *openapi3.Schema
 		if rref, has := odoc.Components.Schemas[kname]; !has {
 			return nil, fmt.Errorf("could not find root schema for version %s at expected path components.schemas.%s", ver, kname)
@@ -236,9 +237,19 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 		var walkfn func(path []cue.Selector, sch *openapi3.Schema) error
 		walkfn = func(path []cue.Selector, sch *openapi3.Schema) error {
 			_, has := sch.Extensions["x-kubernetes-preserve-unknown-fields"]
-			preserve[cue.MakePath(path...).String()] = has
+			if has {
+				preserve = append(preserve, cue.MakePath(path...))
+			}
 			for name, prop := range sch.Properties {
-				if err := walkfn(append(path, cue.Str(name)), prop.Value); err != nil {
+				// Limit capacity so sibling paths cannot overwrite each other during recursion.
+				nextPath := append(path[:len(path):len(path)], cue.Str(name))
+				if err := walkfn(nextPath, prop.Value); err != nil {
+					return err
+				}
+			}
+			if sch.Items != nil {
+				nextPath := append(path[:len(path):len(path)], cue.AnyIndex)
+				if err := walkfn(nextPath, sch.Items.Value); err != nil {
 					return err
 				}
 			}
@@ -256,8 +267,6 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 		// 'x-kubernetes-preserve-unknown-fields: true'.
 		// Note that this implementation is only correct for CUE inputs that do not contain references.
 		// It is safe to use in this context because CRDs already have that invariant.
-		var stack []ast.Node
-		var pathstack []cue.Selector
 		astutil.Apply(schast, func(c astutil.Cursor) bool {
 			// Skip the root
 			if c.Parent() == nil {
@@ -266,27 +275,10 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 
 			switch x := c.Node().(type) {
 			case *ast.StructLit:
-				psel, pc := parentPath(c)
-				// Finding the parent-of-parent in this way is questionable.
-				// pathTo will hop up the tree a potentially large number of
-				// levels until it finds an *ast.Field or *ast.ListLit...but
-				// who knows what's between here and there?
-				_, ppc := parentPath(pc)
-				var i int
-				if ppc != nil {
-					for i = len(stack); i > 0 && stack[i-1] != ppc.Node(); i-- {
-					}
-				}
-				stack = append(stack[:i], pc.Node())
-				pathstack = append(pathstack[:i], psel)
-
-				// Risk not closing up fields that are not marked with 'x-kubernetes-preserve-unknown-fields: true'
-				// if the current field name matches a path that is marked with preserve unknown.
-				// TODO: find a way to fix parentPath when arrays are involved.
-				currentPath := cue.MakePath(pathstack...).String()
+				currentPath := structPath(c)
 				found := false
-				for k, ok := range preserve {
-					if strings.HasSuffix(k, currentPath) && ok {
+				for _, path := range preserve {
+					if preservePathMatches(path, currentPath) {
 						found = true
 						break
 					}
@@ -404,4 +396,41 @@ func parentPath(c astutil.Cursor) (cue.Selector, astutil.Cursor) {
 	}
 
 	return cue.Selector{}, nil
+}
+
+// structPath returns the CUE path to a struct literal from its AST parents.
+func structPath(c astutil.Cursor) cue.Path {
+	var selectors []cue.Selector
+	for {
+		selector, parent := parentPath(c)
+		if parent == nil {
+			break
+		}
+		selectors = append(selectors, selector)
+		c = parent
+	}
+	for i, j := 0, len(selectors)-1; i < j; i, j = i+1, j-1 {
+		selectors[i], selectors[j] = selectors[j], selectors[i]
+	}
+	return cue.MakePath(selectors...)
+}
+
+// preservePathMatches reports whether current is a suffix of preserved, treating AnyIndex as a wildcard.
+func preservePathMatches(preserved, current cue.Path) bool {
+	pattern := preserved.Selectors()
+	actual := current.Selectors()
+	if len(pattern) < len(actual) {
+		return false
+	}
+	for i := 1; i <= len(actual); i++ {
+		want := pattern[len(pattern)-i]
+		got := actual[len(actual)-i]
+		if want.String() == cue.AnyIndex.String() && got.Type().LabelType() == cue.IndexLabel {
+			continue
+		}
+		if want.String() != got.String() {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/engine/importer_test.go
+++ b/internal/engine/importer_test.go
@@ -341,6 +341,33 @@ func TestConvertCRD(t *testing.T) {
 	}
 }`,
 		},
+		{
+			name: "array-item-xk-preserve",
+			spec: `type: "object"
+			properties: {
+				resources: {
+					properties: claims: {
+						items: {
+							properties: name: type: "string"
+							required: ["name"]
+							type: "object"
+							"x-kubernetes-preserve-unknown-fields": true
+						}
+						type: "array"
+					}
+					type: "object"
+				}
+			}
+			`,
+			expect: `{
+	resources?: {
+		claims?: [...{
+			name!: string
+			...
+		}]
+	}
+}`,
+		},
 	}
 
 	for _, item := range table {

--- a/internal/engine/importer_test.go
+++ b/internal/engine/importer_test.go
@@ -368,6 +368,32 @@ func TestConvertCRD(t *testing.T) {
 	}
 }`,
 		},
+		{
+			name: "array-item-xk-preserve-false",
+			spec: `type: "object"
+			properties: {
+				resources: {
+					properties: claims: {
+						items: {
+							properties: name: type: "string"
+							required: ["name"]
+							type: "object"
+							"x-kubernetes-preserve-unknown-fields": false
+						}
+						type: "array"
+					}
+					type: "object"
+				}
+			}
+			`,
+			expect: `{
+	resources?: {
+		claims?: [...{
+			name!: string
+		}]
+	}
+}`,
+		},
 	}
 
 	for _, item := range table {


### PR DESCRIPTION
## What

- Traverse OpenAPI array items when collecting preservation paths.
- Preserve unknown fields only when the Kubernetes extension is `true`.

## Why

Some CRDs, including OpenKruise SidecarSet, preserve unknown fields on array items. Timoni generated closed CUE objects for those items.

## Reproduction

```shell
timoni mod init module .
timoni mod vendor crd ./module -f https://raw.githubusercontent.com/openkruise/kruise/828b8ca4c2c0176b76b2cd43284cb74010e10ad1/config/crd/bases/apps.kruise.io_sidecarsets.yaml
awk '/^[[:space:]]*containers\?: \[\.\.\.\{/ {show=1} show {print; text=$0; sub(/\/\/.*/, "", text); opens=gsub(/\{/, "", text); closes=gsub(/\}/, "", text); depth+=opens-closes; if (depth==0) exit}' ./module/cue.mod/gen/apps.kruise.io/sidecarset/v1alpha1/types_gen.cue
# main closes the array item; this branch emits `...`.
```

## Verification

- `go test ./internal/engine -count=1`
- `make test`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>