### PR TITLE
fix(oci): Validate module cache layers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.13
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/gomega v1.42.1
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/otiai10/copy v1.14.1
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/rs/zerolog v1.35.1
@@ -106,7 +107,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oasdiff/yaml v0.1.1 // indirect
 	github.com/oasdiff/yaml3 v0.0.14 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect

--- a/internal/oci/module_test.go
+++ b/internal/oci/module_test.go
@@ -19,11 +19,14 @@ package oci
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	godigest "github.com/opencontainers/go-digest"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
@@ -111,4 +114,47 @@ func TestModuleOperations(t *testing.T) {
 	cachedLayers, err := os.ReadDir(cacheDir)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(cachedLayers)).To(BeEquivalentTo(2))
+
+	blockedDestination := filepath.Join(tmpDir, "blocked-artifact")
+	err = os.WriteFile(blockedDestination, []byte("blocked"), 0o600)
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = PullModule(digestURL, blockedDestination, cacheDir, opts)
+	g.Expect(err).To(HaveOccurred())
+	for _, layer := range cachedLayers {
+		g.Expect(filepath.Join(cacheDir, layer.Name())).To(BeAnExistingFile())
+	}
+
+	corruptLayer := filepath.Join(cacheDir, cachedLayers[0].Name())
+	err = os.WriteFile(corruptLayer, []byte("invalid layer"), 0o600)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = PullModule(digestURL, filepath.Join(tmpDir, "recovered-artifact"), cacheDir, opts)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(corruptLayer).To(BeAnExistingFile())
+	contents, err := os.ReadFile(corruptLayer)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(contents).ToNot(Equal([]byte("invalid layer")))
+}
+
+// TestWriteCachedLayer verifies atomic publication by concurrent writers.
+func TestWriteCachedLayer(t *testing.T) {
+	g := NewWithT(t)
+	cachedLayer := filepath.Join(t.TempDir(), "layer.tgz")
+	remote, writer := io.Pipe()
+	errCh := make(chan error, 1)
+	expectedDigest := godigest.FromString("layer")
+
+	go func() {
+		errCh <- writeCachedLayer(cachedLayer, remote, expectedDigest)
+	}()
+
+	_, err := writer.Write([]byte("layer"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cachedLayer).ToNot(BeAnExistingFile())
+	g.Expect(writeCachedLayer(cachedLayer, strings.NewReader("layer"), expectedDigest)).To(Succeed())
+	g.Expect(writer.Close()).To(Succeed())
+	g.Expect(<-errCh).To(Succeed())
+	contents, err := os.ReadFile(cachedLayer)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(contents).To(Equal([]byte("layer")))
 }

--- a/internal/oci/pull_module.go
+++ b/internal/oci/pull_module.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/fluxcd/pkg/tar"
 	"github.com/google/go-containerregistry/pkg/crane"
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	godigest "github.com/opencontainers/go-digest"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
@@ -34,8 +35,8 @@ import (
 // - determines the artifact digest corresponding to the module version
 // - fetches the manifest of the remote artifact
 // - verifies that artifact config matches Timoni's media type
-// - downloads all the compressed layer matching Timoni's media type (if not cached)
-// - stores the compressed layers in the local cache (if caching is enabled)
+// - downloads all compressed layers matching Timoni's media type (if not cached)
+// - atomically stores the compressed layers in the local cache (if caching is enabled)
 // - extracts the module contents to the destination directory
 func PullModule(ociURL, dstPath, cacheDir string, opts []crane.Option) (*apiv1.ModuleReference, error) {
 	ref, err := parseArtifactRef(ociURL)
@@ -98,10 +99,15 @@ func PullModule(ociURL, dstPath, cacheDir string, opts []crane.Option) (*apiv1.M
 			layerDigest := layer.Digest.String()
 			blobURL := fmt.Sprintf("%s@%s", repoURL, layerDigest)
 
-			isCached := false
-			cachedLayer := path.Join(cacheDir, fmt.Sprintf("%s.tgz", layer.Digest.Hex))
-			if _, err := os.Stat(cachedLayer); err == nil {
-				isCached = true
+			cachedLayer := filepath.Join(cacheDir, fmt.Sprintf("%s.tgz", layer.Digest.Hex))
+			expectedDigest, err := godigest.Parse(layerDigest)
+			if err != nil {
+				return nil, fmt.Errorf("parsing layer digest %s failed: %w", layerDigest, err)
+			}
+
+			isCached, err := verifyCachedLayer(cachedLayer, expectedDigest)
+			if err != nil {
+				return nil, fmt.Errorf("reading layer from storage failed: %w", err)
 			}
 
 			// Pull the compressed layer from the registry and persist the gzip tarball
@@ -117,16 +123,7 @@ func PullModule(ociURL, dstPath, cacheDir string, opts []crane.Option) (*apiv1.M
 					return nil, fmt.Errorf("pulling layer %s failed: %w", layerDigest, err)
 				}
 
-				local, err := os.Create(cachedLayer)
-				if err != nil {
-					return nil, fmt.Errorf("writing layer to storage failed: %w", err)
-				}
-
-				if _, err := io.Copy(local, remote); err != nil {
-					return nil, fmt.Errorf("writing layer to storage failed: %w", err)
-				}
-
-				if err := local.Close(); err != nil {
+				if err := writeCachedLayer(cachedLayer, remote, expectedDigest); err != nil {
 					return nil, fmt.Errorf("writing layer to storage failed: %w", err)
 				}
 			}
@@ -137,10 +134,8 @@ func PullModule(ociURL, dstPath, cacheDir string, opts []crane.Option) (*apiv1.M
 			}
 
 			// Extract the contents from the gzip tarball stored in cache.
-			// If extraction fails, the gzip tarball is removed from cache.
 			if err = tar.Untar(reader, dstPath, tar.WithMaxUntarSize(-1)); err != nil {
 				_ = reader.Close()
-				_ = os.Remove(cachedLayer)
 				return nil, fmt.Errorf("extracting layer %s failed: %w", layerDigest, err)
 			}
 
@@ -155,4 +150,55 @@ func PullModule(ociURL, dstPath, cacheDir string, opts []crane.Option) (*apiv1.M
 	}
 
 	return moduleRef, nil
+}
+
+// verifyCachedLayer reports whether cachedLayer matches expectedDigest.
+func verifyCachedLayer(cachedLayer string, expectedDigest godigest.Digest) (bool, error) {
+	local, err := os.Open(cachedLayer)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer local.Close()
+
+	verifier := expectedDigest.Verifier()
+	if _, err := io.Copy(verifier, local); err != nil {
+		return false, err
+	}
+	return verifier.Verified(), nil
+}
+
+// writeCachedLayer verifies and publishes a complete compressed layer at cachedLayer.
+func writeCachedLayer(cachedLayer string, remote io.Reader, expectedDigest godigest.Digest) error {
+	local, err := os.CreateTemp(filepath.Dir(cachedLayer), ".layer-*")
+	if err != nil {
+		return err
+	}
+	temporaryLayer := local.Name()
+	defer func() {
+		_ = os.Remove(temporaryLayer)
+	}()
+
+	verifier := expectedDigest.Verifier()
+	if _, err := io.Copy(io.MultiWriter(local, verifier), remote); err != nil {
+		_ = local.Close()
+		return err
+	}
+	if !verifier.Verified() {
+		_ = local.Close()
+		return fmt.Errorf("layer digest mismatch: expected %s", expectedDigest)
+	}
+	if err := local.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(temporaryLayer, cachedLayer); err != nil {
+		if valid, verifyErr := verifyCachedLayer(cachedLayer, expectedDigest); verifyErr == nil && valid {
+			return nil
+		}
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## What

- Verify cached and downloaded layers against their manifest digest.
- Publish complete layers atomically and repair corrupt cache entries.

## Why

Concurrent fetches share digest-named cache files. Readers could observe partial or corrupt layers, while extraction cleanup could remove a file another process owns.

## Reproduction

`go test ./internal/oci -run 'Test(ModuleOperations|WriteCachedLayer)$' -count=1`

Before this patch, the corrupt-cache regression fails with `gzip: invalid header`. The atomic-write test also verifies that concurrent writers publish only complete, valid content.

## Verification

`go test ./internal/oci -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>