### PR TITLE
fix(fetcher): Allow uncached OCI fetching

### DIFF
--- a/internal/engine/fetcher/oci.go
+++ b/internal/engine/fetcher/oci.go
@@ -56,6 +56,7 @@ func (f *OCI) GetModuleRoot() string {
 
 // Fetch copies the module contents to the destination directory.
 // The artifact is pulled from the registry and its contents extracted to the destination dir.
+// An empty cache directory disables persistent caching.
 func (f *OCI) Fetch() (*apiv1.ModuleReference, error) {
 	dstDir := f.GetModuleRoot()
 
@@ -68,8 +69,10 @@ func (f *OCI) Fetch() (*apiv1.ModuleReference, error) {
 		return nil, err
 	}
 
-	if err := os.MkdirAll(f.cacheDir, os.ModePerm); err != nil {
-		return nil, err
+	if f.cacheDir != "" {
+		if err := os.MkdirAll(f.cacheDir, os.ModePerm); err != nil {
+			return nil, err
+		}
 	}
 
 	opts := oci.Options(f.ctx, f.creds, f.insecure)

--- a/internal/engine/fetcher/oci_test.go
+++ b/internal/engine/fetcher/oci_test.go
@@ -64,6 +64,25 @@ func TestOCIFetch(t *testing.T) {
 	digestUrl, err := oci.PushModule(imgVersionURL, srcPath, imgIgnore, map[string]string{}, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 
+	t.Run("without cache", func(t *testing.T) {
+		g := NewWithT(t)
+
+		of := NewOCI(
+			context.Background(),
+			imgURL,
+			imgVersion,
+			filepath.Join(t.TempDir(), "dst"),
+			"",
+			"",
+			true,
+		)
+
+		mr, err := of.Fetch()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(mr.Repository).To(Equal(imgURL))
+		g.Expect(filepath.Join(of.GetModuleRoot(), "cue.mod/module.cue")).To(BeARegularFile())
+	})
+
 	t.Run("with version", func(t *testing.T) {
 		g := NewWithT(t)
 


### PR DESCRIPTION
## What

Pass an empty cache directory through to the OCI module puller so it can use an ephemeral cache.

## Why

Disabling caching leaves the cache directory empty, but the OCI fetcher called `MkdirAll("")` and failed before pulling the module.

## Reproduction

`go test ./internal/engine/fetcher -run 'TestOCIFetch/without_cache' -count=1`

Expected stderr before this patch: `mkdir : no such file or directory`.

## Verification

`go test ./internal/engine/fetcher -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>