### PR TITLE
fix(engine): Preserve unknown CRD map value fields

### DIFF
--- a/internal/engine/importer.go
+++ b/internal/engine/importer.go
@@ -254,6 +254,12 @@ func convertCRD(crd cue.Value) (*IntermediateCRD, error) {
 					return err
 				}
 			}
+			if sch.AdditionalProperties.Schema != nil {
+				nextPath := append(path[:len(path):len(path)], cue.AnyString)
+				if err := walkfn(nextPath, sch.AdditionalProperties.Schema.Value); err != nil {
+					return err
+				}
+			}
 
 			return nil
 		}
@@ -380,6 +386,11 @@ func parentPath(c astutil.Cursor) (cue.Selector, astutil.Cursor) {
 	for p != nil {
 		switch x := p.Node().(type) {
 		case *ast.Field:
+			// Pattern constraints like `[string]: ...` have a list label;
+			// they are how the openapi encoder renders additionalProperties.
+			if _, ok := x.Label.(*ast.ListLit); ok {
+				return cue.AnyString, p
+			}
 			lab, _, _ := ast.LabelName(x.Label)
 			if strings.HasPrefix(lab, "#") {
 				return cue.Def(lab), p
@@ -416,7 +427,10 @@ func structPath(c astutil.Cursor) cue.Path {
 	return cue.MakePath(selectors...)
 }
 
-// preservePathMatches reports whether current is a suffix of preserved, treating AnyIndex as a wildcard.
+// preservePathMatches reports whether current is a suffix of preserved,
+// treating AnyIndex as a wildcard for concrete list indices. Selector types
+// take part in the comparison because AnyIndex and AnyString share the same
+// string form ("[_]").
 func preservePathMatches(preserved, current cue.Path) bool {
 	pattern := preserved.Selectors()
 	actual := current.Selectors()
@@ -426,10 +440,10 @@ func preservePathMatches(preserved, current cue.Path) bool {
 	for i := 1; i <= len(actual); i++ {
 		want := pattern[len(pattern)-i]
 		got := actual[len(actual)-i]
-		if want.String() == cue.AnyIndex.String() && got.Type().LabelType() == cue.IndexLabel {
+		if want.Type() == cue.AnyIndex.Type() && got.Type().LabelType() == cue.IndexLabel {
 			continue
 		}
-		if want.String() != got.String() {
+		if want.Type() != got.Type() || want.String() != got.String() {
 			return false
 		}
 	}

--- a/internal/engine/importer_test.go
+++ b/internal/engine/importer_test.go
@@ -394,6 +394,79 @@ func TestConvertCRD(t *testing.T) {
 	}
 }`,
 		},
+		{
+			name: "map-value-xk-preserve",
+			spec: `type: "object"
+			properties: {
+				policies: {
+					additionalProperties: {
+						properties: module: type: "string"
+						required: ["module"]
+						type: "object"
+						"x-kubernetes-preserve-unknown-fields": true
+					}
+					type: "object"
+				}
+			}
+			`,
+			expect: `{
+	policies?: {
+		[string]: {
+			module!: string
+			...
+		}
+	}
+}`,
+		},
+		{
+			name: "map-value-nested-xk-preserve",
+			spec: `type: "object"
+			properties: {
+				flags: {
+					additionalProperties: {
+						properties: {
+							state: type: "string"
+							variants: {
+								type: "object"
+								"x-kubernetes-preserve-unknown-fields": true
+							}
+						}
+						type: "object"
+					}
+					type: "object"
+				}
+			}
+			`,
+			expect: `{
+	flags?: {
+		[string]: {
+			state?: string
+			variants?: {
+				...
+			}
+		}
+	}
+}`,
+		},
+		{
+			name: "map-value-untyped-xk-preserve",
+			spec: `type: "object"
+			properties: {
+				inputs: {
+					items: {
+						additionalProperties: "x-kubernetes-preserve-unknown-fields": true
+						type: "object"
+					}
+					type: "array"
+				}
+			}
+			`,
+			expect: `{
+	inputs?: [...{
+		[string]: _
+	}]
+}`,
+		},
 	}
 
 	for _, item := range table {
@@ -422,4 +495,12 @@ func TestConvertCRD(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPreservePathMatchesSelectorTypes(t *testing.T) {
+	g := NewWithT(t)
+	suffix := cue.Str("variants")
+
+	g.Expect(preservePathMatches(cue.MakePath(cue.AnyString, suffix), cue.MakePath(cue.Index(0), suffix))).To(BeFalse())
+	g.Expect(preservePathMatches(cue.MakePath(cue.AnyIndex, suffix), cue.MakePath(cue.Str("key"), suffix))).To(BeFalse())
 }


### PR DESCRIPTION
Followup: #566 

Keep map value objects open for CRDs such as OpenFeature FeatureFlag and Kubewarden AdmissionPolicyGroup, which set x-kubernetes-preserve-unknown-fields on schemas nested under additionalProperties.