### PR TITLE
fix(engine): Return CUE lookup errors

### DIFF
--- a/internal/engine/utils.go
+++ b/internal/engine/utils.go
@@ -102,6 +102,7 @@ func ExtractValueFromFile(ctx *cue.Context, filePath, expr string) (cue.Value, e
 	return ExtractValueFromBytes(ctx, vData, expr)
 }
 
+// ExtractValueFromBytes compiles data and returns the value at expr or an error.
 func ExtractValueFromBytes(ctx *cue.Context, data []byte, expr string) (cue.Value, error) {
 	vObj := ctx.CompileBytes(data)
 	if vObj.Err() != nil {
@@ -109,8 +110,8 @@ func ExtractValueFromBytes(ctx *cue.Context, data []byte, expr string) (cue.Valu
 	}
 
 	value := vObj.LookupPath(cue.ParsePath(expr))
-	if value.Err() != nil {
-		return cue.Value{}, vObj.Err()
+	if err := value.Err(); err != nil {
+		return cue.Value{}, err
 	}
 
 	return value, nil

--- a/internal/engine/utils_test.go
+++ b/internal/engine/utils_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"cuelang.org/go/cue/cuecontext"
 	. "github.com/onsi/gomega"
 )
 
@@ -68,4 +69,11 @@ func TestIsFileUrl(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(IsFileUrl("file://afile.txt")).To(BeTrueBecause("file:// is a file URL"))
 	g.Expect(IsFileUrl("oci://foo/bar")).To(BeFalseBecause("oci:// is not a file URL"))
+}
+
+func TestExtractValueFromBytesLookupError(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := ExtractValueFromBytes(cuecontext.New(), []byte("other: true"), "values")
+	g.Expect(err).To(HaveOccurred())
 }

--- a/internal/engine/utils_test.go
+++ b/internal/engine/utils_test.go
@@ -75,5 +75,5 @@ func TestExtractValueFromBytesLookupError(t *testing.T) {
 	g := NewWithT(t)
 
 	_, err := ExtractValueFromBytes(cuecontext.New(), []byte("other: true"), "values")
-	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("not found")))
 }


### PR DESCRIPTION
## What

Return the selected CUE value's lookup error instead of the compiled root's nil error.

## Why

A missing expression reports a generic downstream error instead of the lookup failure.

## Reproduction

```shell
printf 'other: true\n' | timoni build app ./examples/redis -f -
# main: `undefined value`
# here: `field not found: values`
```

## Verification

`go test ./internal/engine -run TestExtractValueFromBytesLookupError -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>