### PR TITLE
fix(cli): Reject extra bundle delete args

### DIFF
--- a/cmd/timoni/bundle_delete.go
+++ b/cmd/timoni/bundle_delete.go
@@ -37,6 +37,7 @@ var bundleDelCmd = &cobra.Command{
 	Use:     "delete",
 	Aliases: []string{"rm", "uninstall"},
 	Short:   "Delete all instances from a bundle",
+	Args:    cobra.MaximumNArgs(1),
 	Long: `The bundle delete command uninstalls the instances and
 deletes all their Kubernetes resources from the cluster.'.
 `,

--- a/cmd/timoni/bundle_delete_test.go
+++ b/cmd/timoni/bundle_delete_test.go
@@ -31,6 +31,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func Test_BundleDeleteRejectsExtraArgs(t *testing.T) {
+	g := NewWithT(t)
+	_, err := executeCommand("bundle delete intended accidental-extra --runtime-cluster absent")
+	g.Expect(err).To(MatchError(ContainSubstring("accepts at most 1 arg(s), received 2")))
+}
+
 func Test_BundleDelete(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
## What

Reject more than one positional argument before selecting bundle instances.

## Why

With extra arguments, the bundle name remained empty and deletion could select every Timoni-managed instance in the selected cluster.

## Reproduction

```shell
timoni bundle delete intended accidental-extra --runtime-cluster absent
# main: Error: no cluster found
# here: Error: accepts at most 1 arg(s), received 2
```

## Verification

`go test ./cmd/timoni -run '^Test_BundleDeleteRejectsExtraArgs$' -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>