### PR TITLE
fix(cli): Reject surplus positional args

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -37,6 +37,7 @@ import (
 
 var applyCmd = &cobra.Command{
 	Use:     "apply [INSTANCE NAME] [MODULE URL]",
+	Args:    cobra.MaximumNArgs(2),
 	Aliases: []string{"install", "upgrade"},
 	Short:   "Install or upgrade a module instance",
 	Long: `The apply command installs or upgrades a module instance on the Kubernetes cluster.

--- a/cmd/timoni/args_test.go
+++ b/cmd/timoni/args_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+func TestCommandsRejectExtraArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		args []string
+	}{
+		{name: "apply", cmd: applyCmd, args: []string{"instance", "module", "extra"}},
+		{name: "artifact list", cmd: listArtifactCmd, args: []string{"url", "extra"}},
+		{name: "artifact pull", cmd: pullArtifactCmd, args: []string{"url", "extra"}},
+		{name: "artifact push", cmd: pushArtifactCmd, args: []string{"url", "extra"}},
+		{name: "build", cmd: buildCmd, args: []string{"instance", "module", "extra"}},
+		{name: "bundle status", cmd: bundleStatusCmd, args: []string{"bundle", "extra"}},
+		{name: "completion bash", cmd: completionBashCmd, args: []string{"extra"}},
+		{name: "completion fish", cmd: completionFishCmd, args: []string{"extra"}},
+		{name: "completion powershell", cmd: completionPowerShellCmd, args: []string{"extra"}},
+		{name: "completion zsh", cmd: completionZshCmd, args: []string{"extra"}},
+		{name: "delete", cmd: deleteCmd, args: []string{"instance", "extra"}},
+		{name: "docgen", cmd: docgenCmd, args: []string{"extra"}},
+		{name: "inspect module", cmd: inspectModuleCmd, args: []string{"instance", "extra"}},
+		{name: "inspect resources", cmd: inspectResourcesCmd, args: []string{"instance", "extra"}},
+		{name: "inspect values", cmd: inspectValuesCmd, args: []string{"instance", "extra"}},
+		{name: "list", cmd: listCmd, args: []string{"extra"}},
+		{name: "mod init", cmd: initModCmd, args: []string{"module", "path", "extra"}},
+		{name: "mod list", cmd: listModCmd, args: []string{"url", "extra"}},
+		{name: "mod pull", cmd: pullModCmd, args: []string{"url", "extra"}},
+		{name: "mod push", cmd: pushModCmd, args: []string{"module", "url", "extra"}},
+		{name: "mod show config", cmd: configShowModCmd, args: []string{"module", "extra"}},
+		{name: "mod vendor crd", cmd: vendorCrdCmd, args: []string{"module", "extra"}},
+		{name: "mod vendor k8s", cmd: vendorK8sCmd, args: []string{"module", "extra"}},
+		{name: "mod vet", cmd: vetModCmd, args: []string{"module", "extra"}},
+		{name: "status", cmd: statusCmd, args: []string{"instance", "extra"}},
+		{name: "version", cmd: versionCmd, args: []string{"extra"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.cmd.Args).NotTo(BeNil())
+			g.Expect(tt.cmd.Args(tt.cmd, nil)).To(Succeed())
+			g.Expect(tt.cmd.Args(tt.cmd, tt.args[:len(tt.args)-1])).To(Succeed())
+			wantErr := "accepts at most"
+			if len(tt.args) == 1 {
+				wantErr = "unknown command"
+			}
+			g.Expect(tt.cmd.Args(tt.cmd, tt.args)).To(MatchError(ContainSubstring(wantErr)))
+		})
+	}
+}

--- a/cmd/timoni/artifact_list.go
+++ b/cmd/timoni/artifact_list.go
@@ -29,6 +29,7 @@ import (
 
 var listArtifactCmd = &cobra.Command{
 	Use:     "list [ARTIFACT URL]",
+	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"ls"},
 	Short:   "List the tags of an artifact",
 	Long:    `The list command prints a table with the artifact tags and their digests.`,

--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -30,6 +30,7 @@ import (
 
 var pullArtifactCmd = &cobra.Command{
 	Use:   "pull [ARTIFACT URL]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Pull an artifact from a container registry",
 	Long: `The pull command downloads an artifact with the application/vnd.timoni media type
 from a container registry and extract the selected layers to the specified directory.`,

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -32,6 +32,7 @@ import (
 
 var pushArtifactCmd = &cobra.Command{
 	Use:   "push [REPOSITORY URL]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Push a directory contents to a container registry",
 	Long: `The push command packages a directory contents as an OCI artifact and pushes
 it to the container registry. If the directory contains a timoni.ignore file,

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -44,6 +44,7 @@ import (
 
 var buildCmd = &cobra.Command{
 	Use:     "build [INSTANCE NAME] [MODULE URL]",
+	Args:    cobra.MaximumNArgs(2),
 	Aliases: []string{"template"},
 	Short:   "Build an instance from a module and print the resulting Kubernetes resources",
 	Example: `  # Build an instance from a local module

--- a/cmd/timoni/bundle_status.go
+++ b/cmd/timoni/bundle_status.go
@@ -36,6 +36,7 @@ import (
 
 var bundleStatusCmd = &cobra.Command{
 	Use:   "status [BUNDLE NAME]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Displays the current status of Kubernetes resources managed by the bundle instances",
 	Example: `  # Show the status of the resources managed by a bundle
   timoni bundle status -f bundle.cue

--- a/cmd/timoni/completion_bash.go
+++ b/cmd/timoni/completion_bash.go
@@ -24,6 +24,7 @@ import (
 
 var completionBashCmd = &cobra.Command{
 	Use:   "bash",
+	Args:  cobra.NoArgs,
 	Short: "Generates bash completion scripts",
 	Example: `To load completion run
 

--- a/cmd/timoni/completion_fish.go
+++ b/cmd/timoni/completion_fish.go
@@ -24,6 +24,7 @@ import (
 
 var completionFishCmd = &cobra.Command{
 	Use:   "fish",
+	Args:  cobra.NoArgs,
 	Short: "Generates fish completion scripts",
 	Example: `To configure your fish shell to load completions for each session write this script to your completions dir:
 

--- a/cmd/timoni/completion_powershell.go
+++ b/cmd/timoni/completion_powershell.go
@@ -24,6 +24,7 @@ import (
 
 var completionPowerShellCmd = &cobra.Command{
 	Use:   "powershell",
+	Args:  cobra.NoArgs,
 	Short: "Generates powershell completion scripts",
 	Example: `To load completion run
 

--- a/cmd/timoni/completion_zsh.go
+++ b/cmd/timoni/completion_zsh.go
@@ -24,6 +24,7 @@ import (
 
 var completionZshCmd = &cobra.Command{
 	Use:   "zsh",
+	Args:  cobra.NoArgs,
 	Short: "Generates zsh completion scripts",
 	Example: `To load completion run
 

--- a/cmd/timoni/delete.go
+++ b/cmd/timoni/delete.go
@@ -31,6 +31,7 @@ import (
 
 var deleteCmd = &cobra.Command{
 	Use:     "delete [INSTANCE NAME]",
+	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"uninstall"},
 	Short:   "Uninstall a module instance from the cluster",
 	Example: `  # Uninstall the app module from the default namespace

--- a/cmd/timoni/docgen.go
+++ b/cmd/timoni/docgen.go
@@ -41,6 +41,7 @@ var (
 
 var docgenCmd = &cobra.Command{
 	Use:    "docgen",
+	Args:   cobra.NoArgs,
 	Short:  "Generate the documentation for the CLI commands.",
 	Hidden: true,
 	RunE:   docgenCmdRun,

--- a/cmd/timoni/inspect_module.go
+++ b/cmd/timoni/inspect_module.go
@@ -29,6 +29,7 @@ import (
 
 var inspectModuleCmd = &cobra.Command{
 	Use:   "module [INSTANCE NAME]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Print the module information of an instance",
 	Example: `  # Print the module info
   timoni -n default inspect module app

--- a/cmd/timoni/inspect_resources.go
+++ b/cmd/timoni/inspect_resources.go
@@ -28,6 +28,7 @@ import (
 
 var inspectResourcesCmd = &cobra.Command{
 	Use:   "resources [INSTANCE NAME]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Print the Kubernetes objects managed by an instance",
 	Example: `  # Print the managed resources
   timoni -n default inspect resources app

--- a/cmd/timoni/inspect_values.go
+++ b/cmd/timoni/inspect_values.go
@@ -26,6 +26,7 @@ import (
 
 var inspectValuesCmd = &cobra.Command{
 	Use:   "values [INSTANCE NAME]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Print the values of an instance",
 	Example: `  # Print the values
   timoni inspect values app

--- a/cmd/timoni/list.go
+++ b/cmd/timoni/list.go
@@ -31,6 +31,7 @@ import (
 
 var listCmd = &cobra.Command{
 	Use:     "list",
+	Args:    cobra.NoArgs,
 	Aliases: []string{"ls"},
 	Short:   "Prints a table of instances and their module version",
 	Example: ` # List all instances in a namespace

--- a/cmd/timoni/mod_init.go
+++ b/cmd/timoni/mod_init.go
@@ -34,6 +34,7 @@ import (
 
 var initModCmd = &cobra.Command{
 	Use:   "init [MODULE NAME] [PATH]",
+	Args:  cobra.MaximumNArgs(2),
 	Short: "Create a module along with common files and directories",
 	Example: `  # Create a module in the current directory
   timoni mod init my-app

--- a/cmd/timoni/mod_list.go
+++ b/cmd/timoni/mod_list.go
@@ -29,6 +29,7 @@ import (
 
 var listModCmd = &cobra.Command{
 	Use:     "list [MODULE URL]",
+	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"ls"},
 	Short:   "List the versions of a module",
 	Long:    `The list command prints a table with the module versions and their digests.`,

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -32,6 +32,7 @@ import (
 
 var pullModCmd = &cobra.Command{
 	Use:   "pull [MODULE URL]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Pull a module version from a container registry",
 	Long: `The pull command downloads the module from a container registry and
 extract its contents the specified directory.`,

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -34,6 +34,7 @@ import (
 
 var pushModCmd = &cobra.Command{
 	Use:   "push [MODULE PATH] [MODULE URL]",
+	Args:  cobra.MaximumNArgs(2),
 	Short: "Push a module to a container registry",
 	Long: `The push command packages the module as an OCI artifact and pushes it to the
 container registry using the version as the image tag.`,

--- a/cmd/timoni/mod_show_config.go
+++ b/cmd/timoni/mod_show_config.go
@@ -40,6 +40,7 @@ import (
 
 var configShowModCmd = &cobra.Command{
 	Use:   "config [MODULE PATH]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Output the #Config structure of a local module",
 	Long:  `The config command parses the local module configuration structure and outputs the information to stdout.`,
 	Example: `  # print the config of a module in the current directory

--- a/cmd/timoni/mod_vendor_crd.go
+++ b/cmd/timoni/mod_vendor_crd.go
@@ -40,6 +40,7 @@ import (
 
 var vendorCrdCmd = &cobra.Command{
 	Use:     "crd [MODULE PATH]",
+	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"crds"},
 	Short:   "Vendor Kubernetes CRD CUE schemas",
 	Example: `  # Vendor CUE schemas generated from Kubernetes CRDs included in a local YAML file

--- a/cmd/timoni/mod_vendor_k8s.go
+++ b/cmd/timoni/mod_vendor_k8s.go
@@ -32,6 +32,7 @@ import (
 
 var vendorK8sCmd = &cobra.Command{
 	Use:   "k8s [MODULE PATH]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Vendor Kubernetes API CUE schemas",
 	Example: `  # Vendor CUE schemas generated from the latest Kubernetes GA APIs
   timoni mod vendor k8s

--- a/cmd/timoni/mod_vet.go
+++ b/cmd/timoni/mod_vet.go
@@ -39,6 +39,7 @@ import (
 
 var vetModCmd = &cobra.Command{
 	Use:     "vet [MODULE PATH]",
+	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"lint"},
 	Short:   "Validate a local module",
 	Long:    `The vet command builds the local module and validates the resulting Kubernetes objects.`,

--- a/cmd/timoni/status.go
+++ b/cmd/timoni/status.go
@@ -34,6 +34,7 @@ import (
 
 var statusCmd = &cobra.Command{
 	Use:   "status [INSTANCE NAME]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Displays the current status of Kubernetes resources managed by an instance",
 	Example: `  # Show the current status of the managed resources
   timoni -n apps status app

--- a/cmd/timoni/version.go
+++ b/cmd/timoni/version.go
@@ -27,6 +27,7 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:     "version",
+	Args:    cobra.NoArgs,
 	Short:   "Print the client and API version information",
 	Example: "timoni version -o yaml",
 	RunE:    runVersionCmd,


### PR DESCRIPTION
## What

Reject surplus positional arguments before command work begins.

## Why

Commands with bounded positional inputs silently ignored trailing arguments, hiding invocation mistakes.

## Reproduction

```shell
timoni mod show config /tmp/timoni-missing extra
# main: module not found at path /tmp/timoni-missing
# here: accepts at most 1 arg(s), received 2
```

## Verification

`go test ./cmd/timoni -run '^TestCommandsRejectExtraArgs$' -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>