### PR TITLE
fix(cli): Validate signer before push

### DIFF
--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -92,7 +92,7 @@ func init() {
 	artifactCmd.AddCommand(pushArtifactCmd)
 }
 
-// pushArtifactCmdRun validates tags, builds, and pushes an OCI artifact.
+// pushArtifactCmdRun validates inputs, builds, and pushes an OCI artifact.
 func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("repository URL is required")
@@ -104,6 +104,11 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	for _, tag := range pushArtifactArgs.tags {
 		if err := oci.ValidateTag(tag); err != nil {
+			return err
+		}
+	}
+	if pushArtifactArgs.sign != "" {
+		if err := oci.ValidateSigningProvider(pushArtifactArgs.sign); err != nil {
 			return err
 		}
 	}

--- a/cmd/timoni/artifact_push_test.go
+++ b/cmd/timoni/artifact_push_test.go
@@ -86,3 +86,10 @@ func TestPushArtifactRejectsInvalidTagsBeforeInput(t *testing.T) {
 	_, err := executeCommand("artifact push oci://registry.example.com/org/artifact -f /does/not/exist -t 1.0.0 -t .invalid")
 	g.Expect(err).To(MatchError(ContainSubstring("invalid OCI tag")))
 }
+
+func TestPushArtifactRejectsInvalidSignerBeforeInput(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := executeCommand("artifact push oci://registry.example.com/org/artifact -f /does/not/exist -t 1.0.0 --sign unsupported")
+	g.Expect(err).To(MatchError(ContainSubstring("signer not supported: unsupported")))
+}

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -106,7 +106,7 @@ func init() {
 	modCmd.AddCommand(pushModCmd)
 }
 
-// pushModCmdRun validates the module version, builds, and pushes a module artifact.
+// pushModCmdRun validates inputs, builds, and pushes a module artifact.
 func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return fmt.Errorf("module and URL are required")
@@ -116,6 +116,11 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	version := pushModArgs.version.String()
 	if err := flags.ValidateModuleVersion(version); err != nil {
 		return err
+	}
+	if pushModArgs.sign != "" {
+		if err := oci.ValidateSigningProvider(pushModArgs.sign); err != nil {
+			return err
+		}
 	}
 
 	ociURL := fmt.Sprintf("%s:%s", args[1], version)

--- a/cmd/timoni/mod_push_test.go
+++ b/cmd/timoni/mod_push_test.go
@@ -106,3 +106,10 @@ func Test_PushModRejectsBuildMetadataVersion(t *testing.T) {
 	))
 	g.Expect(err).To(MatchError(ContainSubstring("version build metadata is not supported")))
 }
+
+func TestPushModRejectsInvalidSignerBeforeInput(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := executeCommand("mod push /does/not/exist oci://registry.example.com/org/module -v 1.0.0 --sign unsupported")
+	g.Expect(err).To(MatchError(ContainSubstring("signer not supported: unsupported")))
+}

--- a/internal/oci/sign_artifact.go
+++ b/internal/oci/sign_artifact.go
@@ -22,22 +22,25 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// SignArtifact signs an OpenContainers artifact using the specified provider.
+// ValidateSigningProvider reports whether the signing provider is supported.
+func ValidateSigningProvider(provider string) error {
+	if provider != "cosign" {
+		return fmt.Errorf("signer not supported: %s", provider)
+	}
+	return nil
+}
+
+// SignArtifact validates the provider and signs an OpenContainers artifact.
 func SignArtifact(log logr.Logger, provider string, ociURL string, keyRef string) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
 	}
 
-	switch provider {
-	case "cosign":
-		if err := SignCosign(log, ref.String(), keyRef); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("signer not supported: %s", provider)
+	if err := ValidateSigningProvider(provider); err != nil {
+		return err
 	}
-	return nil
+	return SignCosign(log, ref.String(), keyRef)
 }
 
 // VerifyArtifact verifies an OpenContainers artifact using the specified provider.


### PR DESCRIPTION
## What

Validate signing providers before artifact and module pushes.

## Why

An unsupported `--sign` provider was rejected only after the registry push succeeded, leaving an unsigned artifact despite the command reporting failure.

## Reproduction

With a registry available at `localhost:5000`:

```shell
artifact push oci://localhost:5000/example/artifact -f ./cmd/timoni/testdata/module-values -t 1.0.0 --sign unsupported
artifact list oci://localhost:5000/example/artifact
# main: stderr contains "signer not supported: unsupported"; the list contains 1.0.0
# here: stderr contains "signer not supported: unsupported"; nothing is published
```

## Verification

`go test ./cmd/timoni -run '^(Test_PushArtifact|Test_PushMod|TestPushArtifactRejectsInvalidSignerBeforeInput|TestPushModRejectsInvalidSignerBeforeInput)$' -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>