### PR TITLE
fix: Propagate input scanner errors

### DIFF
--- a/cmd/timoni/mod_show_config.go
+++ b/cmd/timoni/mod_show_config.go
@@ -154,6 +154,8 @@ func runConfigShowModCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// writeFile updates the generated config table and returns the temporary output path.
+// It reports input errors before the caller replaces the destination.
 func writeFile(readFile string, header []string, rows [][]string, f fetcher.Fetcher) (string, error) {
 	// Generate the markdown table
 	var tableBuffer bytes.Buffer
@@ -182,6 +184,12 @@ func writeFile(readFile string, header []string, rows [][]string, f fetcher.Fetc
 	if err != nil {
 		return "", describeErr(f.GetModuleRoot(), "Unable to create the temporary output file", err)
 	}
+	keepOutputFile := false
+	defer func() {
+		if !keepOutputFile {
+			_ = os.Remove(tmpFileName)
+		}
+	}()
 	defer outputFile.Close()
 
 	// Create the scanner and writer
@@ -217,6 +225,9 @@ func writeFile(readFile string, header []string, rows [][]string, f fetcher.Fetc
 			outputWriter.WriteString(line + "\n")
 		}
 	}
+	if err := inputScanner.Err(); err != nil {
+		return "", describeErr(f.GetModuleRoot(), "Reading the output file failed", err)
+	}
 
 	// If no table was found, append it to the end of the file
 	if !foundTable {
@@ -228,6 +239,7 @@ func writeFile(readFile string, header []string, rows [][]string, f fetcher.Fetc
 		return "", describeErr(f.GetModuleRoot(), "Failed to Flush Writer", err)
 	}
 
+	keepOutputFile = true
 	return tmpFileName, nil
 }
 

--- a/cmd/timoni/mod_show_config_test.go
+++ b/cmd/timoni/mod_show_config_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -93,4 +95,22 @@ func Test_ShowConfigOutputNewFile(t *testing.T) {
 	g.Expect(strContent).To(ContainSubstring("`client: enabled:`"))
 	g.Expect(strContent).To(ContainSubstring("`client: image: repository:`"))
 	g.Expect(strContent).To(ContainSubstring("`server: enabled:`"))
+}
+
+func Test_ShowConfigOutputScannerError(t *testing.T) {
+	g := NewWithT(t)
+	filePath := fmt.Sprintf("%s/README.md", t.TempDir())
+	original := []byte(strings.Repeat("x", bufio.MaxScanTokenSize+1))
+	g.Expect(os.WriteFile(filePath, original, 0o600)).To(Succeed())
+
+	_, err := executeCommand(fmt.Sprintf(
+		"mod show config testdata/module --output %s",
+		filePath,
+	))
+	g.Expect(err).To(HaveOccurred())
+	contents, readErr := os.ReadFile(filePath)
+	g.Expect(readErr).ToNot(HaveOccurred())
+	g.Expect(contents).To(Equal(original))
+	_, statErr := os.Stat(filePath + ".tmp")
+	g.Expect(os.IsNotExist(statErr)).To(BeTrue())
 }

--- a/internal/engine/utils.go
+++ b/internal/engine/utils.go
@@ -73,7 +73,7 @@ func CopyModule(srcDir string, dstDir string) (err error) {
 	return cp.Copy(srcDir, dstDir, opt)
 }
 
-// ReadIgnoreFile returns the ignore patters found in the module root.
+// ReadIgnoreFile returns the module ignore patterns or an input error.
 func ReadIgnoreFile(moduleRoot string) ([]string, error) {
 	path := filepath.Join(moduleRoot, apiv1.IgnoreFile)
 	var ps []string
@@ -85,6 +85,9 @@ func ReadIgnoreFile(moduleRoot string) ([]string, error) {
 			if !strings.HasPrefix(s, "#") && len(strings.TrimSpace(s)) > 0 {
 				ps = append(ps, s)
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, err
 		}
 	} else if !os.IsNotExist(err) {
 		return nil, err

--- a/internal/engine/utils_test.go
+++ b/internal/engine/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"bufio"
 	"fmt"
 	"io/fs"
 	"os"
@@ -76,4 +77,18 @@ func TestExtractValueFromBytesLookupError(t *testing.T) {
 
 	_, err := ExtractValueFromBytes(cuecontext.New(), []byte("other: true"), "values")
 	g.Expect(err).To(MatchError(ContainSubstring("not found")))
+}
+
+func TestReadIgnoreFileScannerError(t *testing.T) {
+	g := NewWithT(t)
+	moduleRoot := t.TempDir()
+	err := os.WriteFile(
+		filepath.Join(moduleRoot, "timoni.ignore"),
+		[]byte(strings.Repeat("x", bufio.MaxScanTokenSize+1)),
+		0o600,
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = ReadIgnoreFile(moduleRoot)
+	g.Expect(err).To(HaveOccurred())
 }


### PR DESCRIPTION
## What

Return scanner failures while reading `timoni.ignore` and existing `mod show config` output files, preserving the destination and removing partial temporary output.

## Why

Scanner failures could silently drop ignore patterns or replace an output file with incomplete content.

## Reproduction

```shell
module="$(mktemp -d)"
cp -R ./examples/redis/. "$module"
printf 'README.md\n%65537s\n' x > "$module/timoni.ignore"
timoni mod build "$module" -v 1.0.0 -o "$module.oci.tar"
# main: succeeds despite the oversized ignore entry.
```

```shell
output="$(mktemp)"
printf '%65537s\n' x > "$output"
wc -c "$output" # 65538 bytes
timoni mod show config ./cmd/timoni/testdata/module --output "$output"
# main: succeeds and replaces the output with 3983 bytes
# here: stderr contains "Reading the output file failed: bufio.Scanner: token too long"; the output stays 65538 bytes
```

## Verification

`go test ./internal/engine ./cmd/timoni -run 'Test(ReadIgnoreFileScannerError|_ShowConfigOutputScannerError)$' -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>