### PR TITLE
fix(oci): Validate pulls before output

### DIFF
--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -109,6 +109,15 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	log := LoggerFrom(cmd.Context())
 
+	if _, err := oci.ParseArtifactURL(ociURL); err != nil {
+		return err
+	}
+	if pullArtifactArgs.verify != "" {
+		if err := oci.ValidateVerificationProvider(pullArtifactArgs.verify); err != nil {
+			return err
+		}
+	}
+
 	if err := os.MkdirAll(pullArtifactArgs.output, os.ModePerm); err != nil {
 		return fmt.Errorf("invalid output path %s: %w", pullArtifactArgs.output, err)
 	}

--- a/cmd/timoni/artifact_pull_test.go
+++ b/cmd/timoni/artifact_pull_test.go
@@ -75,3 +75,33 @@ func Test_PullArtifact(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 
 }
+
+func TestPullArtifactRejectsInvalidInputsBeforeOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		err  string
+	}{
+		{
+			name: "invalid reference",
+			args: "example.com/org/artifact",
+			err:  "URL must be in format 'oci://<domain>/<org>/<repo>'",
+		},
+		{
+			name: "unsupported verifier",
+			args: "oci://example.com/org/artifact --verify unsupported",
+			err:  "verifier not supported: unsupported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			output := filepath.Join(t.TempDir(), "output")
+
+			_, err := executeCommand(fmt.Sprintf("artifact pull %s --output %s", tt.args, output))
+			g.Expect(err).To(MatchError(ContainSubstring(tt.err)))
+			g.Expect(output).ToNot(Or(BeADirectory(), BeAnExistingFile()))
+		})
+	}
+}

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -119,6 +119,14 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	if pullModArgs.output == "" {
 		return fmt.Errorf("invalid output path %s", pullModArgs.output)
 	}
+	if _, err := oci.ParseArtifactURL(ociURL); err != nil {
+		return err
+	}
+	if pullModArgs.verify != "" {
+		if err := oci.ValidateVerificationProvider(pullModArgs.verify); err != nil {
+			return err
+		}
+	}
 
 	if err := os.MkdirAll(pullModArgs.output, os.ModePerm); err != nil {
 		return fmt.Errorf("invalid output path %s: %w", pullModArgs.output, err)

--- a/cmd/timoni/mod_pull_test.go
+++ b/cmd/timoni/mod_pull_test.go
@@ -74,3 +74,33 @@ func Test_PullMod(t *testing.T) {
 	})
 	g.Expect(fsErr).ToNot(HaveOccurred())
 }
+
+func TestPullModRejectsInvalidInputsBeforeOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		err  string
+	}{
+		{
+			name: "invalid reference",
+			args: "example.com/org/module",
+			err:  "URL must be in format 'oci://<domain>/<org>/<repo>'",
+		},
+		{
+			name: "unsupported verifier",
+			args: "oci://example.com/org/module --verify unsupported",
+			err:  "verifier not supported: unsupported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			output := filepath.Join(t.TempDir(), "output")
+
+			_, err := executeCommand(fmt.Sprintf("mod pull %s --output %s", tt.args, output))
+			g.Expect(err).To(MatchError(ContainSubstring(tt.err)))
+			g.Expect(output).ToNot(Or(BeADirectory(), BeAnExistingFile()))
+		})
+	}
+}

--- a/internal/oci/sign_artifact.go
+++ b/internal/oci/sign_artifact.go
@@ -30,6 +30,14 @@ func ValidateSigningProvider(provider string) error {
 	return nil
 }
 
+// ValidateVerificationProvider reports whether the verification provider is supported.
+func ValidateVerificationProvider(provider string) error {
+	if provider != "cosign" {
+		return fmt.Errorf("verifier not supported: %s", provider)
+	}
+	return nil
+}
+
 // SignArtifact validates the provider and signs an OpenContainers artifact.
 func SignArtifact(log logr.Logger, provider string, ociURL string, keyRef string) error {
 	ref, err := parseArtifactRef(ociURL)
@@ -43,20 +51,15 @@ func SignArtifact(log logr.Logger, provider string, ociURL string, keyRef string
 	return SignCosign(log, ref.String(), keyRef)
 }
 
-// VerifyArtifact verifies an OpenContainers artifact using the specified provider.
+// VerifyArtifact validates the provider and verifies an OpenContainers artifact.
 func VerifyArtifact(log logr.Logger, provider string, ociURL string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
 	}
 
-	switch provider {
-	case "cosign":
-		if err := VerifyCosign(log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("verifier not supported: %s", provider)
+	if err := ValidateVerificationProvider(provider); err != nil {
+		return err
 	}
-	return nil
+	return VerifyCosign(log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp)
 }


### PR DESCRIPTION
## What

Validate OCI references and verification providers before creating pull output directories.

## Why

Invalid pull requests left empty output directories behind.

## Reproduction

```shell
artifact_output="$(mktemp -d)/output"
artifact pull example.com/org/artifact --output "$artifact_output"
# main: stderr contains "URL must be in format"; $artifact_output exists
# here: stderr contains "URL must be in format"; $artifact_output is absent

module_output="$(mktemp -d)/output"
mod pull oci://example.com/org/module --output "$module_output" --verify unsupported
# main: stderr contains "verifier not supported: unsupported"; $module_output exists
# here: stderr contains "verifier not supported: unsupported"; $module_output is absent
```

## Verification

`go test ./cmd/timoni -run '^(Test_PullArtifact|Test_PullMod|TestPullArtifactRejectsInvalidInputsBeforeOutput|TestPullModRejectsInvalidInputsBeforeOutput)$' -count=1`

`go test ./internal/oci -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>