### PR TITLE
fix(cli): Mark required operands in usage

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -36,7 +36,7 @@ import (
 )
 
 var applyCmd = &cobra.Command{
-	Use:     "apply [INSTANCE NAME] [MODULE URL]",
+	Use:     "apply INSTANCE_NAME MODULE_URL",
 	Args:    cobra.MaximumNArgs(2),
 	Aliases: []string{"install", "upgrade"},
 	Short:   "Install or upgrade a module instance",

--- a/cmd/timoni/artifact_list.go
+++ b/cmd/timoni/artifact_list.go
@@ -28,7 +28,7 @@ import (
 )
 
 var listArtifactCmd = &cobra.Command{
-	Use:     "list [ARTIFACT URL]",
+	Use:     "list ARTIFACT_URL",
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"ls"},
 	Short:   "List the tags of an artifact",

--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -29,7 +29,7 @@ import (
 )
 
 var pullArtifactCmd = &cobra.Command{
-	Use:   "pull [ARTIFACT URL]",
+	Use:   "pull ARTIFACT_URL",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "Pull an artifact from a container registry",
 	Long: `The pull command downloads an artifact with the application/vnd.timoni media type

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -31,7 +31,7 @@ import (
 )
 
 var pushArtifactCmd = &cobra.Command{
-	Use:   "push [REPOSITORY URL]",
+	Use:   "push REPOSITORY_URL",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "Push a directory contents to a container registry",
 	Long: `The push command packages a directory contents as an OCI artifact and pushes

--- a/cmd/timoni/artifact_tag.go
+++ b/cmd/timoni/artifact_tag.go
@@ -28,7 +28,7 @@ import (
 )
 
 var tagArtifactCmd = &cobra.Command{
-	Use:   "tag [ARTIFACT URL]",
+	Use:   "tag ARTIFACT_URL",
 	Short: "Tag an OCI artifact in the upstream registry",
 	Long:  `The tag command allows adding tags to an existing artifact.`,
 	Example: `  # Tag an existing artifact with a new tags

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -43,7 +43,7 @@ import (
 )
 
 var buildCmd = &cobra.Command{
-	Use:     "build [INSTANCE NAME] [MODULE URL]",
+	Use:     "build INSTANCE_NAME MODULE_URL",
 	Args:    cobra.MaximumNArgs(2),
 	Aliases: []string{"template"},
 	Short:   "Build an instance from a module and print the resulting Kubernetes resources",

--- a/cmd/timoni/command_usage_test.go
+++ b/cmd/timoni/command_usage_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+func TestRequiredOperandsAreNotOptionalInUsage(t *testing.T) {
+	tests := []struct {
+		cmd  *cobra.Command
+		want string
+	}{
+		{applyCmd, "apply INSTANCE_NAME MODULE_URL"},
+		{listArtifactCmd, "list ARTIFACT_URL"},
+		{pullArtifactCmd, "pull ARTIFACT_URL"},
+		{pushArtifactCmd, "push REPOSITORY_URL"},
+		{tagArtifactCmd, "tag ARTIFACT_URL"},
+		{buildCmd, "build INSTANCE_NAME MODULE_URL"},
+		{deleteCmd, "delete INSTANCE_NAME"},
+		{inspectModuleCmd, "module INSTANCE_NAME"},
+		{inspectResourcesCmd, "resources INSTANCE_NAME"},
+		{inspectValuesCmd, "values INSTANCE_NAME"},
+		{initModCmd, "init MODULE_NAME [PATH]"},
+		{listModCmd, "list MODULE_URL"},
+		{pullModCmd, "pull MODULE_URL"},
+		{pushModCmd, "push MODULE_PATH MODULE_URL"},
+		{statusCmd, "status INSTANCE_NAME"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cmd.CommandPath(), func(t *testing.T) {
+			NewWithT(t).Expect(tt.cmd.Use).To(Equal(tt.want))
+		})
+	}
+}

--- a/cmd/timoni/delete.go
+++ b/cmd/timoni/delete.go
@@ -30,7 +30,7 @@ import (
 )
 
 var deleteCmd = &cobra.Command{
-	Use:     "delete [INSTANCE NAME]",
+	Use:     "delete INSTANCE_NAME",
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"uninstall"},
 	Short:   "Uninstall a module instance from the cluster",

--- a/cmd/timoni/inspect_module.go
+++ b/cmd/timoni/inspect_module.go
@@ -28,7 +28,7 @@ import (
 )
 
 var inspectModuleCmd = &cobra.Command{
-	Use:   "module [INSTANCE NAME]",
+	Use:   "module INSTANCE_NAME",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "Print the module information of an instance",
 	Example: `  # Print the module info

--- a/cmd/timoni/inspect_resources.go
+++ b/cmd/timoni/inspect_resources.go
@@ -27,7 +27,7 @@ import (
 )
 
 var inspectResourcesCmd = &cobra.Command{
-	Use:   "resources [INSTANCE NAME]",
+	Use:   "resources INSTANCE_NAME",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "Print the Kubernetes objects managed by an instance",
 	Example: `  # Print the managed resources

--- a/cmd/timoni/inspect_values.go
+++ b/cmd/timoni/inspect_values.go
@@ -25,7 +25,7 @@ import (
 )
 
 var inspectValuesCmd = &cobra.Command{
-	Use:   "values [INSTANCE NAME]",
+	Use:   "values INSTANCE_NAME",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "Print the values of an instance",
 	Example: `  # Print the values

--- a/cmd/timoni/mod_init.go
+++ b/cmd/timoni/mod_init.go
@@ -33,7 +33,7 @@ import (
 )
 
 var initModCmd = &cobra.Command{
-	Use:   "init [MODULE NAME] [PATH]",
+	Use:   "init MODULE_NAME [PATH]",
 	Args:  cobra.MaximumNArgs(2),
 	Short: "Create a module along with common files and directories",
 	Example: `  # Create a module in the current directory

--- a/cmd/timoni/mod_list.go
+++ b/cmd/timoni/mod_list.go
@@ -28,7 +28,7 @@ import (
 )
 
 var listModCmd = &cobra.Command{
-	Use:     "list [MODULE URL]",
+	Use:     "list MODULE_URL",
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"ls"},
 	Short:   "List the versions of a module",

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -31,7 +31,7 @@ import (
 )
 
 var pullModCmd = &cobra.Command{
-	Use:   "pull [MODULE URL]",
+	Use:   "pull MODULE_URL",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "Pull a module version from a container registry",
 	Long: `The pull command downloads the module from a container registry and

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -33,7 +33,7 @@ import (
 )
 
 var pushModCmd = &cobra.Command{
-	Use:   "push [MODULE PATH] [MODULE URL]",
+	Use:   "push MODULE_PATH MODULE_URL",
 	Args:  cobra.MaximumNArgs(2),
 	Short: "Push a module to a container registry",
 	Long: `The push command packages the module as an OCI artifact and pushes it to the

--- a/cmd/timoni/status.go
+++ b/cmd/timoni/status.go
@@ -33,7 +33,7 @@ import (
 )
 
 var statusCmd = &cobra.Command{
-	Use:   "status [INSTANCE NAME]",
+	Use:   "status INSTANCE_NAME",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "Displays the current status of Kubernetes resources managed by an instance",
 	Example: `  # Show the current status of the managed resources


### PR DESCRIPTION
## What

Show required positional operands as required, one-token metavariables in command usage.

## Why

Required operands appeared optional, and spaced labels obscured the actual argument count.

## Reproduction

```shell
apply --help
# main: usage contains "apply [INSTANCE NAME] [MODULE URL]"
# here: usage contains "apply INSTANCE_NAME MODULE_URL"

mod init --help
# main: usage contains "mod init [MODULE NAME] [PATH]"
# here: usage contains "mod init MODULE_NAME [PATH]"
```

## Verification

`go test ./cmd/timoni/... -run TestRequiredOperandsAreNotOptionalInUsage -count=1`

`make docs`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>