### PR TITLE
fix(cli): Clean up failed stdin files

### DIFF
--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -348,19 +348,30 @@ func annotateInstanceOwnershipConflictErr(err error) error {
 	return err
 }
 
+// saveReaderToFile copies a reader into a caller-owned temporary file.
 func saveReaderToFile(reader io.Reader) (string, error) {
 	f, err := os.CreateTemp("", "*.cue")
 	if err != nil {
 		return "", errors.New("unable to create temp dir for stdin")
 	}
-
-	defer f.Close()
+	path := f.Name()
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.Remove(path)
+		}
+	}()
 
 	if _, err := io.Copy(f, reader); err != nil {
+		_ = f.Close()
 		return "", fmt.Errorf("error writing stdin to file: %w", err)
 	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("error closing stdin file: %w", err)
+	}
 
-	return f.Name(), nil
+	keep = true
+	return path, nil
 }
 
 func bundleInstancesOwnershipConflicts(bundleInstances []*apiv1.BundleInstance) error {

--- a/cmd/timoni/stdin_temp_file_test.go
+++ b/cmd/timoni/stdin_temp_file_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"testing/iotest"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSaveReaderToFileRemovesPartialFile(t *testing.T) {
+	g := NewWithT(t)
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+
+	_, err := saveReaderToFile(iotest.ErrReader(errors.New("read failed")))
+	g.Expect(err).To(MatchError(ContainSubstring("read failed")))
+
+	entries, err := os.ReadDir(tempDir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(entries).To(BeEmpty())
+}


### PR DESCRIPTION
## What

Close temporary stdin files explicitly and remove partial files after copy or close failures.

## Why

`bundle apply`, `bundle build`, `bundle vet`, and `runtime build` could leave partial temporary CUE files behind.

## Reproduction

```shell
temp_dir="$(mktemp -d)"
TMPDIR="$temp_dir" bundle build -f - < "$temp_dir"
find "$temp_dir" -maxdepth 1 -name '*.cue'
# main: stderr contains "is a directory"; find prints the leaked CUE file
# here: stderr contains "is a directory"; find prints nothing
```

## Verification

`go test ./cmd/timoni/... -run TestSaveReaderToFileRemovesPartialFile -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>