### PR TITLE
fix(cli): Validate output formats early

### DIFF
--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -98,6 +98,9 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return errors.New("name and module are required")
 	}
+	if err := validateOutputFormat(buildArgs.output, false); err != nil {
+		return err
+	}
 
 	buildArgs.name = args[0]
 	buildArgs.module = args[1]

--- a/cmd/timoni/build_test.go
+++ b/cmd/timoni/build_test.go
@@ -231,6 +231,13 @@ func TestBuild(t *testing.T) {
 	})
 }
 
+func TestBuildRejectsInvalidOutputBeforeInput(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := executeCommand("build app /does/not/exist --output invalid")
+	g.Expect(err).To(MatchError("unknown --output=invalid, can be yaml or json"))
+}
+
 func TestBuild_WithDigest(t *testing.T) {
 	g := NewWithT(t)
 

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -118,7 +118,7 @@ func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
 
 func resetCmdArgs() {
 	applyArgs = applyFlags{}
-	buildArgs = buildFlags{}
+	buildArgs = buildFlags{output: "yaml"}
 	deleteArgs = deleteFlags{}
 	statusArgs = statusFlags{}
 	inspectModuleArgs = inspectModuleFlags{}
@@ -146,6 +146,7 @@ func resetCmdArgs() {
 	}
 	pullArtifactArgs = pullArtifactFlags{}
 	runtimeBuildArgs = runtimeBuildFlags{}
+	versionArgs = versionFlags{output: "yaml"}
 }
 
 func rnd(prefix string, n int) string {

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -118,6 +118,9 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	if err := flags.ValidateModuleVersion(version); err != nil {
 		return err
 	}
+	if err := validateOutputFormat(pushModArgs.output, true); err != nil {
+		return err
+	}
 	if pushModArgs.sign != "" {
 		if err := oci.ValidateSigningProvider(pushModArgs.sign); err != nil {
 			return err

--- a/cmd/timoni/mod_push_test.go
+++ b/cmd/timoni/mod_push_test.go
@@ -113,3 +113,10 @@ func TestPushModRejectsInvalidSignerBeforeInput(t *testing.T) {
 	_, err := executeCommand("mod push /does/not/exist oci://registry.example.com/org/module -v 1.0.0 --sign unsupported")
 	g.Expect(err).To(MatchError(ContainSubstring("signer not supported: unsupported")))
 }
+
+func TestPushModRejectsInvalidOutputBeforeInput(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := executeCommand("mod push /does/not/exist oci://registry.example.com/org/module -v 1.0.0 --output invalid")
+	g.Expect(err).To(MatchError("unknown --output=invalid, can be yaml or json"))
+}

--- a/cmd/timoni/output.go
+++ b/cmd/timoni/output.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "fmt"
+
+// validateOutputFormat checks if an output format is supported.
+func validateOutputFormat(output string, allowEmpty bool) error {
+	if output == "yaml" || output == "json" || allowEmpty && output == "" {
+		return nil
+	}
+
+	return fmt.Errorf("unknown --output=%s, can be yaml or json", output)
+}

--- a/cmd/timoni/version.go
+++ b/cmd/timoni/version.go
@@ -46,6 +46,10 @@ func init() {
 }
 
 func runVersionCmd(cmd *cobra.Command, args []string) error {
+	if err := validateOutputFormat(versionArgs.output, false); err != nil {
+		return err
+	}
+
 	info := map[string]string{}
 	info["client"] = VERSION
 	info["api"] = apiv1.GroupVersion.String()

--- a/cmd/timoni/version_test.go
+++ b/cmd/timoni/version_test.go
@@ -39,3 +39,10 @@ func TestVersion(t *testing.T) {
 	g.Expect(data).To(HaveKey("client"))
 	g.Expect(data).To(HaveKey("cue"))
 }
+
+func TestVersionRejectsInvalidOutput(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := executeCommand("version --output invalid")
+	g.Expect(err).To(MatchError("unknown --output=invalid, can be yaml or json"))
+}


### PR DESCRIPTION
## What

Reject unsupported `--output` formats before reading inputs, rendering modules, or publishing artifacts.

## Why

`version` treated unknown formats as YAML, while `build` and `mod push` rejected them only after expensive or externally visible work.

## Reproduction

```shell
version --output toml
# main: prints YAML
# here: stderr contains "unknown --output=toml, can be yaml or json"

build app /does/not/exist --output toml
# main: stderr contains "module not found at path /does/not/exist"
# here: stderr contains "unknown --output=toml, can be yaml or json"

mod push /does/not/exist oci://example.com/org/module -v 1.0.0 --output toml
# main: stderr contains "module not found at path /does/not/exist"
# here: stderr contains "unknown --output=toml, can be yaml or json"
```

## Verification

`go test ./cmd/timoni -run '^(TestBuild|TestVersion|Test_PushMod|TestBuildRejectsInvalidOutputBeforeInput|TestVersionRejectsInvalidOutput|TestPushModRejectsInvalidOutputBeforeInput)$' -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>