### PR TITLE
fix(mod): Clean up failed initialization

### DIFF
--- a/cmd/timoni/mod_init.go
+++ b/cmd/timoni/mod_init.go
@@ -66,6 +66,7 @@ const (
 	modTemplateURL  = "oci://ghcr.io/stefanprodan/timoni/minimal"
 )
 
+// runInitModCmd initializes a module from an OCI template.
 func runInitModCmd(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("module name is required")
@@ -110,17 +111,12 @@ func runInitModCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	dst := filepath.Join(initModArgs.path, initModArgs.name)
-	err = initModuleFromTemplate(
+	err = initializeModule(
 		initModArgs.name,
 		templateName,
 		tmpDir,
 		dst,
 	)
-	if err != nil {
-		return err
-	}
-
-	err = os.WriteFile(filepath.Join(dst, apiv1.IgnoreFile), []byte(apiv1.DefaultIgnorePatterns), 0600)
 	if err != nil {
 		return err
 	}
@@ -176,6 +172,21 @@ func copyModuleFile(mName, mTmpl, src, dst string) (err error) {
 	return
 }
 
+// initializeModule copies a template and writes the default ignore file.
+// It removes the newly created destination if either operation fails.
+func initializeModule(mName, mTmpl, src, dst string) error {
+	if err := initModuleFromTemplate(mName, mTmpl, src, dst); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dst, apiv1.IgnoreFile), []byte(apiv1.DefaultIgnorePatterns), 0600); err != nil {
+		_ = os.RemoveAll(dst)
+		return err
+	}
+	return nil
+}
+
+// initModuleFromTemplate copies a template into a new module destination.
+// It removes the destination if initialization fails.
 func initModuleFromTemplate(mName, mTmpl, src string, dst string) (err error) {
 	src = filepath.Clean(src)
 	dst = filepath.Clean(dst)
@@ -188,18 +199,21 @@ func initModuleFromTemplate(mName, mTmpl, src string, dst string) (err error) {
 		return errors.New("source is not a directory")
 	}
 
-	_, err = os.Stat(dst)
-	if err != nil && !os.IsNotExist(err) {
+	if err = os.MkdirAll(filepath.Dir(dst), si.Mode()); err != nil {
 		return
 	}
-	if err == nil {
+	err = os.Mkdir(dst, si.Mode())
+	if errors.Is(err, os.ErrExist) {
 		return fmt.Errorf("module %s already exists", dst)
 	}
-
-	err = os.MkdirAll(dst, si.Mode())
 	if err != nil {
 		return
 	}
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(dst)
+		}
+	}()
 
 	entries, err := os.ReadDir(src)
 	if err != nil {
@@ -216,8 +230,12 @@ func initModuleFromTemplate(mName, mTmpl, src string, dst string) (err error) {
 				return
 			}
 		} else {
-			if fi, fiErr := entry.Info(); fiErr != nil || !fi.Mode().IsRegular() {
-				return
+			fi, fiErr := entry.Info()
+			if fiErr != nil {
+				return fmt.Errorf("reading template entry %s failed: %w", srcPath, fiErr)
+			}
+			if !fi.Mode().IsRegular() {
+				return fmt.Errorf("template entry is not a regular file: %s", srcPath)
 			}
 
 			err = copyModuleFile(mName, mTmpl, srcPath, dstPath)

--- a/cmd/timoni/mod_init_test.go
+++ b/cmd/timoni/mod_init_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+func TestInitModuleFromTemplateRejectsSymlinkAndCleansDestination(t *testing.T) {
+	g := NewWithT(t)
+	src := t.TempDir()
+	g.Expect(os.WriteFile(filepath.Join(src, "a.txt"), []byte("module"), 0o600)).To(Succeed())
+	if err := os.Symlink("a.txt", filepath.Join(src, "z-link")); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "module")
+
+	err := initModuleFromTemplate("module", "template", src, dst)
+
+	g.Expect(err).To(MatchError(ContainSubstring("template entry is not a regular file")))
+	_, statErr := os.Stat(dst)
+	g.Expect(os.IsNotExist(statErr)).To(BeTrue())
+}
+
+func TestInitModuleFromTemplatePreservesExistingDestination(t *testing.T) {
+	g := NewWithT(t)
+	src := t.TempDir()
+	dst := t.TempDir()
+	sentinel := filepath.Join(dst, "sentinel")
+	g.Expect(os.WriteFile(sentinel, []byte("keep"), 0o600)).To(Succeed())
+
+	err := initModuleFromTemplate("module", "template", src, dst)
+
+	g.Expect(err).To(MatchError(ContainSubstring("already exists")))
+	g.Expect(sentinel).To(BeAnExistingFile())
+}
+
+func TestInitializeModuleCleansDestinationAfterIgnoreWriteError(t *testing.T) {
+	g := NewWithT(t)
+	src := t.TempDir()
+	g.Expect(os.Mkdir(filepath.Join(src, apiv1.IgnoreFile), 0o700)).To(Succeed())
+	dst := filepath.Join(t.TempDir(), "module")
+
+	err := initializeModule("module", "template", src, dst)
+
+	g.Expect(err).To(HaveOccurred())
+	_, statErr := os.Stat(dst)
+	g.Expect(os.IsNotExist(statErr)).To(BeTrue())
+}


### PR DESCRIPTION
## What

Remove newly created module destinations when template initialization fails.

## Why

`mod init` could leave an incomplete module after a template copy or default ignore-file error. Template entry errors could also be silently ignored.

## Reproduction

```shell
docker run --rm -d --name timoni-registry -p 5001:5000 registry:2
blueprint="$(mktemp -d)"
mkdir "$blueprint/timoni.ignore"
printf 'package main\n' > "$blueprint/module.cue"
artifact push oci://localhost:5001/blueprint -t 1.0.0 -f "$blueprint" --registry-insecure --creds=anonymous
modules="$(mktemp -d)"
mod init app "$modules" --blueprint oci://localhost:5001/blueprint:1.0.0 --registry-insecure
# main: stderr contains "timoni.ignore: is a directory"; $modules/app remains
# here: stderr contains "timoni.ignore: is a directory"; $modules/app is absent
docker stop timoni-registry
```

## Verification

`go test ./cmd/timoni -run '^(TestInitModuleFromTemplate|TestInitializeModule)' -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>