### PR TITLE
fix(oci): Bound Cosign subprocesses

### DIFF
--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -108,6 +108,8 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	ociURL := args[0]
 
 	log := LoggerFrom(cmd.Context())
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
+	defer cancel()
 
 	if _, err := oci.ParseArtifactURL(ociURL); err != nil {
 		return err
@@ -123,7 +125,7 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if pullArtifactArgs.verify != "" {
-		err := oci.VerifyArtifact(log,
+		err := oci.VerifyArtifact(ctx, log,
 			pullArtifactArgs.verify,
 			ociURL,
 			pullArtifactArgs.cosignKey,
@@ -138,9 +140,6 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin := logger.StartSpinner("pulling artifact")
 	defer spin.Stop()
-
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
-	defer cancel()
 
 	opts := oci.Options(ctx, pullArtifactArgs.creds.String(), rootArgs.registryInsecure)
 	err := oci.PullArtifact(ociURL, pullArtifactArgs.output, pullArtifactArgs.contentType, opts)

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -133,7 +133,7 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	log := LoggerFrom(cmd.Context())
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	annotations, err := oci.ParseAnnotations(pushArtifactArgs.annotations)
@@ -168,7 +168,7 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin.Stop()
 	if pushArtifactArgs.sign != "" {
-		err = oci.SignArtifact(log, pushArtifactArgs.sign, digestURL, pushArtifactArgs.cosignKey)
+		err = oci.SignArtifact(ctx, log, pushArtifactArgs.sign, digestURL, pushArtifactArgs.cosignKey)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -53,7 +52,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Inject the logger in the command context.
-		ctx := logr.NewContext(context.Background(), cliLogger)
+		ctx := logr.NewContext(cmd.Context(), cliLogger)
 		cmd.SetContext(ctx)
 	},
 }

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -17,9 +17,11 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/go-logr/zerologr"
 	"github.com/mattn/go-shellwords"
+	. "github.com/onsi/gomega"
 	"github.com/phayes/freeport"
 	"github.com/rs/zerolog"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +33,18 @@ var (
 	envTestClient  client.Client
 	dockerRegistry string
 )
+
+func TestRootCommandPreservesContextCancellation(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+
+	rootCmd.PersistentPreRun(cmd, nil)
+	cancel()
+
+	g.Expect(cmd.Context().Err()).To(MatchError(context.Canceled))
+}
 
 func TestMain(m *testing.M) {
 	ctx := ctrl.SetupSignalHandler()

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -133,9 +133,11 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	log := LoggerFrom(cmd.Context())
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
+	defer cancel()
 
 	if pullModArgs.verify != "" {
-		err := oci.VerifyArtifact(log,
+		err := oci.VerifyArtifact(ctx, log,
 			pullModArgs.verify,
 			ociURL,
 			pullModArgs.cosignKey,
@@ -147,9 +149,6 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
-	defer cancel()
 
 	spin := logger.StartSpinner(fmt.Sprintf("pulling %s", ociURL))
 	opts := oci.Options(ctx, pullModArgs.creds.String(), rootArgs.registryInsecure)

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -143,7 +143,7 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	annotations[apiv1.VersionAnnotation] = version
 	oci.AppendGitMetadata(pushModArgs.module, annotations)
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	ps, err := engine.ReadIgnoreFile(pushModArgs.module)
@@ -169,7 +169,7 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin.Stop()
 	if pushModArgs.sign != "" {
-		err = oci.SignArtifact(log, pushModArgs.sign, digestURL, pushModArgs.cosignKey)
+		err = oci.SignArtifact(ctx, log, pushModArgs.sign, digestURL, pushModArgs.cosignKey)
 		if err != nil {
 			return err
 		}

--- a/internal/oci/sign_artifact.go
+++ b/internal/oci/sign_artifact.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oci
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -39,7 +40,7 @@ func ValidateVerificationProvider(provider string) error {
 }
 
 // SignArtifact validates the provider and signs an OpenContainers artifact.
-func SignArtifact(log logr.Logger, provider string, ociURL string, keyRef string) error {
+func SignArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
@@ -48,11 +49,11 @@ func SignArtifact(log logr.Logger, provider string, ociURL string, keyRef string
 	if err := ValidateSigningProvider(provider); err != nil {
 		return err
 	}
-	return SignCosign(log, ref.String(), keyRef)
+	return SignCosign(ctx, log, ref.String(), keyRef)
 }
 
 // VerifyArtifact validates the provider and verifies an OpenContainers artifact.
-func VerifyArtifact(log logr.Logger, provider string, ociURL string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
+func VerifyArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
@@ -61,5 +62,5 @@ func VerifyArtifact(log logr.Logger, provider string, ociURL string, keyRef stri
 	if err := ValidateVerificationProvider(provider); err != nil {
 		return err
 	}
-	return VerifyCosign(log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp)
+	return VerifyCosign(ctx, log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp)
 }

--- a/internal/oci/sign_cosign.go
+++ b/internal/oci/sign_cosign.go
@@ -18,6 +18,7 @@ package oci
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -27,14 +28,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// SignCosign signs an image (`imageRef`) using a cosign private key (`keyRef`)
-func SignCosign(log logr.Logger, imageRef string, keyRef string) error {
+// SignCosign signs an image (`imageRef`) using a cosign private key (`keyRef`).
+func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string) error {
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
 	}
 
-	cosignCmd := exec.Command(cosignExecutable, []string{"sign"}...)
+	cosignCmd := exec.CommandContext(ctx, cosignExecutable, []string{"sign"}...)
 	cosignCmd.Env = os.Environ()
 
 	// if key is empty, use keyless mode
@@ -45,24 +46,24 @@ func SignCosign(log logr.Logger, imageRef string, keyRef string) error {
 	cosignCmd.Args = append(cosignCmd.Args, "--yes")
 	cosignCmd.Args = append(cosignCmd.Args, imageRef)
 
-	err = processCosignIO(log, cosignCmd)
+	err = processCosignIO(ctx, log, cosignCmd)
 	if err != nil {
 		return err
 	}
 
-	return cosignCmd.Wait()
+	return nil
 }
 
-// VerifyCosign verifies an image (`rawRef`) with a cosign public key (`keyRef`)
+// VerifyCosign verifies an image (`rawRef`) with a cosign public key (`keyRef`).
 // Either --cosign-certificate-identity or --cosign-certificate-identity-regexp and either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows.
-func VerifyCosign(log logr.Logger, imageRef string, keyRef string,
+func VerifyCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string,
 	certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
 	}
 
-	cosignCmd := exec.Command(cosignExecutable, []string{"verify"}...)
+	cosignCmd := exec.CommandContext(ctx, cosignExecutable, []string{"verify"}...)
 	cosignCmd.Env = os.Environ()
 
 	// if key is empty, use keyless mode
@@ -91,40 +92,70 @@ func VerifyCosign(log logr.Logger, imageRef string, keyRef string,
 
 	cosignCmd.Args = append(cosignCmd.Args, imageRef)
 
-	err = processCosignIO(log, cosignCmd)
+	err = processCosignIO(ctx, log, cosignCmd)
 	if err != nil {
-		return err
-	}
-	if err := cosignCmd.Wait(); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func processCosignIO(log logr.Logger, cosignCmd *exec.Cmd) error {
+// processCosignIO runs cosign and logs its output while draining both streams.
+func processCosignIO(ctx context.Context, log logr.Logger, cosignCmd *exec.Cmd) error {
 	stdout, err := cosignCmd.StdoutPipe()
 	if err != nil {
-		log.Error(err, "cosign stdout pipe failed")
+		return fmt.Errorf("cosign stdout pipe failed: %w", err)
 	}
 	stderr, err := cosignCmd.StderrPipe()
 	if err != nil {
-		log.Error(err, "cosign stderr pipe failed")
+		return fmt.Errorf("cosign stderr pipe failed: %w", err)
 	}
-
-	merged := io.MultiReader(stdout, stderr)
-	scanner := bufio.NewScanner(merged)
 
 	if err := cosignCmd.Start(); err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
 	}
 
+	outputErrs := make(chan error, 2)
+	go func() {
+		outputErrs <- scanCosignOutput(log, stdout)
+	}()
+	go func() {
+		outputErrs <- scanCosignOutput(log, stderr)
+	}()
+	stopClosing := make(chan struct{})
+	pipesClosed := make(chan struct{})
+	go func() {
+		defer close(pipesClosed)
+		select {
+		case <-ctx.Done():
+			_ = stdout.Close()
+			_ = stderr.Close()
+		case <-stopClosing:
+		}
+	}()
+	stdoutErr := <-outputErrs
+	stderrErr := <-outputErrs
+	close(stopClosing)
+	<-pipesClosed
+
+	if err := cosignCmd.Wait(); err != nil {
+		return errors.Join(ctx.Err(), err, stdoutErr, stderrErr)
+	}
+	return errors.Join(stdoutErr, stderrErr)
+}
+
+// scanCosignOutput logs one cosign output stream and drains it after errors.
+func scanCosignOutput(log logr.Logger, output io.Reader) error {
+	scanner := bufio.NewScanner(output)
 	for scanner.Scan() {
 		log.Info("cosign: " + scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
-		log.Error(err, "cosign stdout/stderr scanner failed")
+		if errors.Is(err, os.ErrClosed) {
+			return nil
+		}
+		_, drainErr := io.Copy(io.Discard, output)
+		return errors.Join(err, drainErr)
 	}
-
 	return nil
 }

--- a/internal/oci/sign_cosign_test.go
+++ b/internal/oci/sign_cosign_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+)
+
+func TestProcessCosignIOReturnsExitError(t *testing.T) {
+	g := NewWithT(t)
+	cmd := cosignHelperCommand(t, "exit-error")
+
+	err := processCosignIO(context.Background(), logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(ContainSubstring("exit status 23")))
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+}
+
+func TestProcessCosignIODrainsOutputConcurrently(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := cosignHelperCommandContext(t, ctx, "large-stderr")
+
+	err := processCosignIO(ctx, logr.Discard(), cmd)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+	g.Expect(cmd.ProcessState.Success()).To(BeTrue())
+}
+
+func TestProcessCosignIOReturnsScannerError(t *testing.T) {
+	g := NewWithT(t)
+	cmd := cosignHelperCommand(t, "long-line")
+
+	err := processCosignIO(context.Background(), logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(ContainSubstring("token too long")))
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+}
+
+func TestScanCosignOutputIgnoresClosedPipe(t *testing.T) {
+	g := NewWithT(t)
+	output, input, err := os.Pipe()
+	g.Expect(err).NotTo(HaveOccurred())
+	defer input.Close()
+	g.Expect(output.Close()).To(Succeed())
+
+	g.Expect(scanCosignOutput(logr.Discard(), output)).To(Succeed())
+}
+
+func TestProcessCosignIOReturnsOutputAndExitErrors(t *testing.T) {
+	g := NewWithT(t)
+	cmd := cosignHelperCommand(t, "long-line-exit-error")
+
+	err := processCosignIO(context.Background(), logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(And(
+		ContainSubstring("token too long"),
+		ContainSubstring("exit status 23"),
+	)))
+}
+
+func TestProcessCosignIOHonorsContext(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	cmd := cosignHelperCommandContext(t, ctx, "wait")
+
+	err := processCosignIO(ctx, logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(ContainSubstring(context.DeadlineExceeded.Error())))
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+}
+
+func TestProcessCosignIOClosesInheritedPipes(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	cmd := cosignHelperCommandContext(t, ctx, "grandchild")
+	start := time.Now()
+
+	err := processCosignIO(ctx, logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(ContainSubstring(context.DeadlineExceeded.Error())))
+	g.Expect(time.Since(start)).To(BeNumerically("<", 1500*time.Millisecond))
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+}
+
+func cosignHelperCommand(t *testing.T, mode string) *exec.Cmd {
+	t.Helper()
+	return cosignHelperCommandContext(t, context.Background(), mode)
+}
+
+func cosignHelperCommandContext(t *testing.T, ctx context.Context, mode string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestCosignHelperProcess", "--", mode)
+	cmd.Env = append(os.Environ(), "GO_WANT_COSIGN_HELPER_PROCESS=1")
+	return cmd
+}
+
+func TestCosignHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_COSIGN_HELPER_PROCESS") != "1" {
+		return
+	}
+	mode := os.Args[len(os.Args)-1]
+	switch mode {
+	case "exit-error":
+		os.Exit(23)
+	case "large-stderr":
+		_, _ = fmt.Fprint(os.Stderr, strings.Repeat("stderr\n", 32*1024))
+	case "long-line":
+		_, _ = fmt.Fprint(os.Stdout, strings.Repeat("x", 128*1024))
+	case "long-line-exit-error":
+		_, _ = fmt.Fprint(os.Stdout, strings.Repeat("x", 128*1024))
+		os.Exit(23)
+	case "wait":
+		time.Sleep(time.Hour)
+	case "grandchild":
+		cmd := exec.Command(os.Args[0], "-test.run=TestCosignHelperProcess", "--", "hold-pipes")
+		cmd.Env = append(os.Environ(), "GO_WANT_COSIGN_HELPER_PROCESS=1")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			os.Exit(25)
+		}
+		time.Sleep(time.Hour)
+	case "hold-pipes":
+		time.Sleep(2 * time.Second)
+	default:
+		os.Exit(24)
+	}
+}


### PR DESCRIPTION
## What

Drain Cosign output concurrently, preserve all subprocess errors, and honor caller cancellation and `--timeout`.

## Why

Reading stdout before stderr can deadlock when Cosign fills the stderr pipe. Descendants could keep those pipes open after cancellation, while a nonzero exit discarded output-processing errors.

## Reproduction

```shell
docker run --rm -d --name timoni-registry -p 5001:5000 registry:2
tmp="$(mktemp -d)"
mkdir "$tmp/bin" "$tmp/artifact"
printf artifact > "$tmp/artifact/data"
printf '%s\n' '#!/bin/sh' 'i=0' 'while [ "$i" -lt 20000 ]; do' '  echo stderr >&2' '  i=$((i + 1))' 'done' > "$tmp/bin/cosign"
chmod +x "$tmp/bin/cosign"
PATH="$tmp/bin:$PATH" artifact push oci://localhost:5001/demo -t 1.0.0 -f "$tmp/artifact" --sign=cosign --registry-insecure --creds=anonymous
# main: hangs after publishing while the fake Cosign fills stderr
# here: exits successfully
docker stop timoni-registry
```

## Verification

`go test ./internal/oci -run '^TestProcessCosignIO' -count=1`

`go test ./cmd/timoni -run '^TestRootCommandPreservesContextCancellation$' -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
