### PR TITLE
fix(cli): Validate provider companion flags

### DIFF
--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -109,6 +109,9 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	log := LoggerFrom(cmd.Context())
 
+	if err := validateVerificationFlags(cmd, pullArtifactArgs.verify); err != nil {
+		return err
+	}
 	if _, err := oci.ParseArtifactURL(ociURL); err != nil {
 		return err
 	}

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -108,6 +108,9 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+	if err := validateProviderCompanionFlags(cmd, pushArtifactArgs.sign, "sign", "cosign-key"); err != nil {
+		return err
+	}
 	if pushArtifactArgs.sign != "" {
 		if err := oci.ValidateSigningProvider(pushArtifactArgs.sign); err != nil {
 			return err

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -119,6 +119,9 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	if pullModArgs.output == "" {
 		return fmt.Errorf("invalid output path %s", pullModArgs.output)
 	}
+	if err := validateVerificationFlags(cmd, pullModArgs.verify); err != nil {
+		return err
+	}
 	if _, err := oci.ParseArtifactURL(ociURL); err != nil {
 		return err
 	}

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -121,6 +121,9 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	if err := validateOutputFormat(pushModArgs.output, true); err != nil {
 		return err
 	}
+	if err := validateProviderCompanionFlags(cmd, pushModArgs.sign, "sign", "cosign-key"); err != nil {
+		return err
+	}
 	if pushModArgs.sign != "" {
 		if err := oci.ValidateSigningProvider(pushModArgs.sign); err != nil {
 			return err

--- a/cmd/timoni/provider_flags.go
+++ b/cmd/timoni/provider_flags.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/spf13/cobra"
+)
+
+// validateProviderCompanionFlags checks that companion flags have a provider.
+func validateProviderCompanionFlags(cmd *cobra.Command, provider, providerFlag string, companionFlags ...string) error {
+	if provider != "" {
+		return nil
+	}
+
+	for _, name := range companionFlags {
+		value, err := cmd.Flags().GetString(name)
+		if err != nil {
+			return err
+		}
+		if value != "" {
+			return fmt.Errorf("--%s requires --%s", name, providerFlag)
+		}
+	}
+
+	return nil
+}
+
+// validateVerificationFlags checks verification companion flag relationships.
+func validateVerificationFlags(cmd *cobra.Command, provider string) error {
+	companionFlags := []string{
+		"cosign-key", "certificate-identity", "certificate-identity-regexp",
+		"certificate-oidc-issuer", "certificate-oidc-issuer-regexp",
+	}
+	if err := validateProviderCompanionFlags(cmd, provider, "verify", companionFlags...); err != nil {
+		return err
+	}
+	values := make(map[string]string, len(companionFlags))
+	for _, name := range companionFlags {
+		value, err := cmd.Flags().GetString(name)
+		if err != nil {
+			return err
+		}
+		values[name] = value
+	}
+
+	conflicts := [][2]string{
+		{"certificate-identity", "certificate-identity-regexp"},
+		{"certificate-oidc-issuer", "certificate-oidc-issuer-regexp"},
+	}
+	for _, pair := range conflicts {
+		if values[pair[0]] != "" && values[pair[1]] != "" {
+			return fmt.Errorf("--%s and --%s are mutually exclusive", pair[0], pair[1])
+		}
+	}
+	if provider != "cosign" {
+		return nil
+	}
+
+	certificateFlags := companionFlags[1:]
+	if values["cosign-key"] != "" {
+		for _, name := range certificateFlags {
+			if values[name] != "" {
+				return fmt.Errorf("--cosign-key cannot be combined with certificate verification flags")
+			}
+		}
+		return nil
+	}
+	if values["certificate-identity"] == "" && values["certificate-identity-regexp"] == "" {
+		return fmt.Errorf("--certificate-identity or --certificate-identity-regexp is required for Cosign verification in keyless mode")
+	}
+	if values["certificate-oidc-issuer"] == "" && values["certificate-oidc-issuer-regexp"] == "" {
+		return fmt.Errorf("--certificate-oidc-issuer or --certificate-oidc-issuer-regexp is required for Cosign verification in keyless mode")
+	}
+	for _, name := range []string{"certificate-identity-regexp", "certificate-oidc-issuer-regexp"} {
+		if value := values[name]; value != "" {
+			if _, err := regexp.Compile(value); err != nil {
+				return fmt.Errorf("invalid --%s: %w", name, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/timoni/provider_flags_test.go
+++ b/cmd/timoni/provider_flags_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+func TestPushCommandsRequireSigningProvider(t *testing.T) {
+	tests := []string{
+		"artifact push oci://example.com/org/artifact --tag 1.0.0 --filepath /does/not/exist --cosign-key key",
+		"mod push /does/not/exist oci://example.com/org/module --version 1.0.0 --cosign-key key",
+	}
+
+	for _, command := range tests {
+		_, err := executeCommand(command)
+		NewWithT(t).Expect(err).To(MatchError("--cosign-key requires --sign"))
+	}
+}
+
+func TestValidateVerificationFlagsAcceptsValidModes(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "key", args: []string{"--cosign-key", "key"}},
+		{name: "keyless", args: []string{"--certificate-identity", "user@example.com", "--certificate-oidc-issuer", "issuer"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			for _, name := range []string{
+				"cosign-key", "certificate-identity", "certificate-identity-regexp",
+				"certificate-oidc-issuer", "certificate-oidc-issuer-regexp",
+			} {
+				cmd.Flags().String(name, "", "")
+			}
+			NewWithT(t).Expect(cmd.Flags().Parse(tt.args)).To(Succeed())
+			NewWithT(t).Expect(validateVerificationFlags(cmd, "cosign")).To(Succeed())
+		})
+	}
+}
+
+func TestPullCommandsValidateVerificationFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		err     string
+	}{
+		{
+			name:    "artifact companion",
+			command: "artifact pull oci://example.com/org/artifact --output %s --certificate-identity user@example.com",
+			err:     "--certificate-identity requires --verify",
+		},
+		{
+			name:    "module companion",
+			command: "mod pull oci://example.com/org/module --output %s --cosign-key key",
+			err:     "--cosign-key requires --verify",
+		},
+		{
+			name:    "artifact identity conflict",
+			command: "artifact pull oci://example.com/org/artifact --output %s --verify cosign --certificate-identity user@example.com --certificate-identity-regexp example.com",
+			err:     "--certificate-identity and --certificate-identity-regexp are mutually exclusive",
+		},
+		{
+			name:    "artifact issuer conflict",
+			command: "artifact pull oci://example.com/org/artifact --output %s --verify cosign --certificate-oidc-issuer issuer --certificate-oidc-issuer-regexp issuer",
+			err:     "--certificate-oidc-issuer and --certificate-oidc-issuer-regexp are mutually exclusive",
+		},
+		{
+			name:    "module identity conflict",
+			command: "mod pull oci://example.com/org/module --output %s --verify cosign --certificate-identity user@example.com --certificate-identity-regexp example.com",
+			err:     "--certificate-identity and --certificate-identity-regexp are mutually exclusive",
+		},
+		{
+			name:    "module issuer conflict",
+			command: "mod pull oci://example.com/org/module --output %s --verify cosign --certificate-oidc-issuer issuer --certificate-oidc-issuer-regexp issuer",
+			err:     "--certificate-oidc-issuer and --certificate-oidc-issuer-regexp are mutually exclusive",
+		},
+		{
+			name:    "artifact keyless identity required",
+			command: "artifact pull oci://example.com/org/artifact --output %s --verify cosign --certificate-oidc-issuer issuer",
+			err:     "--certificate-identity or --certificate-identity-regexp is required for Cosign verification in keyless mode",
+		},
+		{
+			name:    "module keyless issuer required",
+			command: "mod pull oci://example.com/org/module --output %s --verify cosign --certificate-identity user@example.com",
+			err:     "--certificate-oidc-issuer or --certificate-oidc-issuer-regexp is required for Cosign verification in keyless mode",
+		},
+		{
+			name:    "artifact key and certificate conflict",
+			command: "artifact pull oci://example.com/org/artifact --output %s --verify cosign --cosign-key key --certificate-identity user@example.com",
+			err:     "--cosign-key cannot be combined with certificate verification flags",
+		},
+		{
+			name:    "module key and certificate conflict",
+			command: "mod pull oci://example.com/org/module --output %s --verify cosign --cosign-key key --certificate-oidc-issuer issuer",
+			err:     "--cosign-key cannot be combined with certificate verification flags",
+		},
+		{
+			name:    "artifact invalid identity regexp",
+			command: "artifact pull oci://example.com/org/artifact --output %s --verify cosign --certificate-identity-regexp '[' --certificate-oidc-issuer issuer",
+			err:     "invalid --certificate-identity-regexp",
+		},
+		{
+			name:    "module invalid issuer regexp",
+			command: "mod pull oci://example.com/org/module --output %s --verify cosign --certificate-identity user@example.com --certificate-oidc-issuer-regexp '['",
+			err:     "invalid --certificate-oidc-issuer-regexp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			output := filepath.Join(t.TempDir(), "output")
+
+			_, err := executeCommand(fmt.Sprintf(tt.command, output))
+			g.Expect(err).To(MatchError(ContainSubstring(tt.err)))
+			g.Expect(output).ToNot(Or(BeADirectory(), BeAnExistingFile()))
+		})
+	}
+}


### PR DESCRIPTION
## What

Validate signing and verification companion flags before command side effects.

## Why

Provider-less flags were ignored, while invalid Cosign modes and regular expressions failed only after creating pull output.

## Reproduction

```shell
artifact push oci://example.com/org/artifact --tag 1.0.0 --filepath /does/not/exist --cosign-key key
# main: stderr contains "file path not found /does/not/exist"
# here: stderr contains "--cosign-key requires --sign"

output="$(mktemp -d)/output"
artifact pull oci://example.com/org/artifact --output "$output" --verify cosign --certificate-oidc-issuer issuer
# main: stderr contains a Cosign error; $output exists
# here: stderr contains "--certificate-identity or --certificate-identity-regexp is required"; $output is absent

output="$(mktemp -d)/output"
mod pull oci://example.com/org/module --output "$output" --verify cosign --cosign-key key --certificate-identity user@example.com
# main: stderr contains a Cosign error; $output exists
# here: stderr contains "--cosign-key cannot be combined with certificate verification flags"; $output is absent

output="$(mktemp -d)/output"
artifact pull oci://example.com/org/artifact --output "$output" --verify cosign --certificate-identity-regexp '[' --certificate-oidc-issuer issuer
# main: stderr contains a Cosign error; $output exists
# here: stderr contains "invalid --certificate-identity-regexp"; $output is absent
```

## Verification

`go test ./cmd/timoni/... -run 'Test(PushCommandsRequireSigningProvider|PullCommandsValidateVerificationFlags|ValidateVerificationFlagsAcceptsValidModes)$' -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
