### PR TITLE
fix(oci): Preflight and bound Cosign subprocesses

### DIFF
--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -108,6 +108,8 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	ociURL := args[0]
 
 	log := LoggerFrom(cmd.Context())
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
+	defer cancel()
 
 	if _, err := oci.ParseArtifactURL(ociURL); err != nil {
 		return err
@@ -123,7 +125,7 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if pullArtifactArgs.verify != "" {
-		err := oci.VerifyArtifact(log,
+		err := oci.VerifyArtifact(ctx, log,
 			pullArtifactArgs.verify,
 			ociURL,
 			pullArtifactArgs.cosignKey,
@@ -138,9 +140,6 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin := logger.StartSpinner("pulling artifact")
 	defer spin.Stop()
-
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
-	defer cancel()
 
 	opts := oci.Options(ctx, pullArtifactArgs.creds.String(), rootArgs.registryInsecure)
 	err := oci.PullArtifact(ociURL, pullArtifactArgs.output, pullArtifactArgs.contentType, opts)

--- a/cmd/timoni/artifact_pull_test.go
+++ b/cmd/timoni/artifact_pull_test.go
@@ -105,3 +105,13 @@ func TestPullArtifactRejectsInvalidInputsBeforeOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestPullArtifactRejectsMissingCosignBeforeOutput(t *testing.T) {
+	t.Setenv("PATH", "")
+	g := NewWithT(t)
+	output := filepath.Join(t.TempDir(), "output")
+
+	_, err := executeCommand(fmt.Sprintf("artifact pull oci://example.com/org/artifact --verify cosign --cosign-key key.pub --output %s", output))
+	g.Expect(err).To(MatchError(ContainSubstring("executing cosign failed")))
+	g.Expect(output).ToNot(Or(BeADirectory(), BeAnExistingFile()))
+}

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -133,7 +133,7 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	log := LoggerFrom(cmd.Context())
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	annotations, err := oci.ParseAnnotations(pushArtifactArgs.annotations)
@@ -168,7 +168,7 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin.Stop()
 	if pushArtifactArgs.sign != "" {
-		err = oci.SignArtifact(log, pushArtifactArgs.sign, digestURL, pushArtifactArgs.cosignKey)
+		err = oci.SignArtifact(ctx, log, pushArtifactArgs.sign, digestURL, pushArtifactArgs.cosignKey)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/artifact_push_test.go
+++ b/cmd/timoni/artifact_push_test.go
@@ -93,3 +93,11 @@ func TestPushArtifactRejectsInvalidSignerBeforeInput(t *testing.T) {
 	_, err := executeCommand("artifact push oci://registry.example.com/org/artifact -f /does/not/exist -t 1.0.0 --sign unsupported")
 	g.Expect(err).To(MatchError(ContainSubstring("signer not supported: unsupported")))
 }
+
+func TestPushArtifactRejectsMissingCosignBeforeInput(t *testing.T) {
+	t.Setenv("PATH", "")
+	g := NewWithT(t)
+
+	_, err := executeCommand("artifact push oci://registry.example.com/org/artifact -f /does/not/exist -t 1.0.0 --sign cosign")
+	g.Expect(err).To(MatchError(ContainSubstring("executing cosign failed")))
+}

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -53,7 +52,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Inject the logger in the command context.
-		ctx := logr.NewContext(context.Background(), cliLogger)
+		ctx := logr.NewContext(cmd.Context(), cliLogger)
 		cmd.SetContext(ctx)
 	},
 }

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -17,9 +17,11 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/go-logr/zerologr"
 	"github.com/mattn/go-shellwords"
+	. "github.com/onsi/gomega"
 	"github.com/phayes/freeport"
 	"github.com/rs/zerolog"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +33,18 @@ var (
 	envTestClient  client.Client
 	dockerRegistry string
 )
+
+func TestRootCommandPreservesContextCancellation(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+
+	rootCmd.PersistentPreRun(cmd, nil)
+	cancel()
+
+	g.Expect(cmd.Context().Err()).To(MatchError(context.Canceled))
+}
 
 func TestMain(m *testing.M) {
 	ctx := ctrl.SetupSignalHandler()

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -133,9 +133,11 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	log := LoggerFrom(cmd.Context())
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
+	defer cancel()
 
 	if pullModArgs.verify != "" {
-		err := oci.VerifyArtifact(log,
+		err := oci.VerifyArtifact(ctx, log,
 			pullModArgs.verify,
 			ociURL,
 			pullModArgs.cosignKey,
@@ -147,9 +149,6 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
-	defer cancel()
 
 	spin := logger.StartSpinner(fmt.Sprintf("pulling %s", ociURL))
 	opts := oci.Options(ctx, pullModArgs.creds.String(), rootArgs.registryInsecure)

--- a/cmd/timoni/mod_pull_test.go
+++ b/cmd/timoni/mod_pull_test.go
@@ -104,3 +104,13 @@ func TestPullModRejectsInvalidInputsBeforeOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestPullModRejectsMissingCosignBeforeOutput(t *testing.T) {
+	t.Setenv("PATH", "")
+	g := NewWithT(t)
+	output := filepath.Join(t.TempDir(), "output")
+
+	_, err := executeCommand(fmt.Sprintf("mod pull oci://example.com/org/module --verify cosign --cosign-key key.pub --output %s", output))
+	g.Expect(err).To(MatchError(ContainSubstring("executing cosign failed")))
+	g.Expect(output).ToNot(Or(BeADirectory(), BeAnExistingFile()))
+}

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -143,7 +143,7 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	annotations[apiv1.VersionAnnotation] = version
 	oci.AppendGitMetadata(pushModArgs.module, annotations)
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	ps, err := engine.ReadIgnoreFile(pushModArgs.module)
@@ -169,7 +169,7 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin.Stop()
 	if pushModArgs.sign != "" {
-		err = oci.SignArtifact(log, pushModArgs.sign, digestURL, pushModArgs.cosignKey)
+		err = oci.SignArtifact(ctx, log, pushModArgs.sign, digestURL, pushModArgs.cosignKey)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/mod_push_test.go
+++ b/cmd/timoni/mod_push_test.go
@@ -114,6 +114,14 @@ func TestPushModRejectsInvalidSignerBeforeInput(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("signer not supported: unsupported")))
 }
 
+func TestPushModRejectsMissingCosignBeforeInput(t *testing.T) {
+	t.Setenv("PATH", "")
+	g := NewWithT(t)
+
+	_, err := executeCommand("mod push /does/not/exist oci://registry.example.com/org/module -v 1.0.0 --sign cosign")
+	g.Expect(err).To(MatchError(ContainSubstring("executing cosign failed")))
+}
+
 func TestPushModRejectsInvalidOutputBeforeInput(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/oci/sign_artifact.go
+++ b/internal/oci/sign_artifact.go
@@ -19,22 +19,33 @@ package oci
 import (
 	"context"
 	"fmt"
+	"os/exec"
 
 	"github.com/go-logr/logr"
 )
 
-// ValidateSigningProvider reports whether the signing provider is supported.
+// ValidateSigningProvider reports whether the signing provider is supported
+// and available.
 func ValidateSigningProvider(provider string) error {
 	if provider != "cosign" {
 		return fmt.Errorf("signer not supported: %s", provider)
 	}
-	return nil
+	return validateCosignExecutable()
 }
 
-// ValidateVerificationProvider reports whether the verification provider is supported.
+// ValidateVerificationProvider reports whether the verification provider is
+// supported and available.
 func ValidateVerificationProvider(provider string) error {
 	if provider != "cosign" {
 		return fmt.Errorf("verifier not supported: %s", provider)
+	}
+	return validateCosignExecutable()
+}
+
+// validateCosignExecutable reports whether Cosign can be executed.
+func validateCosignExecutable() error {
+	if _, err := exec.LookPath("cosign"); err != nil {
+		return fmt.Errorf("executing cosign failed: %w", err)
 	}
 	return nil
 }

--- a/internal/oci/sign_artifact.go
+++ b/internal/oci/sign_artifact.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oci
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -39,7 +40,7 @@ func ValidateVerificationProvider(provider string) error {
 }
 
 // SignArtifact validates the provider and signs an OpenContainers artifact.
-func SignArtifact(log logr.Logger, provider string, ociURL string, keyRef string) error {
+func SignArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
@@ -48,11 +49,11 @@ func SignArtifact(log logr.Logger, provider string, ociURL string, keyRef string
 	if err := ValidateSigningProvider(provider); err != nil {
 		return err
 	}
-	return SignCosign(log, ref.String(), keyRef)
+	return SignCosign(ctx, log, ref.String(), keyRef)
 }
 
 // VerifyArtifact validates the provider and verifies an OpenContainers artifact.
-func VerifyArtifact(log logr.Logger, provider string, ociURL string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
+func VerifyArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
@@ -61,5 +62,5 @@ func VerifyArtifact(log logr.Logger, provider string, ociURL string, keyRef stri
 	if err := ValidateVerificationProvider(provider); err != nil {
 		return err
 	}
-	return VerifyCosign(log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp)
+	return VerifyCosign(ctx, log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp)
 }

--- a/internal/oci/sign_cosign.go
+++ b/internal/oci/sign_cosign.go
@@ -18,6 +18,7 @@ package oci
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -27,14 +28,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// SignCosign signs an image (`imageRef`) using a cosign private key (`keyRef`)
-func SignCosign(log logr.Logger, imageRef string, keyRef string) error {
+// SignCosign signs an image (`imageRef`) using a cosign private key (`keyRef`).
+func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string) error {
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
 	}
 
-	cosignCmd := exec.Command(cosignExecutable, []string{"sign"}...)
+	cosignCmd := exec.CommandContext(ctx, cosignExecutable, []string{"sign"}...)
 	cosignCmd.Env = os.Environ()
 
 	// if key is empty, use keyless mode
@@ -45,24 +46,24 @@ func SignCosign(log logr.Logger, imageRef string, keyRef string) error {
 	cosignCmd.Args = append(cosignCmd.Args, "--yes")
 	cosignCmd.Args = append(cosignCmd.Args, imageRef)
 
-	err = processCosignIO(log, cosignCmd)
+	err = processCosignIO(ctx, log, cosignCmd)
 	if err != nil {
 		return err
 	}
 
-	return cosignCmd.Wait()
+	return nil
 }
 
-// VerifyCosign verifies an image (`rawRef`) with a cosign public key (`keyRef`)
+// VerifyCosign verifies an image (`rawRef`) with a cosign public key (`keyRef`).
 // Either --cosign-certificate-identity or --cosign-certificate-identity-regexp and either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows.
-func VerifyCosign(log logr.Logger, imageRef string, keyRef string,
+func VerifyCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string,
 	certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
 	}
 
-	cosignCmd := exec.Command(cosignExecutable, []string{"verify"}...)
+	cosignCmd := exec.CommandContext(ctx, cosignExecutable, []string{"verify"}...)
 	cosignCmd.Env = os.Environ()
 
 	// if key is empty, use keyless mode
@@ -91,40 +92,70 @@ func VerifyCosign(log logr.Logger, imageRef string, keyRef string,
 
 	cosignCmd.Args = append(cosignCmd.Args, imageRef)
 
-	err = processCosignIO(log, cosignCmd)
+	err = processCosignIO(ctx, log, cosignCmd)
 	if err != nil {
-		return err
-	}
-	if err := cosignCmd.Wait(); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func processCosignIO(log logr.Logger, cosignCmd *exec.Cmd) error {
+// processCosignIO runs cosign and logs its output while draining both streams.
+func processCosignIO(ctx context.Context, log logr.Logger, cosignCmd *exec.Cmd) error {
 	stdout, err := cosignCmd.StdoutPipe()
 	if err != nil {
-		log.Error(err, "cosign stdout pipe failed")
+		return fmt.Errorf("cosign stdout pipe failed: %w", err)
 	}
 	stderr, err := cosignCmd.StderrPipe()
 	if err != nil {
-		log.Error(err, "cosign stderr pipe failed")
+		return fmt.Errorf("cosign stderr pipe failed: %w", err)
 	}
-
-	merged := io.MultiReader(stdout, stderr)
-	scanner := bufio.NewScanner(merged)
 
 	if err := cosignCmd.Start(); err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
 	}
 
+	outputErrs := make(chan error, 2)
+	go func() {
+		outputErrs <- scanCosignOutput(log, stdout)
+	}()
+	go func() {
+		outputErrs <- scanCosignOutput(log, stderr)
+	}()
+	stopClosing := make(chan struct{})
+	pipesClosed := make(chan struct{})
+	go func() {
+		defer close(pipesClosed)
+		select {
+		case <-ctx.Done():
+			_ = stdout.Close()
+			_ = stderr.Close()
+		case <-stopClosing:
+		}
+	}()
+	stdoutErr := <-outputErrs
+	stderrErr := <-outputErrs
+	close(stopClosing)
+	<-pipesClosed
+
+	if err := cosignCmd.Wait(); err != nil {
+		return errors.Join(ctx.Err(), err, stdoutErr, stderrErr)
+	}
+	return errors.Join(stdoutErr, stderrErr)
+}
+
+// scanCosignOutput logs one cosign output stream and drains it after errors.
+func scanCosignOutput(log logr.Logger, output io.Reader) error {
+	scanner := bufio.NewScanner(output)
 	for scanner.Scan() {
 		log.Info("cosign: " + scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
-		log.Error(err, "cosign stdout/stderr scanner failed")
+		if errors.Is(err, os.ErrClosed) {
+			return nil
+		}
+		_, drainErr := io.Copy(io.Discard, output)
+		return errors.Join(err, drainErr)
 	}
-
 	return nil
 }

--- a/internal/oci/sign_cosign.go
+++ b/internal/oci/sign_cosign.go
@@ -28,6 +28,11 @@ import (
 	"github.com/go-logr/logr"
 )
 
+const (
+	maxCosignOutputLogLine   = 1024 * 1024
+	maxCosignOutputScanToken = maxCosignOutputLogLine + 1
+)
+
 // SignCosign signs an image (`imageRef`) using a cosign private key (`keyRef`).
 func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string) error {
 	cosignExecutable, err := exec.LookPath("cosign")
@@ -138,15 +143,19 @@ func processCosignIO(ctx context.Context, log logr.Logger, cosignCmd *exec.Cmd) 
 	close(stopClosing)
 	<-pipesClosed
 
-	if err := cosignCmd.Wait(); err != nil {
-		return errors.Join(ctx.Err(), err, stdoutErr, stderrErr)
+	if err := errors.Join(stdoutErr, stderrErr); err != nil {
+		log.Error(err, "cosign output could not be fully logged")
 	}
-	return errors.Join(stdoutErr, stderrErr)
+	if err := cosignCmd.Wait(); err != nil {
+		return errors.Join(ctx.Err(), err)
+	}
+	return nil
 }
 
 // scanCosignOutput logs one cosign output stream and drains it after errors.
 func scanCosignOutput(log logr.Logger, output io.Reader) error {
 	scanner := bufio.NewScanner(output)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxCosignOutputScanToken)
 	for scanner.Scan() {
 		log.Info("cosign: " + scanner.Text())
 	}

--- a/internal/oci/sign_cosign_test.go
+++ b/internal/oci/sign_cosign_test.go
@@ -52,14 +52,32 @@ func TestProcessCosignIODrainsOutputConcurrently(t *testing.T) {
 	g.Expect(cmd.ProcessState.Success()).To(BeTrue())
 }
 
-func TestProcessCosignIOReturnsScannerError(t *testing.T) {
+func TestProcessCosignIOAcceptsLargeCosignJSONOutput(t *testing.T) {
 	g := NewWithT(t)
 	cmd := cosignHelperCommand(t, "long-line")
 
 	err := processCosignIO(context.Background(), logr.Discard(), cmd)
 
-	g.Expect(err).To(MatchError(ContainSubstring("token too long")))
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cmd.ProcessState).ToNot(BeNil())
+	g.Expect(cmd.ProcessState.Success()).To(BeTrue())
+}
+
+func TestScanCosignOutputAcceptsLineAtLogLimit(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(scanCosignOutput(logr.Discard(), strings.NewReader(strings.Repeat("x", maxCosignOutputLogLine)))).To(Succeed())
+}
+
+func TestProcessCosignIODoesNotFailOnOutputLoggingError(t *testing.T) {
+	g := NewWithT(t)
+	cmd := cosignHelperCommand(t, "overlong-line")
+
+	err := processCosignIO(context.Background(), logr.Discard(), cmd)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+	g.Expect(cmd.ProcessState.Success()).To(BeTrue())
 }
 
 func TestScanCosignOutputIgnoresClosedPipe(t *testing.T) {
@@ -72,15 +90,15 @@ func TestScanCosignOutputIgnoresClosedPipe(t *testing.T) {
 	g.Expect(scanCosignOutput(logr.Discard(), output)).To(Succeed())
 }
 
-func TestProcessCosignIOReturnsOutputAndExitErrors(t *testing.T) {
+func TestProcessCosignIOReturnsExitErrorDespiteOutputLoggingError(t *testing.T) {
 	g := NewWithT(t)
 	cmd := cosignHelperCommand(t, "long-line-exit-error")
 
 	err := processCosignIO(context.Background(), logr.Discard(), cmd)
 
 	g.Expect(err).To(MatchError(And(
-		ContainSubstring("token too long"),
 		ContainSubstring("exit status 23"),
+		Not(ContainSubstring("token too long")),
 	)))
 }
 
@@ -137,6 +155,8 @@ func TestCosignHelperProcess(t *testing.T) {
 	case "long-line-exit-error":
 		_, _ = fmt.Fprint(os.Stdout, strings.Repeat("x", 128*1024))
 		os.Exit(23)
+	case "overlong-line":
+		_, _ = fmt.Fprint(os.Stdout, strings.Repeat("x", 2*1024*1024))
 	case "wait":
 		time.Sleep(time.Hour)
 	case "grandchild":

--- a/internal/oci/sign_cosign_test.go
+++ b/internal/oci/sign_cosign_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+)
+
+func TestProcessCosignIOReturnsExitError(t *testing.T) {
+	g := NewWithT(t)
+	cmd := cosignHelperCommand(t, "exit-error")
+
+	err := processCosignIO(context.Background(), logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(ContainSubstring("exit status 23")))
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+}
+
+func TestProcessCosignIODrainsOutputConcurrently(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := cosignHelperCommandContext(t, ctx, "large-stderr")
+
+	err := processCosignIO(ctx, logr.Discard(), cmd)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+	g.Expect(cmd.ProcessState.Success()).To(BeTrue())
+}
+
+func TestProcessCosignIOReturnsScannerError(t *testing.T) {
+	g := NewWithT(t)
+	cmd := cosignHelperCommand(t, "long-line")
+
+	err := processCosignIO(context.Background(), logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(ContainSubstring("token too long")))
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+}
+
+func TestScanCosignOutputIgnoresClosedPipe(t *testing.T) {
+	g := NewWithT(t)
+	output, input, err := os.Pipe()
+	g.Expect(err).NotTo(HaveOccurred())
+	defer input.Close()
+	g.Expect(output.Close()).To(Succeed())
+
+	g.Expect(scanCosignOutput(logr.Discard(), output)).To(Succeed())
+}
+
+func TestProcessCosignIOReturnsOutputAndExitErrors(t *testing.T) {
+	g := NewWithT(t)
+	cmd := cosignHelperCommand(t, "long-line-exit-error")
+
+	err := processCosignIO(context.Background(), logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(And(
+		ContainSubstring("token too long"),
+		ContainSubstring("exit status 23"),
+	)))
+}
+
+func TestProcessCosignIOHonorsContext(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	cmd := cosignHelperCommandContext(t, ctx, "wait")
+
+	err := processCosignIO(ctx, logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(ContainSubstring(context.DeadlineExceeded.Error())))
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+}
+
+func TestProcessCosignIOClosesInheritedPipes(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	cmd := cosignHelperCommandContext(t, ctx, "grandchild")
+	start := time.Now()
+
+	err := processCosignIO(ctx, logr.Discard(), cmd)
+
+	g.Expect(err).To(MatchError(ContainSubstring(context.DeadlineExceeded.Error())))
+	g.Expect(time.Since(start)).To(BeNumerically("<", 1500*time.Millisecond))
+	g.Expect(cmd.ProcessState).ToNot(BeNil())
+}
+
+func cosignHelperCommand(t *testing.T, mode string) *exec.Cmd {
+	t.Helper()
+	return cosignHelperCommandContext(t, context.Background(), mode)
+}
+
+func cosignHelperCommandContext(t *testing.T, ctx context.Context, mode string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestCosignHelperProcess", "--", mode)
+	cmd.Env = append(os.Environ(), "GO_WANT_COSIGN_HELPER_PROCESS=1")
+	return cmd
+}
+
+func TestCosignHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_COSIGN_HELPER_PROCESS") != "1" {
+		return
+	}
+	mode := os.Args[len(os.Args)-1]
+	switch mode {
+	case "exit-error":
+		os.Exit(23)
+	case "large-stderr":
+		_, _ = fmt.Fprint(os.Stderr, strings.Repeat("stderr\n", 32*1024))
+	case "long-line":
+		_, _ = fmt.Fprint(os.Stdout, strings.Repeat("x", 128*1024))
+	case "long-line-exit-error":
+		_, _ = fmt.Fprint(os.Stdout, strings.Repeat("x", 128*1024))
+		os.Exit(23)
+	case "wait":
+		time.Sleep(time.Hour)
+	case "grandchild":
+		cmd := exec.Command(os.Args[0], "-test.run=TestCosignHelperProcess", "--", "hold-pipes")
+		cmd.Env = append(os.Environ(), "GO_WANT_COSIGN_HELPER_PROCESS=1")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			os.Exit(25)
+		}
+		time.Sleep(time.Hour)
+	case "hold-pipes":
+		time.Sleep(2 * time.Second)
+	default:
+		os.Exit(24)
+	}
+}


### PR DESCRIPTION
## Summary

- Resolve the configured Cosign executable before registry or filesystem side effects.
- Bound and concurrently drain Cosign subprocess output while preserving cancellation and process errors.
- Supersedes #582, which contained the first commit in this PR.

## Verification

- `go test ./cmd/timoni/... ./internal/oci/...`

Signed-off-by: Rene Leonhardt <65483435+reneleonhardt@users.noreply.github.com>
Co-Authored-By: GPT-5.6 Sol <codex@openai.com>