### PR TITLE
fix(oci): Bound layer extraction

### DIFF
--- a/internal/oci/extract.go
+++ b/internal/oci/extract.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"io"
+
+	"github.com/fluxcd/pkg/tar"
+)
+
+// extractLayer extracts a compressed OCI layer within the shared size and symlink policy.
+func extractLayer(r io.Reader, dstPath string) error {
+	return tar.Untar(r, dstPath,
+		tar.WithMaxUntarSize(tar.DefaultMaxUntarSize),
+		tar.WithSkipSymlinks())
+}

--- a/internal/oci/extract_test.go
+++ b/internal/oci/extract_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	archiveTar "archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	fluxTar "github.com/fluxcd/pkg/tar"
+	. "github.com/onsi/gomega"
+)
+
+func TestExtractLayer(t *testing.T) {
+	t.Run("skips symlinks", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := t.TempDir()
+
+		err := extractLayer(tarGzip(t,
+			&archiveTar.Header{Name: "link", Linkname: "../outside", Typeflag: archiveTar.TypeSymlink},
+			&archiveTar.Header{Name: "file", Mode: 0o600, Size: 1, Typeflag: archiveTar.TypeReg},
+		), dst)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(filepath.Join(dst, "link")).ToNot(BeAnExistingFile())
+		g.Expect(os.ReadFile(filepath.Join(dst, "file"))).To(Equal([]byte{0}))
+	})
+
+	t.Run("limits extracted bytes", func(t *testing.T) {
+		g := NewWithT(t)
+		err := extractLayer(tarGzip(t, &archiveTar.Header{
+			Name: "large", Mode: 0o600, Size: int64(fluxTar.DefaultMaxUntarSize) + 1, Typeflag: archiveTar.TypeReg,
+		}), t.TempDir())
+		g.Expect(err).To(MatchError(ContainSubstring("bigger than max archive size")))
+	})
+}
+
+func tarGzip(t *testing.T, headers ...*archiveTar.Header) *bytes.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := archiveTar.NewWriter(gz)
+	for _, header := range headers {
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if header.Typeflag == archiveTar.TypeReg && header.Size > 0 && header.Size <= fluxTar.DefaultMaxUntarSize {
+			if _, err := tw.Write(make([]byte, header.Size)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	_ = tw.Close()
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}

--- a/internal/oci/pull_artifact.go
+++ b/internal/oci/pull_artifact.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/fluxcd/pkg/tar"
 	"github.com/google/go-containerregistry/pkg/crane"
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
 
@@ -74,7 +73,7 @@ func PullArtifact(ociURL, dstPath, contentType string, opts []crane.Option) erro
 				return fmt.Errorf("extracting artifact layer %s failed: %w", layerDigest, err)
 			}
 
-			if err = tar.Untar(blob, dstPath, tar.WithMaxUntarSize(-1)); err != nil {
+			if err = extractLayer(blob, dstPath); err != nil {
 				return fmt.Errorf("extracting artifact layer %s failed: %w", layerDigest, err)
 			}
 		}

--- a/internal/oci/pull_module.go
+++ b/internal/oci/pull_module.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fluxcd/pkg/tar"
 	"github.com/google/go-containerregistry/pkg/crane"
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	godigest "github.com/opencontainers/go-digest"
@@ -134,7 +133,7 @@ func PullModule(ociURL, dstPath, cacheDir string, opts []crane.Option) (*apiv1.M
 			}
 
 			// Extract the contents from the gzip tarball stored in cache.
-			if err = tar.Untar(reader, dstPath, tar.WithMaxUntarSize(-1)); err != nil {
+			if err = extractLayer(reader, dstPath); err != nil {
 				_ = reader.Close()
 				return nil, fmt.Errorf("extracting layer %s failed: %w", layerDigest, err)
 			}


### PR DESCRIPTION
## What

Extract OCI layers with Flux's 100 MiB limit and skip archived symlinks.

## Why

Layer extraction disabled Flux's size limit and failed when an archive contained symlinks.

## Reproduction

```shell
tmp_dir="$(mktemp -d)"
dd if=/dev/zero of="$tmp_dir/large" bs=1048576 count=101
artifact push oci://localhost:5000/example -t 1.0.0 -f "$tmp_dir" --registry-insecure
artifact pull oci://localhost:5000/example:1.0.0 -o "$tmp_dir/output" --registry-insecure
# main: extracts the layer
# here: stderr contains 'bigger than max archive size'
```

## Verification

```shell
go test ./internal/oci -run TestExtractLayer -count=1
```

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
