### PR TITLE
fix(cli): Support registry credential files

### DIFF
--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -42,8 +42,8 @@ the ignore rules will be used to exclude files from the artifact.`,
   timoni artifact push oci://docker.io/org/app -t latest -f .
 
  # Push a dir contents to GitHub Container Registry using a GitHub token
+  printf %s "$GITHUB_TOKEN" | timoni registry login ghcr.io -u timoni --password-stdin
   timoni artifact push oci://ghcr.io/org/schemas/app -f ./path/to/bundles \
-	--creds=timoni:$GITHUB_TOKEN \
 	--tag="$(git rev-parse --short HEAD)" \
 	--tag=latest \
 	--annotation="org.opencontainers.image.source=$(git config --get remote.origin.url)" \

--- a/cmd/timoni/mod_list.go
+++ b/cmd/timoni/mod_list.go
@@ -40,8 +40,8 @@ var listModCmd = &cobra.Command{
   timoni mod list oci://docker.io/org/app --with-digest=false
 
   # Print the versions of a module from GitHub Container Registry
-  timoni mod list oci://ghcr.io/org/manifests/app \
-	--creds timoni:$GITHUB_TOKEN
+  printf %s "$GITHUB_TOKEN" | timoni registry login ghcr.io -u timoni --password-stdin
+  timoni mod list oci://ghcr.io/org/manifests/app
 `,
 	RunE: listModCmdRun,
 }

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -42,9 +42,9 @@ extract its contents the specified directory.`,
 	--output ./path/to/module
 
   # Pull a specific module version from GitHub Container Registry
+  printf %s "$GITHUB_TOKEN" | timoni registry login ghcr.io -u timoni --password-stdin
   timoni mod pull oci://ghcr.io/org/modules/app --version 1.0.0 \
-	--output=./modules/app \
-	--creds timoni:$GITHUB_TOKEN
+	--output=./modules/app
 
   # Verify the Cosign signature and pull (the cosign binary must be present in PATH)
   timoni mod pull oci://docker.io/org/app-module \

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -43,9 +43,9 @@ container registry using the version as the image tag.`,
   timoni mod push ./path/to/module oci://docker.io/org/app-module -v 1.0.0
 
   # Push a module to GitHub Container Registry using a GitHub token
+  printf %s "$GITHUB_TOKEN" | timoni registry login ghcr.io -u timoni --password-stdin
   timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
-	--version=1.0.0 \
-	--creds timoni:$GITHUB_TOKEN
+	--version=1.0.0
 
   # Push a release candidate without marking it as the latest stable
   timoni mod push ./path/to/module oci://docker.io/org/app-module \

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -364,6 +364,7 @@ The apply command performs the following actions for each instance:
 - Pulls the module version from the specified container registry.
 - If the registry is private, uses the credentials found in `~/.docker/config.json`.
 - If the registry credentials are specified with `--creds`, these take priority over the docker ones.
+- A value such as `--creds @./registry-creds` reads credentials from a file so the secret is absent from process arguments; use `@@` for a literal leading `@`.
 - Merges the custom values supplied in the Bundle with the default values found in the module.
 - Builds the module by passing the instance name, namespace and values.
 - Labels the resulting Kubernetes resources with the instance name and namespace.

--- a/docs/cue/module/github-actions.md
+++ b/docs/cue/module/github-actions.md
@@ -46,11 +46,13 @@ jobs:
         run: |
           timoni mod vet ./modules/my-module
       - name: Push module
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          printf %s "$GHCR_TOKEN" | timoni registry login ghcr.io --username "${{ github.actor }}" --password-stdin
           timoni mod push ./my-module \
             oci://ghcr.io/${{ github.repository_owner }}/my-module \
             --version ${{ github.ref_name }} \
-            --creds ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}  
             --latest \
             -a 'org.opencontainers.image.licenses=Apache-2.0' \
             -a 'org.opencontainers.image.source=https://github.com/${{ github.repository }}' \

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -49,11 +49,13 @@ jobs:
         run: |
           timoni build -n testing test ./my-module
       - name: Push
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          printf %s "$GHCR_TOKEN" | timoni registry login ghcr.io --username "${{ github.actor }}" --password-stdin
           timoni mod push ./my-module \
             oci://ghcr.io/${{ github.repository_owner }}/my-module \
             --version ${{ github.ref_name }} \
-            --creds ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
             --latest \
             -a 'org.opencontainers.image.licenses=Apache-2.0' \
             -a 'org.opencontainers.image.source=https://github.com/${{ github.repository }}' \

--- a/internal/flags/credentials.go
+++ b/internal/flags/credentials.go
@@ -1,20 +1,80 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package flags
 
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const maxCredentialsFileSize = 64 << 10
+
+// Credentials stores container registry credentials supplied by a CLI flag.
 type Credentials string
 
+// String returns the credentials in username and optional password format.
 func (f *Credentials) String() string {
 	return string(*f)
 }
 
+// Set stores inline credentials or reads exact credential bytes from an @path.
 func (f *Credentials) Set(str string) error {
+	if strings.HasPrefix(str, "@@") {
+		*f = Credentials(str[1:])
+		return nil
+	}
+	if strings.HasPrefix(str, "@") {
+		path := str[1:]
+		file, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("reading credentials file %q failed: %w", path, err)
+		}
+		contents, readErr := io.ReadAll(io.LimitReader(file, maxCredentialsFileSize+1))
+		closeErr := file.Close()
+		if readErr != nil {
+			return fmt.Errorf("reading credentials file %q failed: %w", path, readErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("reading credentials file %q failed: %w", path, closeErr)
+		}
+		if len(contents) > maxCredentialsFileSize {
+			return fmt.Errorf("credentials file exceeds %d bytes", maxCredentialsFileSize)
+		}
+		if bytes.HasSuffix(contents, []byte("\r\n")) {
+			contents = contents[:len(contents)-2]
+		} else {
+			contents = bytes.TrimSuffix(contents, []byte("\n"))
+		}
+		*f = Credentials(contents)
+		return nil
+	}
 	*f = Credentials(str)
 	return nil
 }
 
+// Type returns the CLI flag name.
 func (f *Credentials) Type() string {
 	return "creds"
 }
 
+// Description returns the CLI flag help text.
 func (f *Credentials) Description() string {
-	return "The credentials for the container registry in the format '<username>[:<password>]'."
+	return "The credentials for the container registry as '<username>[:<password>]' or '@<path>' ('@@' escapes a leading '@')."
 }

--- a/internal/flags/credentials_test.go
+++ b/internal/flags/credentials_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCredentialsSet(t *testing.T) {
+	g := NewWithT(t)
+
+	var inline Credentials
+	g.Expect(inline.Set("user:password")).To(Succeed())
+	g.Expect(inline.String()).To(Equal("user:password"))
+
+	var escaped Credentials
+	g.Expect(escaped.Set("@@user:password")).To(Succeed())
+	g.Expect(escaped.String()).To(Equal("@user:password"))
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials")
+	contents := []byte("user:password \r\n")
+	g.Expect(os.WriteFile(path, contents, 0o600)).To(Succeed())
+
+	var fromFile Credentials
+	g.Expect(fromFile.Set("@" + path)).To(Succeed())
+	g.Expect(fromFile.String()).To(Equal("user:password "))
+}
+
+func TestCredentialsSetRejectsInvalidFiles(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "missing")
+
+	var credentials Credentials
+	err := credentials.Set("@" + missing)
+	g.Expect(err).To(MatchError(ContainSubstring("reading credentials file")))
+	g.Expect(err.Error()).ToNot(ContainSubstring("password"))
+
+	oversized := filepath.Join(dir, "oversized")
+	g.Expect(os.WriteFile(oversized, bytes.Repeat([]byte("x"), 64<<10+1), 0o600)).To(Succeed())
+	err = credentials.Set("@" + oversized)
+	g.Expect(err).To(MatchError(ContainSubstring("credentials file exceeds 65536 bytes")))
+}


### PR DESCRIPTION
## What

Allow `--creds @<path>` to read registry credentials from a file of up to 64 KiB. Remove one terminal LF or CRLF, and use `@@` for a literal leading `@`.

## Why

Inline credentials expose registry passwords in shell history and process arguments.

## Reproduction

```shell
artifact list oci://127.0.0.1:1/example --creds @/tmp/missing-registry-creds
# main: stderr contains 'listing tags failed'
# here: stderr contains 'reading credentials file'
```

## Verification

```shell
go test ./internal/flags -run TestCredentialsSet -count=1
```

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>