### PR TITLE
fix(cli): Bound and secure CRD downloads

### DIFF
--- a/cmd/timoni/mod_vendor_crd.go
+++ b/cmd/timoni/mod_vendor_crd.go
@@ -59,6 +59,8 @@ type vendorCrdFlags struct {
 
 var vendorCrdArgs vendorCrdFlags
 
+const maxRemoteCRDManifestSize int64 = 16 << 20
+
 func init() {
 	vendorCrdCmd.Flags().StringVarP(&vendorCrdArgs.crdFile, "file", "f", "",
 		"The path to Kubernetes CRD YAML.")
@@ -94,27 +96,13 @@ func runVendorCrdCmd(cmd *cobra.Command, args []string) error {
 		err     error
 	)
 	if strings.HasPrefix(vendorCrdArgs.crdFile, "https://") {
-		req, err := http.NewRequest("GET", vendorCrdArgs.crdFile, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create HTTP request for %s, error: %w", vendorCrdArgs.crdFile, err)
-		}
-
-		hctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+		hctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 		defer cancel()
 
-		resp, err := cleanhttp.DefaultClient().Do(req.WithContext(hctx))
+		crdData, err = readRemoteCRDManifest(hctx, cleanhttp.DefaultClient(), vendorCrdArgs.crdFile,
+			maxRemoteCRDManifestSize)
 		if err != nil {
-			return fmt.Errorf("failed to download manifest from %s, error: %w", vendorCrdArgs.crdFile, err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("failed to download manifest from %s, status: %s", vendorCrdArgs.crdFile, resp.Status)
-		}
-
-		crdData, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to download manifest from %s, error: %w", vendorCrdArgs.crdFile, err)
+			return err
 		}
 	} else {
 		if fs, err := os.Stat(vendorCrdArgs.crdFile); err != nil || !fs.Mode().IsRegular() {
@@ -178,6 +166,52 @@ func runVendorCrdCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// readRemoteCRDManifest downloads a response within the size limit without redirecting to HTTP.
+func readRemoteCRDManifest(ctx context.Context, client *http.Client, url string, maxSize int64) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request for %s, error: %w", url, err)
+	}
+
+	httpClient := *client
+	checkRedirect := httpClient.CheckRedirect
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Scheme != "https" {
+			return fmt.Errorf("redirect to insecure HTTP URL %s", req.URL)
+		}
+		if checkRedirect != nil {
+			return checkRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		return nil
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download manifest from %s, error: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download manifest from %s, status: %s", url, resp.Status)
+	}
+	if resp.ContentLength > maxSize {
+		return nil, fmt.Errorf("failed to download manifest from %s, response exceeds the %d-byte limit", url, maxSize)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to download manifest from %s, error: %w", url, err)
+	}
+	if int64(len(data)) > maxSize {
+		return nil, fmt.Errorf("failed to download manifest from %s, response exceeds the %d-byte limit", url, maxSize)
+	}
+
+	return data, nil
 }
 
 // removeCRDStatusSchema removes the read-only status field from each version.

--- a/cmd/timoni/mod_vendor_crd_test.go
+++ b/cmd/timoni/mod_vendor_crd_test.go
@@ -17,7 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path"
@@ -28,6 +33,103 @@ import (
 	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+func TestReadRemoteCRDManifestAcceptsBodyAtLimit(t *testing.T) {
+	g := NewWithT(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("crd!"))
+	}))
+	defer server.Close()
+
+	data, err := readRemoteCRDManifest(context.Background(), server.Client(), server.URL, 4)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(data)).To(Equal("crd!"))
+}
+
+func TestReadRemoteCRDManifestHonorsCancellation(t *testing.T) {
+	g := NewWithT(t)
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-started
+		cancel()
+	}()
+
+	_, err := readRemoteCRDManifest(ctx, server.Client(), server.URL, 4)
+
+	g.Expect(err).To(MatchError(ContainSubstring(context.Canceled.Error())))
+}
+
+func TestReadRemoteCRDManifestRejectsLargeContentLength(t *testing.T) {
+	g := NewWithT(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "5")
+		_, _ = w.Write([]byte("crd!!"))
+	}))
+	defer server.Close()
+
+	_, err := readRemoteCRDManifest(context.Background(), server.Client(), server.URL, 4)
+
+	g.Expect(err).To(MatchError(ContainSubstring("exceeds the 4-byte limit")))
+	g.Expect(err).To(MatchError(ContainSubstring(server.URL)))
+}
+
+func TestReadRemoteCRDManifestRejectsUnknownLengthBody(t *testing.T) {
+	g := NewWithT(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.(http.Flusher).Flush()
+		_, _ = w.Write([]byte("crd!!"))
+	}))
+	defer server.Close()
+
+	_, err := readRemoteCRDManifest(context.Background(), server.Client(), server.URL, 4)
+
+	g.Expect(err).To(MatchError(ContainSubstring("exceeds the 4-byte limit")))
+}
+
+func TestReadRemoteCRDManifestLimitsDecodedBody(t *testing.T) {
+	g := NewWithT(t)
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	_, err := zw.Write(bytes.Repeat([]byte("x"), 101))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(zw.Close()).To(Succeed())
+	g.Expect(compressed.Len()).To(BeNumerically("<", 100))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	defer server.Close()
+
+	_, err = readRemoteCRDManifest(context.Background(), server.Client(), server.URL, 100)
+
+	g.Expect(err).To(MatchError(ContainSubstring("exceeds the 100-byte limit")))
+}
+
+func TestReadRemoteCRDManifestRejectsInsecureRedirect(t *testing.T) {
+	g := NewWithT(t)
+	insecure := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("crd"))
+	}))
+	defer insecure.Close()
+	secure := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", insecure.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer secure.Close()
+
+	_, err := readRemoteCRDManifest(context.Background(), secure.Client(), secure.URL, 4)
+
+	g.Expect(err).To(MatchError(ContainSubstring("redirect to insecure HTTP")))
+}
 
 func TestRemoveCRDStatusSchema(t *testing.T) {
 	tests := []struct {

--- a/docs/cue/module/custom-resources.md
+++ b/docs/cue/module/custom-resources.md
@@ -21,6 +21,8 @@ to the YAML file which contains the Prometheus Operator CRDs:
 timoni mod vendor crds -f https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.68.0/stripped-down-crds.yaml
 ```
 
+Remote CRD manifests are limited to 16 MiB after HTTP content decoding.
+
 The above command will generate the CUE schemas corresponding to the Kubernetes CRDs
 inside the `cue.mod/gen` directory:
 


### PR DESCRIPTION
## What

Limit remote CRD manifests to 16 MiB after HTTP content decoding, reject redirects to plain HTTP, and cancel downloads with the command context.

## Why

Remote manifests were read into memory without a size bound, could follow HTTPS redirects to plain HTTP, and ignored caller cancellation until the command timeout.

## Reproduction

```shell
mod vendor crd ./module -f https://server.example/crds-over-16mib.yaml
# main: downloads the complete response before parsing
# here: stderr contains 'response exceeds the 16777216-byte limit'
```

## Verification

```shell
go test ./cmd/timoni -run 'TestReadRemoteCRDManifest' -count=1
```

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>