### PR TITLE
fix(cli): Preserve command cancellation

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -170,7 +170,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	ctxPull, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctxPull, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	f, err := fetcher.New(ctxPull, fetcher.Options{

--- a/cmd/timoni/artifact_build.go
+++ b/cmd/timoni/artifact_build.go
@@ -92,7 +92,7 @@ func buildArtifactCmdRun(cmd *cobra.Command, _ []string) (err error) {
 	if err != nil {
 		return err
 	}
-	oci.AppendGitMetadata(buildArtifactArgs.path, annotations)
+	oci.AppendGitMetadata(cmd.Context(), buildArtifactArgs.path, annotations)
 
 	build, err := oci.BuildArtifactImage(buildArtifactArgs.path, ignorePaths, buildArtifactArgs.contentType, annotations)
 	if err != nil {

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -143,7 +143,7 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	oci.AppendGitMetadata(pushArtifactArgs.path, annotations)
+	oci.AppendGitMetadata(cmd.Context(), pushArtifactArgs.path, annotations)
 
 	spin := logger.StartSpinner("pushing artifact")
 	defer spin.Stop()

--- a/cmd/timoni/artifact_tag.go
+++ b/cmd/timoni/artifact_tag.go
@@ -73,7 +73,7 @@ func tagArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	defer spin.Stop()
 
 	log := LoggerFrom(cmd.Context())
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	opts := oci.Options(ctx, tagArtifactArgs.creds.String(), rootArgs.registryInsecure)

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -122,7 +122,7 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	ctxPull, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctxPull, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	f, err := fetcher.New(ctxPull, fetcher.Options{

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -193,7 +193,7 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 		log := loggerBundle(cmd.Context(), bundle.Name, cluster.Name, true)
 
 		if !bundleApplyArgs.overwriteOwnership {
-			err = bundleInstancesOwnershipConflicts(bundle.Instances)
+			err = bundleInstancesOwnershipConflicts(cmd.Context(), bundle.Instances)
 			if err != nil {
 				return annotateInstanceOwnershipConflictErr(err)
 			}
@@ -374,14 +374,14 @@ func saveReaderToFile(reader io.Reader) (string, error) {
 	return path, nil
 }
 
-func bundleInstancesOwnershipConflicts(bundleInstances []*apiv1.BundleInstance) error {
+func bundleInstancesOwnershipConflicts(parent context.Context, bundleInstances []*apiv1.BundleInstance) error {
 	var conflicts reconciler.InstanceOwnershipConflictErr
 	rm, err := runtime.NewResourceManager(kubeconfigArgs)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(parent, rootArgs.timeout)
 	defer cancel()
 
 	sm := runtime.NewStorageManager(rm)

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -163,7 +163,7 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ctxPull, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctxPull, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	for _, instance := range bundle.Instances {

--- a/cmd/timoni/bundle_delete.go
+++ b/cmd/timoni/bundle_delete.go
@@ -105,7 +105,7 @@ func runBundleDelCmd(cmd *cobra.Command, args []string) error {
 		return errors.New("no cluster found")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	for _, cluster := range clusters {
@@ -155,7 +155,7 @@ func deleteBundleInstance(ctx context.Context, instance *apiv1.BundleInstance, w
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(ctx, rootArgs.timeout)
 	defer cancel()
 
 	iStorage := runtime.NewStorageManager(sm)

--- a/cmd/timoni/bundle_status.go
+++ b/cmd/timoni/bundle_status.go
@@ -87,7 +87,7 @@ func runBundleStatusCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no cluster found")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	failed := false

--- a/cmd/timoni/completion_funcs.go
+++ b/cmd/timoni/completion_funcs.go
@@ -28,7 +28,7 @@ import (
 // a Timoni instance, based on the current context in ~/.kube/config,
 // and the current namespace set via --namespace.
 func completeInstanceList(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	instances, err := listInstancesFromFlags()
+	instances, err := listInstancesFromFlags(cmd.Context())
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -51,7 +51,7 @@ func completeNamespaceList(cmd *cobra.Command, args []string, toComplete string)
 
 	iStorage := runtime.NewStorageManager(sm)
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	namespaces, err := iStorage.ListNamespaces(ctx)

--- a/cmd/timoni/delete.go
+++ b/cmd/timoni/delete.go
@@ -80,7 +80,7 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	iStorage := runtime.NewStorageManager(sm)

--- a/cmd/timoni/inspect_module.go
+++ b/cmd/timoni/inspect_module.go
@@ -66,7 +66,7 @@ func runInspectModuleCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	iStorage := runtime.NewStorageManager(sm)

--- a/cmd/timoni/inspect_resources.go
+++ b/cmd/timoni/inspect_resources.go
@@ -65,7 +65,7 @@ func runInspectResourcesCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	iStorage := runtime.NewStorageManager(sm)

--- a/cmd/timoni/inspect_values.go
+++ b/cmd/timoni/inspect_values.go
@@ -66,7 +66,7 @@ func runInspectValuesCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	iStorage := runtime.NewStorageManager(sm)

--- a/cmd/timoni/list.go
+++ b/cmd/timoni/list.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 func runListCmd(cmd *cobra.Command, args []string) error {
-	instances, err := listInstancesFromFlags()
+	instances, err := listInstancesFromFlags(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func runListCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func listInstancesFromFlags() ([]*apiv1.Instance, error) {
+func listInstancesFromFlags(parent context.Context) ([]*apiv1.Instance, error) {
 	sm, err := runtime.NewResourceManager(kubeconfigArgs)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func listInstancesFromFlags() ([]*apiv1.Instance, error) {
 
 	iStorage := runtime.NewStorageManager(sm)
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(parent, rootArgs.timeout)
 	defer cancel()
 
 	ns := *kubeconfigArgs.Namespace

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -17,9 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
 	"path"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/fatih/color"
@@ -96,7 +99,10 @@ func init() {
 
 func main() {
 	setCacheDir()
-	if err := rootCmd.Execute(); err != nil {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	go restoreSignalHandling(ctx, cancel)
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		// Ensure a logger is initialized even if the rootCmd
 		// failed before running its hooks.
 		if cliLogger.IsZero() {
@@ -108,6 +114,12 @@ func main() {
 		cliLogger.Error(nil, err.Error())
 		os.Exit(1)
 	}
+}
+
+// restoreSignalHandling restores default signal behavior after cancellation.
+func restoreSignalHandling(ctx context.Context, stop context.CancelFunc) {
+	<-ctx.Done()
+	stop()
 }
 
 func setCacheDir() {

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -99,6 +99,20 @@ func executeCommand(cmd string) (string, error) {
 	return executeCommandWithIn(cmd, nil)
 }
 
+func TestRestoreSignalHandlingAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+
+	go restoreSignalHandling(ctx, func() { close(stopped) })
+	cancel()
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("signal handling was not restored")
+	}
+}
+
 func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
 	defer resetCmdArgs()
 	args, err := shellwords.Parse(cmd)

--- a/cmd/timoni/mod_build.go
+++ b/cmd/timoni/mod_build.go
@@ -82,7 +82,7 @@ func buildModCmdRun(cmd *cobra.Command, args []string) (err error) {
 	}
 	// The required flag owns the manifest version annotation.
 	annotations[apiv1.VersionAnnotation] = buildModArgs.version
-	oci.AppendGitMetadata(module, annotations)
+	oci.AppendGitMetadata(cmd.Context(), module, annotations)
 	ignorePaths, err := engine.ReadIgnoreFile(module)
 	if err != nil {
 		return fmt.Errorf("reading %s failed: %w", apiv1.IgnoreFile, err)

--- a/cmd/timoni/mod_init.go
+++ b/cmd/timoni/mod_init.go
@@ -91,7 +91,7 @@ func runInitModCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	templateURL := modTemplateURL

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -144,7 +144,7 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	annotations[apiv1.VersionAnnotation] = version
-	oci.AppendGitMetadata(pushModArgs.module, annotations)
+	oci.AppendGitMetadata(cmd.Context(), pushModArgs.module, annotations)
 
 	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()

--- a/cmd/timoni/mod_show_config.go
+++ b/cmd/timoni/mod_show_config.go
@@ -88,7 +88,7 @@ func runConfigShowModCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	ctxPull, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctxPull, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	f, err := fetcher.New(ctxPull, fetcher.Options{

--- a/cmd/timoni/mod_vendor_k8s.go
+++ b/cmd/timoni/mod_vendor_k8s.go
@@ -72,7 +72,7 @@ func runVendorK8sCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cue.mod not found in the module path %s", vendorK8sArgs.modRoot)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	ociURL := fmt.Sprintf("%s:%s", k8sSchemaURL, vendorK8sArgs.version)

--- a/cmd/timoni/mod_vet.go
+++ b/cmd/timoni/mod_vet.go
@@ -92,7 +92,7 @@ func runVetModCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	ctxPull, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctxPull, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	f, err := fetcher.New(ctxPull, fetcher.Options{

--- a/cmd/timoni/status.go
+++ b/cmd/timoni/status.go
@@ -73,7 +73,7 @@ func runStatusCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
 	st := runtime.NewStorageManager(rm)

--- a/internal/oci/artifact_test.go
+++ b/internal/oci/artifact_test.go
@@ -42,7 +42,7 @@ func TestArtifactOperations(t *testing.T) {
 
 	annotations, err := ParseAnnotations([]string{imgLicense})
 	g.Expect(err).ToNot(HaveOccurred())
-	AppendGitMetadata(srcPath, annotations)
+	AppendGitMetadata(context.Background(), srcPath, annotations)
 
 	opts := Options(ctx, "", false)
 	digestURL, err := PushArtifact(imgVersionURL, srcPath, imgIgnore, imgContentType, annotations, opts)

--- a/internal/oci/metadata.go
+++ b/internal/oci/metadata.go
@@ -45,13 +45,14 @@ func ParseAnnotations(args []string) (map[string]string, error) {
 }
 
 // AppendGitMetadata fills missing creation, source, and revision annotations.
-// Creation uses SOURCE_DATE_EPOCH before Git commit time; Git failures are ignored.
-func AppendGitMetadata(repoPath string, annotations map[string]string) {
+// Creation uses SOURCE_DATE_EPOCH before Git commit time; Git failures and
+// cancellations are ignored.
+func AppendGitMetadata(parent context.Context, repoPath string, annotations map[string]string) {
 	if info, err := os.Stat(repoPath); err == nil && !info.IsDir() {
 		repoPath = filepath.Dir(repoPath)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 10*time.Second)
 	defer cancel()
 
 	if _, found := annotations[apiv1.CreatedAnnotation]; !found {

--- a/internal/oci/metadata_test.go
+++ b/internal/oci/metadata_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oci
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -42,7 +43,7 @@ func TestAppendGitMetadataPrecedence(t *testing.T) {
 		t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
 		annotations := map[string]string{apiv1.CreatedAnnotation: "2024-01-02T03:04:05Z"}
 
-		AppendGitMetadata(t.TempDir(), annotations)
+		AppendGitMetadata(context.Background(), t.TempDir(), annotations)
 
 		g.Expect(annotations).To(HaveKeyWithValue(apiv1.CreatedAnnotation, "2024-01-02T03:04:05Z"))
 	})
@@ -52,7 +53,7 @@ func TestAppendGitMetadataPrecedence(t *testing.T) {
 		t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
 		annotations := map[string]string{}
 
-		AppendGitMetadata(t.TempDir(), annotations)
+		AppendGitMetadata(context.Background(), t.TempDir(), annotations)
 
 		g.Expect(annotations).To(HaveKeyWithValue(apiv1.CreatedAnnotation, "2023-11-14T22:13:20Z"))
 	})
@@ -70,7 +71,7 @@ func TestAppendGitMetadataPrecedence(t *testing.T) {
 		g.Expect(cmd.Run()).To(Succeed())
 
 		annotations := map[string]string{}
-		AppendGitMetadata(repo, annotations)
+		AppendGitMetadata(context.Background(), repo, annotations)
 
 		g.Expect(annotations).To(HaveKeyWithValue(apiv1.CreatedAnnotation, "2023-11-14T22:13:20Z"))
 		g.Expect(annotations[apiv1.RevisionAnnotation]).To(HaveLen(40))
@@ -81,10 +82,22 @@ func TestAppendGitMetadataPrecedence(t *testing.T) {
 		t.Setenv("SOURCE_DATE_EPOCH", "")
 		annotations := map[string]string{}
 
-		AppendGitMetadata(t.TempDir(), annotations)
+		AppendGitMetadata(context.Background(), t.TempDir(), annotations)
 
 		g.Expect(annotations).ToNot(HaveKey(apiv1.CreatedAnnotation))
 	})
+}
+
+func TestAppendGitMetadataHonorsCancellation(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("SOURCE_DATE_EPOCH", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	annotations := map[string]string{}
+
+	AppendGitMetadata(ctx, t.TempDir(), annotations)
+
+	g.Expect(annotations).To(BeEmpty())
 }
 
 func runGitTestCommand(t *testing.T, dir string, args ...string) {

--- a/internal/oci/module_test.go
+++ b/internal/oci/module_test.go
@@ -46,7 +46,7 @@ func TestModuleOperations(t *testing.T) {
 	annotations, err := ParseAnnotations([]string{imgLicense})
 	g.Expect(err).ToNot(HaveOccurred())
 	annotations[apiv1.VersionAnnotation] = imgVersion
-	AppendGitMetadata(srcPath, annotations)
+	AppendGitMetadata(context.Background(), srcPath, annotations)
 
 	opts := Options(ctx, "", false)
 	digestURL, err := PushModule(imgVersionURL, srcPath, imgIgnore, annotations, opts)


### PR DESCRIPTION
## What

Propagate `SIGINT`, `SIGTERM`, and Cobra caller cancellation through command timeouts, Kubernetes and registry operations, completions, and Git metadata collection. Restore default signal handling after cancellation.

## Why

The logger hook and command timeouts replaced caller contexts with background contexts, delaying cancellation until local timeouts or abrupt process termination. Continued signal interception could also prevent a second signal from terminating a stuck command.

## Reproduction

```shell
nc -l 5000 >/dev/null &
server=$!
mod pull oci://127.0.0.1:5000/example -v 1.0.0 -o /tmp/module --creds : --registry-insecure --timeout 1h &
pid=$!
sleep 1
kill -TERM "$pid"
wait "$pid"
kill "$server"
# main: the process is terminated directly
# here: stderr contains 'context canceled' after deferred cleanup
```

## Verification

```shell
go test ./cmd/timoni -run 'Test(RootCommandPreservesContextCancellation|RestoreSignalHandlingAfterCancellation)' -count=1
go test ./internal/oci -run TestAppendGitMetadata -count=1
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./cmd/timoni -o /tmp/timoni-command-context.test.exe
```

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
