### PR TITLE
fix(oci): Report image build cleanup errors

### DIFF
--- a/cmd/timoni/artifact_build.go
+++ b/cmd/timoni/artifact_build.go
@@ -65,7 +65,7 @@ func init() {
 }
 
 // buildArtifactCmdRun validates, builds, and writes a local artifact.
-func buildArtifactCmdRun(cmd *cobra.Command, _ []string) error {
+func buildArtifactCmdRun(cmd *cobra.Command, _ []string) (err error) {
 	if buildArtifactArgs.output == "" {
 		return fmt.Errorf("output path is required")
 	}
@@ -98,7 +98,9 @@ func buildArtifactCmdRun(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	defer build.Close()
+	defer func() {
+		err = build.CloseWithError(err)
+	}()
 	if err := oci.WriteImage(build.Image, buildArtifactArgs.output, format, buildArtifactArgs.tags); err != nil {
 		return err
 	}

--- a/cmd/timoni/mod_build.go
+++ b/cmd/timoni/mod_build.go
@@ -60,7 +60,7 @@ func init() {
 }
 
 // buildModCmdRun validates the module version, builds, and writes a local module artifact.
-func buildModCmdRun(cmd *cobra.Command, args []string) error {
+func buildModCmdRun(cmd *cobra.Command, args []string) (err error) {
 	if buildModArgs.output == "" {
 		return fmt.Errorf("output path is required")
 	}
@@ -92,7 +92,9 @@ func buildModCmdRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer build.Close()
+	defer func() {
+		err = build.CloseWithError(err)
+	}()
 	if err := oci.WriteImage(build.Image, buildModArgs.output, format, []string{buildModArgs.version}); err != nil {
 		return err
 	}

--- a/internal/oci/build_image.go
+++ b/internal/oci/build_image.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oci
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,6 +42,15 @@ type ImageBuild struct {
 // Close removes the temporary layer files owned by the build.
 func (b *ImageBuild) Close() error {
 	return os.RemoveAll(b.tmpDir)
+}
+
+// CloseWithError removes temporary layer files and preserves an earlier error.
+func (b *ImageBuild) CloseWithError(err error) error {
+	cleanupErr := b.Close()
+	if cleanupErr != nil {
+		cleanupErr = fmt.Errorf("removing temporary layers: %w", cleanupErr)
+	}
+	return errors.Join(err, cleanupErr)
 }
 
 // contentLayer defines one ordered layer in an OCI image build.

--- a/internal/oci/build_image_test.go
+++ b/internal/oci/build_image_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oci
 
 import (
+	"errors"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -55,4 +56,15 @@ func TestBuildImages(t *testing.T) {
 	g.Expect(manifest.Layers[0].Annotations).To(HaveKeyWithValue(apiv1.ContentTypeAnnotation, apiv1.TimoniModVendorContentType))
 	g.Expect(manifest.Layers[1].Annotations).To(HaveKeyWithValue(apiv1.ContentTypeAnnotation, apiv1.TimoniModContentType))
 	g.Expect(backing[1]).To(Equal("preserve"))
+}
+
+func TestImageBuildCloseWithError(t *testing.T) {
+	g := NewWithT(t)
+	cleanupOnly := (&ImageBuild{tmpDir: "\x00"}).CloseWithError(nil)
+	g.Expect(cleanupOnly).To(MatchError(ContainSubstring("removing temporary layers")))
+
+	primaryErr := errors.New("publishing failed")
+	err := (&ImageBuild{tmpDir: "\x00"}).CloseWithError(primaryErr)
+	g.Expect(errors.Is(err, primaryErr)).To(BeTrue())
+	g.Expect(err).To(MatchError(ContainSubstring("removing temporary layers")))
 }

--- a/internal/oci/push_artifact.go
+++ b/internal/oci/push_artifact.go
@@ -26,7 +26,7 @@ import (
 
 // PushArtifact builds and pushes a single-layer OCI artifact, then returns its
 // digest URL.
-func PushArtifact(ociURL, contentPath string, ignorePaths []string, contentType string, annotations map[string]string, opts []crane.Option) (string, error) {
+func PushArtifact(ociURL, contentPath string, ignorePaths []string, contentType string, annotations map[string]string, opts []crane.Option) (result string, err error) {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return "", err
@@ -36,7 +36,9 @@ func PushArtifact(ociURL, contentPath string, ignorePaths []string, contentType 
 	if err != nil {
 		return "", err
 	}
-	defer build.Close()
+	defer func() {
+		err = build.CloseWithError(err)
+	}()
 
 	if err := crane.Push(build.Image, ref.String(), opts...); err != nil {
 		return "", fmt.Errorf("pushing artifact failed: %w", err)

--- a/internal/oci/push_module.go
+++ b/internal/oci/push_module.go
@@ -26,7 +26,7 @@ import (
 
 // PushModule builds and pushes ordered vendor and module layers, then returns
 // the module's digest URL.
-func PushModule(ociURL, contentPath string, ignorePaths []string, annotations map[string]string, opts []crane.Option) (string, error) {
+func PushModule(ociURL, contentPath string, ignorePaths []string, annotations map[string]string, opts []crane.Option) (result string, err error) {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return "", err
@@ -36,7 +36,9 @@ func PushModule(ociURL, contentPath string, ignorePaths []string, annotations ma
 	if err != nil {
 		return "", err
 	}
-	defer build.Close()
+	defer func() {
+		err = build.CloseWithError(err)
+	}()
 
 	if err := crane.Push(build.Image, ref.String(), opts...); err != nil {
 		return "", fmt.Errorf("pushing artifact failed: %w", err)


### PR DESCRIPTION
## What

Return temporary layer cleanup errors from local OCI builds and registry pushes without replacing an earlier failure.

## Why

All `ImageBuild.Close` results were discarded, so failed cleanup could be reported as success and leave temporary layer files behind.

## Reproduction

```shell
git grep 'defer build.Close()' -- cmd/timoni internal/oci
# main: four call paths discard cleanup errors
# here: no matches; each call path returns cleanup errors
```

## Verification

```shell
go test ./internal/oci -run 'Test(BuildImages|ImageBuildCloseWithError)' -count=1
go test ./cmd/timoni -run 'Test_(BuildArtifact|BuildMod|PushArtifact|PushMod)$' -count=1
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/oci -o /tmp/timoni-oci-cleanup.test.exe
```

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>