### PR TITLE
fix(oci): Forward insecure registry transport

### DIFF
--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -135,7 +135,8 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 			pullArtifactArgs.certificateIdentity,
 			pullArtifactArgs.certificateIdentityRegexp,
 			pullArtifactArgs.certificateOidcIssuer,
-			pullArtifactArgs.certificateOidcIssuerRegexp)
+			pullArtifactArgs.certificateOidcIssuerRegexp,
+			rootArgs.registryInsecure)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -171,7 +171,7 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin.Stop()
 	if pushArtifactArgs.sign != "" {
-		err = oci.SignArtifact(ctx, log, pushArtifactArgs.sign, digestURL, pushArtifactArgs.cosignKey)
+		err = oci.SignArtifact(ctx, log, pushArtifactArgs.sign, digestURL, pushArtifactArgs.cosignKey, rootArgs.registryInsecure)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -147,7 +147,8 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 			pullModArgs.certificateIdentity,
 			pullModArgs.certificateIdentityRegexp,
 			pullModArgs.certificateOidcIssuer,
-			pullModArgs.certificateOidcIssuerRegexp)
+			pullModArgs.certificateOidcIssuerRegexp,
+			rootArgs.registryInsecure)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -172,7 +172,7 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin.Stop()
 	if pushModArgs.sign != "" {
-		err = oci.SignArtifact(ctx, log, pushModArgs.sign, digestURL, pushModArgs.cosignKey)
+		err = oci.SignArtifact(ctx, log, pushModArgs.sign, digestURL, pushModArgs.cosignKey, rootArgs.registryInsecure)
 		if err != nil {
 			return err
 		}

--- a/docs/bundle-distribution.md
+++ b/docs/bundle-distribution.md
@@ -50,6 +50,9 @@ When publishing bundles with [timoni artifact push](cmd/timoni_artifact_push.md)
 
 Registry tags must follow the OCI Distribution tag grammar.
 
+When `--registry-insecure` is set, Timoni also permits Cosign to use plain HTTP or skip TLS verification.
+Use this option only for testing.
+
 ### Push and sign example
 
 Login to the container registry:

--- a/docs/cue/module/signing.md
+++ b/docs/cue/module/signing.md
@@ -12,6 +12,9 @@ OCI artifacts with a public/private key pair or with an OIDC token provided by G
 To sign modules, you need to [install](https://docs.sigstore.dev/system_config/installation/)
 the Cosign v2 binary and place it in the `PATH` for Timoni to use it.
 
+When `--registry-insecure` is set, Timoni also permits Cosign to use plain HTTP or skip TLS verification.
+Use this option only for testing.
+
 ### Sign with static keys
 
 Generate a cosign key pair:

--- a/internal/oci/sign_artifact.go
+++ b/internal/oci/sign_artifact.go
@@ -50,8 +50,9 @@ func validateCosignExecutable() error {
 	return nil
 }
 
-// SignArtifact validates the provider and signs an OpenContainers artifact.
-func SignArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string) error {
+// SignArtifact validates the provider and signs an OpenContainers artifact
+// with the requested registry transport.
+func SignArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string, insecure bool) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
@@ -60,11 +61,12 @@ func SignArtifact(ctx context.Context, log logr.Logger, provider string, ociURL 
 	if err := ValidateSigningProvider(provider); err != nil {
 		return err
 	}
-	return SignCosign(ctx, log, ref.String(), keyRef)
+	return SignCosign(ctx, log, ref.String(), keyRef, insecure)
 }
 
-// VerifyArtifact validates the provider and verifies an OpenContainers artifact.
-func VerifyArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
+// VerifyArtifact validates the provider and verifies an OpenContainers artifact
+// with the requested registry transport.
+func VerifyArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string, insecure bool) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
@@ -73,5 +75,5 @@ func VerifyArtifact(ctx context.Context, log logr.Logger, provider string, ociUR
 	if err := ValidateVerificationProvider(provider); err != nil {
 		return err
 	}
-	return VerifyCosign(ctx, log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp)
+	return VerifyCosign(ctx, log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp, insecure)
 }

--- a/internal/oci/sign_cosign.go
+++ b/internal/oci/sign_cosign.go
@@ -33,14 +33,14 @@ const (
 	maxCosignOutputScanToken = maxCosignOutputLogLine + 1
 )
 
-// SignCosign signs an image (`imageRef`) using a cosign private key (`keyRef`).
-func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string) error {
+// SignCosign signs an image and optionally permits insecure registry transport.
+func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string, insecure bool) error {
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
 	}
 
-	cosignCmd := exec.CommandContext(ctx, cosignExecutable, []string{"sign"}...)
+	cosignCmd := newCosignCommand(ctx, cosignExecutable, "sign", insecure)
 	cosignCmd.Env = os.Environ()
 
 	// if key is empty, use keyless mode
@@ -59,16 +59,18 @@ func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef st
 	return nil
 }
 
-// VerifyCosign verifies an image (`rawRef`) with a cosign public key (`keyRef`).
-// Either --cosign-certificate-identity or --cosign-certificate-identity-regexp and either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows.
+// VerifyCosign verifies an image and optionally permits insecure registry
+// transport. Keyless flows require an identity and an OIDC issuer or their
+// regular-expression alternatives.
 func VerifyCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string,
-	certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) error {
+	certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string,
+	insecure bool) error {
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
 	}
 
-	cosignCmd := exec.CommandContext(ctx, cosignExecutable, []string{"verify"}...)
+	cosignCmd := newCosignCommand(ctx, cosignExecutable, "verify", insecure)
 	cosignCmd.Env = os.Environ()
 
 	// if key is empty, use keyless mode
@@ -103,6 +105,15 @@ func VerifyCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef 
 	}
 
 	return nil
+}
+
+// newCosignCommand creates a Cosign command with the requested registry transport.
+func newCosignCommand(ctx context.Context, executable string, operation string, insecure bool) *exec.Cmd {
+	args := []string{operation}
+	if insecure {
+		args = append(args, "--allow-http-registry", "--allow-insecure-registry")
+	}
+	return exec.CommandContext(ctx, executable, args...)
 }
 
 // processCosignIO runs cosign and logs its output while draining both streams.

--- a/internal/oci/sign_cosign_test.go
+++ b/internal/oci/sign_cosign_test.go
@@ -39,6 +39,22 @@ func TestProcessCosignIOReturnsExitError(t *testing.T) {
 	g.Expect(cmd.ProcessState).ToNot(BeNil())
 }
 
+func TestNewCosignCommandRegistryFlags(t *testing.T) {
+	for _, operation := range []string{"sign", "verify"} {
+		t.Run(operation, func(t *testing.T) {
+			g := NewWithT(t)
+
+			secure := newCosignCommand(context.Background(), "cosign", operation, false)
+			insecure := newCosignCommand(context.Background(), "cosign", operation, true)
+
+			g.Expect(secure.Args).To(Equal([]string{"cosign", operation}))
+			g.Expect(insecure.Args).To(Equal([]string{
+				"cosign", operation, "--allow-http-registry", "--allow-insecure-registry",
+			}))
+		})
+	}
+}
+
 func TestProcessCosignIODrainsOutputConcurrently(t *testing.T) {
 	g := NewWithT(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## What

Forward `--registry-insecure` to Cosign for module and artifact signing and verification.

## Why

Timoni allowed insecure registry transport for push and pull, but Cosign still required secure HTTPS.
Plain HTTP and self-signed TLS therefore failed during signing or verification.

## Reproduction

```shell
tmp="$(mktemp -d)"
mkdir "$tmp/bin"
printf '%s\n' '#!/bin/sh' 'printf "%s\n" "$@"' 'exit 23' > "$tmp/bin/cosign"
chmod +x "$tmp/bin/cosign"
PATH="$tmp/bin:$PATH" ./bin/timoni artifact pull oci://example.com/org/app:1.0.0 --verify=cosign --cosign-key=key.pub --registry-insecure -o "$tmp/output"
# main: Cosign receives neither insecure-registry transport flag
# here: Cosign receives --allow-http-registry and --allow-insecure-registry
```

## Verification

`go test ./internal/oci -run '^TestNewCosignCommandRegistryFlags$' -count=1`

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>