### PR TITLE
fix(oci): Forward Cosign registry credentials

### DIFF
--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -136,7 +136,8 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 			pullArtifactArgs.certificateIdentityRegexp,
 			pullArtifactArgs.certificateOidcIssuer,
 			pullArtifactArgs.certificateOidcIssuerRegexp,
-			rootArgs.registryInsecure)
+			rootArgs.registryInsecure,
+			pullArtifactArgs.creds.String())
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -171,7 +171,7 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin.Stop()
 	if pushArtifactArgs.sign != "" {
-		err = oci.SignArtifact(ctx, log, pushArtifactArgs.sign, digestURL, pushArtifactArgs.cosignKey, rootArgs.registryInsecure)
+		err = oci.SignArtifact(ctx, log, pushArtifactArgs.sign, digestURL, pushArtifactArgs.cosignKey, rootArgs.registryInsecure, pushArtifactArgs.creds.String())
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -148,7 +148,8 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 			pullModArgs.certificateIdentityRegexp,
 			pullModArgs.certificateOidcIssuer,
 			pullModArgs.certificateOidcIssuerRegexp,
-			rootArgs.registryInsecure)
+			rootArgs.registryInsecure,
+			pullModArgs.creds.String())
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -172,7 +172,7 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 
 	spin.Stop()
 	if pushModArgs.sign != "" {
-		err = oci.SignArtifact(ctx, log, pushModArgs.sign, digestURL, pushModArgs.cosignKey, rootArgs.registryInsecure)
+		err = oci.SignArtifact(ctx, log, pushModArgs.sign, digestURL, pushModArgs.cosignKey, rootArgs.registryInsecure, pushModArgs.creds.String())
 		if err != nil {
 			return err
 		}

--- a/docs/bundle-distribution.md
+++ b/docs/bundle-distribution.md
@@ -52,6 +52,7 @@ Registry tags must follow the OCI Distribution tag grammar.
 
 When `--registry-insecure` is set, Timoni also permits Cosign to use plain HTTP or skip TLS verification.
 Use this option only for testing.
+When `--creds` is set, Timoni also uses those credentials for Cosign.
 
 ### Push and sign example
 

--- a/docs/cue/module/signing.md
+++ b/docs/cue/module/signing.md
@@ -14,6 +14,7 @@ the Cosign v2 binary and place it in the `PATH` for Timoni to use it.
 
 When `--registry-insecure` is set, Timoni also permits Cosign to use plain HTTP or skip TLS verification.
 Use this option only for testing.
+When `--creds` is set, Timoni also uses those credentials for Cosign.
 
 ### Sign with static keys
 

--- a/internal/oci/sign_artifact.go
+++ b/internal/oci/sign_artifact.go
@@ -51,8 +51,8 @@ func validateCosignExecutable() error {
 }
 
 // SignArtifact validates the provider and signs an OpenContainers artifact
-// with the requested registry transport.
-func SignArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string, insecure bool) error {
+// with the requested registry credentials and transport.
+func SignArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string, insecure bool, credentials string) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
@@ -61,12 +61,12 @@ func SignArtifact(ctx context.Context, log logr.Logger, provider string, ociURL 
 	if err := ValidateSigningProvider(provider); err != nil {
 		return err
 	}
-	return SignCosign(ctx, log, ref.String(), keyRef, insecure)
+	return SignCosign(ctx, log, ref.String(), keyRef, insecure, credentials)
 }
 
 // VerifyArtifact validates the provider and verifies an OpenContainers artifact
-// with the requested registry transport.
-func VerifyArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string, insecure bool) error {
+// with the requested registry credentials and transport.
+func VerifyArtifact(ctx context.Context, log logr.Logger, provider string, ociURL string, keyRef string, certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string, insecure bool, credentials string) error {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return err
@@ -75,5 +75,5 @@ func VerifyArtifact(ctx context.Context, log logr.Logger, provider string, ociUR
 	if err := ValidateVerificationProvider(provider); err != nil {
 		return err
 	}
-	return VerifyCosign(ctx, log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp, insecure)
+	return VerifyCosign(ctx, log, ref.String(), keyRef, certIdentity, certIdentityRegexp, certOidcIssuer, certOidcIssuerRegexp, insecure, credentials)
 }

--- a/internal/oci/sign_cosign.go
+++ b/internal/oci/sign_cosign.go
@@ -19,13 +19,19 @@ package oci
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 )
 
 const (
@@ -33,8 +39,19 @@ const (
 	maxCosignOutputScanToken = maxCosignOutputLogLine + 1
 )
 
-// SignCosign signs an image and optionally permits insecure registry transport.
-func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string, insecure bool) error {
+// dockerConfig contains registry authentication for a Cosign subprocess.
+type dockerConfig struct {
+	Auths map[string]dockerAuthConfig `json:"auths"`
+}
+
+// dockerAuthConfig contains one registry's Docker-compatible authentication.
+type dockerAuthConfig struct {
+	Auth          string `json:"auth,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty"`
+}
+
+// SignCosign signs an image with the requested registry credentials and transport.
+func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string, insecure bool, credentials string) (retErr error) {
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
@@ -42,6 +59,13 @@ func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef st
 
 	cosignCmd := newCosignCommand(ctx, cosignExecutable, "sign", insecure)
 	cosignCmd.Env = os.Environ()
+	cleanup, err := configureCosignCredentials(cosignCmd, imageRef, credentials)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		retErr = errors.Join(retErr, cleanup())
+	}()
 
 	// if key is empty, use keyless mode
 	if keyRef != "" {
@@ -64,7 +88,7 @@ func SignCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef st
 // regular-expression alternatives.
 func VerifyCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef string,
 	certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string,
-	insecure bool) error {
+	insecure bool, credentials string) (retErr error) {
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
 		return fmt.Errorf("executing cosign failed: %w", err)
@@ -72,6 +96,13 @@ func VerifyCosign(ctx context.Context, log logr.Logger, imageRef string, keyRef 
 
 	cosignCmd := newCosignCommand(ctx, cosignExecutable, "verify", insecure)
 	cosignCmd.Env = os.Environ()
+	cleanup, err := configureCosignCredentials(cosignCmd, imageRef, credentials)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		retErr = errors.Join(retErr, cleanup())
+	}()
 
 	// if key is empty, use keyless mode
 	if keyRef != "" {
@@ -114,6 +145,70 @@ func newCosignCommand(ctx context.Context, executable string, operation string, 
 		args = append(args, "--allow-http-registry", "--allow-insecure-registry")
 	}
 	return exec.CommandContext(ctx, executable, args...)
+}
+
+// configureCosignCredentials gives a Cosign subprocess an isolated Docker
+// config and returns a function that removes it.
+func configureCosignCredentials(cosignCmd *exec.Cmd, imageRef string, credentials string) (func() error, error) {
+	cleanup := func() error { return nil }
+	if credentials == "" {
+		return cleanup, nil
+	}
+
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return cleanup, fmt.Errorf("parsing artifact reference failed: %w", err)
+	}
+	authKey := ref.Context().RegistryStr()
+	if authKey == name.DefaultRegistry {
+		authKey = authn.DefaultAuthKey
+	}
+
+	authConfig := dockerAuthConfig{}
+	parts := strings.SplitN(credentials, ":", 2)
+	if len(parts) == 1 {
+		authConfig.RegistryToken = parts[0]
+	} else {
+		authConfig.Auth = base64.StdEncoding.EncodeToString([]byte(credentials))
+	}
+	configData, err := json.Marshal(dockerConfig{Auths: map[string]dockerAuthConfig{authKey: authConfig}})
+	if err != nil {
+		return cleanup, fmt.Errorf("encoding Cosign registry credentials failed: %w", err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "timoni-cosign-")
+	if err != nil {
+		return cleanup, fmt.Errorf("creating Cosign registry config failed: %w", err)
+	}
+	cleanup = func() error { return os.RemoveAll(tempDir) }
+	dockerConfigDir := filepath.Join(tempDir, ".docker")
+	if err := os.Mkdir(dockerConfigDir, 0o700); err != nil {
+		return cleanup, errors.Join(fmt.Errorf("creating Cosign registry config failed: %w", err), cleanup())
+	}
+	if err := os.WriteFile(filepath.Join(dockerConfigDir, "config.json"), configData, 0o600); err != nil {
+		return cleanup, errors.Join(fmt.Errorf("writing Cosign registry config failed: %w", err), cleanup())
+	}
+
+	cosignCmd.Env = replaceCommandEnv(cosignCmd.Env, "DOCKER_CONFIG", dockerConfigDir)
+	cosignCmd.Env = removeCommandEnv(cosignCmd.Env, "DOCKER_AUTH_CONFIG")
+	return cleanup, nil
+}
+
+// replaceCommandEnv replaces one variable in a subprocess environment.
+func replaceCommandEnv(env []string, key string, value string) []string {
+	return append(removeCommandEnv(env, key), key+"="+value)
+}
+
+// removeCommandEnv removes one variable from a subprocess environment.
+func removeCommandEnv(env []string, key string) []string {
+	result := make([]string, 0, len(env))
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		if !strings.EqualFold(name, key) {
+			result = append(result, entry)
+		}
+	}
+	return result
 }
 
 // processCosignIO runs cosign and logs its output while draining both streams.

--- a/internal/oci/sign_cosign_test.go
+++ b/internal/oci/sign_cosign_test.go
@@ -18,9 +18,13 @@ package oci
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +57,103 @@ func TestNewCosignCommandRegistryFlags(t *testing.T) {
 			}))
 		})
 	}
+}
+
+func TestConfigureCosignCredentials(t *testing.T) {
+	for name, tt := range map[string]struct {
+		credentials string
+		imageRef    string
+		authKey     string
+		expected    dockerAuthConfig
+	}{
+		"username and password": {
+			credentials: "timoni:secret",
+			imageRef:    "registry.example.com/org/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			authKey:     "registry.example.com",
+			expected: dockerAuthConfig{
+				Auth: base64.StdEncoding.EncodeToString([]byte("timoni:secret")),
+			},
+		},
+		"registry token": {
+			credentials: "secret-token",
+			imageRef:    "registry.example.com/org/app:1.0.0",
+			authKey:     "registry.example.com",
+			expected: dockerAuthConfig{
+				RegistryToken: "secret-token",
+			},
+		},
+		"Docker Hub": {
+			credentials: "timoni:secret",
+			imageRef:    "docker.io/org/app:1.0.0",
+			authKey:     "https://index.docker.io/v1/",
+			expected: dockerAuthConfig{
+				Auth: base64.StdEncoding.EncodeToString([]byte("timoni:secret")),
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			sourceConfigDir := t.TempDir()
+			existingConfig := `{"auths":{"registry.example.com":{"auth":"stale"}},"credsStore":"desktop","credHelpers":{"registry.example.com":"helper"}}`
+			g.Expect(os.WriteFile(filepath.Join(sourceConfigDir, "config.json"), []byte(existingConfig), 0o600)).To(Succeed())
+			cmd := exec.Command("cosign", "sign")
+			cmd.Env = append(os.Environ(), "HOME=/original/home", "DOCKER_CONFIG="+sourceConfigDir, `docker_auth_config={"auths":{}}`)
+
+			cleanup, err := configureCosignCredentials(cmd, tt.imageRef, tt.credentials)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer cleanup()
+
+			dockerConfigDir := commandEnv(cmd, "DOCKER_CONFIG")
+			g.Expect(commandEnv(cmd, "HOME")).To(Equal("/original/home"))
+			g.Expect(dockerConfigDir).NotTo(Equal(sourceConfigDir))
+			g.Expect(commandEnv(cmd, "DOCKER_AUTH_CONFIG")).To(BeEmpty())
+			g.Expect(strings.Join(cmd.Args, " ")).NotTo(ContainSubstring("secret"))
+
+			configPath := filepath.Join(dockerConfigDir, "config.json")
+			configData, err := os.ReadFile(configPath)
+			g.Expect(err).NotTo(HaveOccurred())
+			var config dockerConfig
+			g.Expect(json.Unmarshal(configData, &config)).To(Succeed())
+			var rawConfig map[string]json.RawMessage
+			g.Expect(json.Unmarshal(configData, &rawConfig)).To(Succeed())
+			g.Expect(rawConfig).To(HaveLen(1))
+			g.Expect(config.Auths).To(Equal(map[string]dockerAuthConfig{
+				tt.authKey: tt.expected,
+			}))
+
+			if runtime.GOOS != "windows" {
+				info, err := os.Stat(configPath)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+			}
+
+			g.Expect(cleanup()).To(Succeed())
+			_, err = os.Stat(filepath.Dir(dockerConfigDir))
+			g.Expect(err).To(MatchError(os.ErrNotExist))
+		})
+	}
+}
+
+func TestConfigureCosignCredentialsSkipsEmptyCredentials(t *testing.T) {
+	g := NewWithT(t)
+	cmd := exec.Command("cosign", "verify")
+	cmd.Env = os.Environ()
+
+	cleanup, err := configureCosignCredentials(cmd, "registry.example.com/org/app:1.0.0", "")
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cleanup()).To(Succeed())
+	g.Expect(commandEnv(cmd, "HOME")).To(Equal(os.Getenv("HOME")))
+}
+
+func commandEnv(cmd *exec.Cmd, key string) string {
+	for i := len(cmd.Env) - 1; i >= 0; i-- {
+		name, value, _ := strings.Cut(cmd.Env[i], "=")
+		if strings.EqualFold(name, key) {
+			return value
+		}
+	}
+	return ""
 }
 
 func TestProcessCosignIODrainsOutputConcurrently(t *testing.T) {


### PR DESCRIPTION
## What

Forward explicit registry credentials to Cosign through an isolated temporary Docker config. Remove it after signing or verification without placing credentials in Cosign's arguments.

## Why

`--creds` authenticated Timoni's push or pull, but Cosign could still fail against the same private registry.

## Reproduction

```shell
export COSIGN_PASSWORD="$KEY_PASSWORD"
mod push ./module oci://registry.example.com/modules/app -v 1.0.0 --creds "$REGISTRY_USER:$REGISTRY_PASSWORD" --sign cosign --cosign-key cosign.key
# main: Cosign reports an authorization error after Timoni pushes the module.
# here: Timoni and Cosign use the same registry credentials.
```

## Verification

```shell
go test ./internal/oci -run 'TestConfigureCosignCredentials' -count=1
```

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>