### PR TITLE
docs: Add guide for embedding files in modules

### DIFF
--- a/docs/cue/module/embedding-files.md
+++ b/docs/cue/module/embedding-files.md
@@ -1,0 +1,167 @@
+# Embedding files
+
+Timoni modules can embed plain files (configs, scripts, dashboards, web assets)
+using the CUE [`@embed()` attribute](https://cuelang.org/docs/howto/embed-files-in-cue-evaluation/).
+At build time, the file contents are loaded into CUE values that templates can use
+like any other value, for example to populate the data of a Kubernetes ConfigMap or Secret.
+
+Embedding is the type-safe alternative to inlining file contents as CUE strings:
+the files keep their native extension, so they can be edited, linted and highlighted
+with the standard tooling for their format, while the module retains full control
+over how their contents end up in the generated Kubernetes objects.
+
+## Embedding text files
+
+Assuming you want to ship an `nginx` configuration and a static HTML page with your module,
+stored as plain files in the module's `templates` directory:
+
+```text
+templates/
+├── config.cue
+├── configmap.cue
+├── nginx.default.conf
+└── index.html
+```
+
+In the `templates/configmap.cue` file, enable embedding with the file-level
+`@extern(embed)` attribute, then embed the sibling files with `@embed()`:
+
+```cue
+@extern(embed)
+
+package templates
+
+import (
+	timoniv1 "timoni.sh/core/v1alpha1"
+)
+
+_nginxConf: string @embed(file="nginx.default.conf", type=text)
+_indexHTML: string @embed(file="index.html", type=text)
+
+#ConfigMap: timoniv1.#ImmutableConfig & {
+	#config: #Config
+	#Kind:   timoniv1.#ConfigMapKind
+	#Meta:   #config.metadata
+	#Data: {
+		"nginx.default.conf": _nginxConf
+		"index.html":         _indexHTML
+	}
+}
+```
+
+The file path is relative to the directory of the CUE file containing the attribute.
+The `type=text` argument tells CUE to load the file contents as a string; it is required
+for file extensions CUE does not recognise, such as `.conf` and `.html`.
+
+Combined with the [`#ImmutableConfig` generator](immutable-config.md), any change to the
+embedded files results in a ConfigMap with a new name suffix, which triggers a rolling
+update of the workloads referencing it.
+
+## Templating the file contents
+
+Embedded files are static, but their contents can be rendered with the instance
+configuration using the CUE `text/template` package, which implements Go templating:
+
+```cue
+@extern(embed)
+
+package templates
+
+import (
+	"text/template"
+
+	timoniv1 "timoni.sh/core/v1alpha1"
+)
+
+_nginxConf: string @embed(file="nginx.default.conf", type=text)
+
+#ConfigMap: timoniv1.#ImmutableConfig & {
+	#config: #Config
+	#Kind:   timoniv1.#ConfigMapKind
+	#Meta:   #config.metadata
+	#Data: {
+		"nginx.default.conf": template.Execute(_nginxConf, #config)
+	}
+}
+```
+
+With the `templates/nginx.default.conf` file referencing the config values
+using Go template expressions:
+
+```nginx
+server {
+	listen       8080;
+	server_name  {{ .metadata.name }};
+}
+```
+
+For a complete example, see the
+[minimal module](https://github.com/stefanprodan/timoni/tree/main/examples/minimal)
+which embeds and templates its `nginx` configuration and HTML index page.
+
+## Embedding structured data
+
+When embedding `.json`, `.yaml` or `.toml` files without the `type` argument,
+CUE parses the file contents into a structured value instead of a string.
+The parsed value can be validated against a CUE schema and further transformed
+at build time:
+
+```cue
+@extern(embed)
+
+package templates
+
+import "encoding/json"
+
+// Validate the embedded dashboard against a schema.
+_dashboard: #GrafanaDashboard @embed(file="dashboard.json")
+
+#DashboardConfigMap: {
+	apiVersion: "v1"
+	kind:       "ConfigMap"
+	// omitted for brevity
+	data: "dashboard.json": json.Marshal(_dashboard)
+}
+```
+
+This goes beyond verbatim file inclusion: invalid files fail the build with a
+validation error instead of being applied to the cluster as-is.
+
+## Embedding multiple files
+
+A glob pattern embeds a set of files as a struct, keyed by the file path
+relative to the CUE file:
+
+```cue
+@extern(embed)
+
+package templates
+
+import "path"
+
+_dashboards: _ @embed(glob="dashboards/*.json", type=text)
+
+#DashboardConfigMap: {
+	apiVersion: "v1"
+	kind:       "ConfigMap"
+	// omitted for brevity
+	data: {for p, content in _dashboards {(path.Base(p)): content}}
+}
+```
+
+Note that the struct keys contain the directory prefix, e.g. `dashboards/latency.json`.
+Since Kubernetes does not allow `/` in ConfigMap keys, the comprehension above
+uses `path.Base` to strip the directory from the keys.
+
+## Restrictions
+
+CUE enforces the following rules for embedded files:
+
+- Files must be located inside the module's root directory, referencing files
+  outside the module with `../` or absolute paths is not allowed.
+- Hidden files (dot files) and files under `cue.mod` cannot be embedded,
+  nor matched by glob patterns.
+
+When using a `timoni.ignore` file, make sure its patterns do not exclude
+embedded files, otherwise `timoni mod push` would strip them from the
+module's OCI artifact and the build would fail on the consumer's side.

--- a/examples/minimal/templates/configmap.cue
+++ b/examples/minimal/templates/configmap.cue
@@ -1,55 +1,24 @@
+@extern(embed)
+
 package templates
 
 import (
+	"text/template"
+
 	timoniv1 "timoni.sh/core/v1alpha1"
 )
+
+// The config files are embedded from the sibling files at build time
+// and rendered with the instance config using Go text templating.
+_nginxConf: string @embed(file="nginx.default.conf", type=text)
+_indexHTML: string @embed(file="index.html", type=text)
 
 #ConfigMap: timoniv1.#ImmutableConfig & {
 	#config: #Config
 	#Kind:   timoniv1.#ConfigMapKind
 	#Meta:   #config.metadata
 	#Data: {
-		"nginx.default.conf": """
-			server {
-				listen       8080;
-				server_name  \(#config.metadata.name);
-
-				location / {
-			  	root   /usr/share/nginx/html;
-			  	index  index.html index.htm;
-				}
-
-				location /healthz {
-					access_log off;
-					default_type text/plain;
-					return 200 "OK";
-				}
-
-				error_page  404              /404.html;
-			  error_page  500 502 503 504  /50x.html;
-			  location = /50x.html {
-			    root   /usr/share/nginx/html;
-			  }
-			}
-			"""
-		"index.html":         """
-			<!doctype html>
-			<html lang="en">
-			<head>
-			 	<meta charset="utf-8">
-			 	<meta http-equiv="refresh" content="10" />
-				<title>\(#config.metadata.name)</title>
-				<style>
-				html { color-scheme: light dark; }
-				body { width: 35em; margin: 0 auto;
-				font-family: Tahoma, Verdana, Arial, sans-serif; }
-				</style>
-			</head>
-			<body>
-				<h1> \(#config.message) from \(#config.metadata.name)!</h1>
-				<p>If you see this page, the <b>\(#config.metadata.name)</b> instance is successfully deployed in the <b>\(#config.metadata.namespace)</b> namespace by Timoni.</p>
-			</body>
-			</html>
-			"""
+		"nginx.default.conf": template.Execute(_nginxConf, #config)
+		"index.html":         template.Execute(_indexHTML, #config)
 	}
 }

--- a/examples/minimal/templates/index.html
+++ b/examples/minimal/templates/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="refresh" content="10" />
+	<title>{{ .metadata.name }}</title>
+	<style>
+	html { color-scheme: light dark; }
+	body { width: 35em; margin: 0 auto;
+	font-family: Tahoma, Verdana, Arial, sans-serif; }
+	</style>
+</head>
+<body>
+	<h1> {{ .message }} from {{ .metadata.name }}!</h1>
+	<p>If you see this page, the <b>{{ .metadata.name }}</b> instance is successfully deployed in the <b>{{ .metadata.namespace }}</b> namespace by Timoni.</p>
+</body>
+</html>

--- a/examples/minimal/templates/nginx.default.conf
+++ b/examples/minimal/templates/nginx.default.conf
@@ -1,0 +1,21 @@
+server {
+	listen       8080;
+	server_name  {{ .metadata.name }};
+
+	location / {
+		root   /usr/share/nginx/html;
+		index  index.html index.htm;
+	}
+
+	location /healthz {
+		access_log off;
+		default_type text/plain;
+		return 200 "OK";
+	}
+
+	error_page  404              /404.html;
+	error_page  500 502 503 504  /50x.html;
+	location = /50x.html {
+		root   /usr/share/nginx/html;
+	}
+}

--- a/examples/redis/templates/instance.cue
+++ b/examples/redis/templates/instance.cue
@@ -9,20 +9,31 @@ import (
 #Instance: {
 	config: c.#Config
 
+	// The immutable ConfigMap is shared by the master and replica deployments.
+	// Its generated name is passed to the deployments so that a config change
+	// triggers a rolling update.
+	_cm: m.#ConfigMap & {#config: config}
+
 	master: objects: {
 		"\(config.metadata.name)-sa": m.#ServiceAccount & {#config: config}
-		"\(config.metadata.name)-cm": m.#ConfigMap & {#config: config}
+		"\(config.metadata.name)-cm": _cm
 
 		if config.persistence.enabled {
 			"\(config.metadata.name)-pvc": m.#MasterPVC & {#config: config}
 		}
 
 		"\(config.metadata.name)-svc": m.#MasterService & {#config: config}
-		"\(config.metadata.name)-deploy": m.#MasterDeployment & {#config: config}
+		"\(config.metadata.name)-deploy": m.#MasterDeployment & {
+			#config: config
+			#cmName: _cm.metadata.name
+		}
 	}
 
 	replica: objects: {
-		"\(config.metadata.name)-deploy-replica": r.#ReplicaDeployment & {#config: config}
+		"\(config.metadata.name)-deploy-replica": r.#ReplicaDeployment & {
+			#config: config
+			#cmName: _cm.metadata.name
+		}
 		"\(config.metadata.name)-svc-replica": r.#ReplicaService & {#config: config}
 	}
 

--- a/examples/redis/templates/master/configmap.cue
+++ b/examples/redis/templates/master/configmap.cue
@@ -1,26 +1,21 @@
+@extern(embed)
+
 package master
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"text/template"
+
+	timoniv1 "timoni.sh/core/v1alpha1"
 	"timoni.sh/redis/templates/config"
 )
 
-#ConfigMap: corev1.#ConfigMap & {
-	#config:    config.#Config
-	apiVersion: "v1"
-	kind:       "ConfigMap"
-	metadata:   #config.metadata
-	data:
-		"redis.conf": """
-			maxmemory \(#config.maxmemory)mb
-			maxmemory-policy allkeys-lru
+// The Redis configuration is embedded from the sibling redis.conf file
+// at build time and rendered with the instance config.
+_redisConf: string @embed(file="redis.conf", type=text)
 
-			dir /data
-			save \"\"
-			appendonly yes
-
-			protected-mode no
-			rename-command CONFIG \"\"
-
-			"""
+#ConfigMap: timoniv1.#ImmutableConfig & {
+	#config: config.#Config
+	#Kind:   timoniv1.#ConfigMapKind
+	#Meta:   #config.metadata
+	#Data: "redis.conf": template.Execute(_redisConf, #config)
 }

--- a/examples/redis/templates/master/deployment.cue
+++ b/examples/redis/templates/master/deployment.cue
@@ -9,6 +9,7 @@ import (
 
 #MasterDeployment: appsv1.#Deployment & {
 	#config: config.#Config
+	#cmName: string
 	_selectorLabel: {
 		(timoniv1.#StdLabelName): "\(#config.metadata.name)-master"
 	}
@@ -88,7 +89,7 @@ import (
 					{
 						name: "config"
 						configMap: {
-							name: "\(#config.metadata.name)"
+							name: #cmName
 							items: [{
 								key:  "redis.conf"
 								path: key

--- a/examples/redis/templates/master/redis.conf
+++ b/examples/redis/templates/master/redis.conf
@@ -1,0 +1,9 @@
+maxmemory {{ .maxmemory }}mb
+maxmemory-policy allkeys-lru
+
+dir /data
+save ""
+appendonly yes
+
+protected-mode no
+rename-command CONFIG ""

--- a/examples/redis/templates/replica/deployment.cue
+++ b/examples/redis/templates/replica/deployment.cue
@@ -9,6 +9,7 @@ import (
 
 #ReplicaDeployment: appsv1.#Deployment & {
 	#config: config.#Config
+	#cmName: string
 	_selectorLabel: {
 		(timoniv1.#StdLabelName): "\(#config.metadata.name)-replica"
 	}
@@ -91,7 +92,7 @@ import (
 					{
 						name: "config"
 						configMap: {
-							name: "\(#config.metadata.name)"
+							name: #cmName
 							items: [{
 								key:  "redis.conf"
 								path: key

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - Module Development:
           - Get started with modules: cue/module/initialization.md
           - Immutable ConfigMaps and Secrets: cue/module/immutable-config.md
+          - Embedding files: cue/module/embedding-files.md
           - Add custom resources: cue/module/custom-resources.md
           - Cluster version constraints: cue/module/semver-constraints.md
           - Control the apply behavior: cue/module/apply-behavior.md


### PR DESCRIPTION
Add a guide to module devel section on how to use the CUE `@embed()` attribute to embed plain files (configs, scripts, dashboards, web assets) in the generated Kubernetes objects.

This PR also updates the example modules to showcase how redis & nginx configs and HTLM files can be templated and embedded in immutable ConfigMaps.