### PR TITLE
fix(engine): Validate runtime values before injecting them into CUE

### DIFF
--- a/docs/bundle-runtime.md
+++ b/docs/bundle-runtime.md
@@ -359,6 +359,12 @@ At apply time, Timoni injects the fields values from the runtime,
 if a specified runtime var is not found and if a default is not provided,
 the apply with fail with an `incomplete value` error.
 
+Runtime values are validated against the type declared in the attribute before
+they are injected. A `number` value must be a CUE number literal, and a `bool`
+value must be `true` or `false`; anything else fails the apply with a
+`failed to parse attribute` error. A `string` value is quoted, so it may hold
+arbitrary text including newlines.
+
 ## Using values from environment variables
 
 To use values from environment variables,

--- a/internal/engine/runtime_injector.go
+++ b/internal/engine/runtime_injector.go
@@ -102,18 +102,15 @@ func (in *RuntimeInjector) inject(node ast.Node, vars map[string]string) (ast.No
 			ra, _ := apiv1.NewRuntimeAttribute(key, body)
 
 			if envVal, ok := vars[ra.Name]; ok {
-				switch ra.Type {
-				case "string":
-					field.Value = ast.NewLit(token.STRING, in.quoteString(envVal))
-				case "number":
-					field.Value = ast.NewLit(token.INT, envVal)
-				case "bool":
-					field.Value = ast.NewIdent(envVal)
-				default:
-					err = fmt.Errorf("failed to parse attribute '@%s(%s)', unknown type '%s' must be string, number or bool",
-						apiv1.FieldManager, body, ra.Type)
+				var value ast.Expr
+				value, err = in.valueExpr(ra.Type, envVal)
+				if err != nil {
+					err = fmt.Errorf("failed to parse attribute '@%s(%s)': %w",
+						apiv1.FieldManager, body, err)
 					return false
 				}
+
+				field.Value = value
 				c.Replace(field)
 			}
 		}
@@ -121,6 +118,39 @@ func (in *RuntimeInjector) inject(node ast.Node, vars map[string]string) (ast.No
 	}
 
 	return astutil.Apply(node, f, nil), err
+}
+
+// valueExpr converts a runtime value to the CUE expression matching the
+// attribute type. Number and bool values must be validated: unlike strings
+// they are emitted unquoted, so an unchecked value is read back as CUE source
+// instead of as data.
+func (in *RuntimeInjector) valueExpr(valType, val string) (ast.Expr, error) {
+	switch valType {
+	case "string":
+		return ast.NewLit(token.STRING, in.quoteString(val)), nil
+	case "number":
+		// ParseNum accepts exactly what CUE accepts as a number literal,
+		// including signs, multipliers and non-decimal bases. Its error
+		// quotes the value, so it is discarded rather than wrapped: runtime
+		// values may hold secrets and must not reach the logs.
+		var num literal.NumInfo
+		if err := literal.ParseNum(val, &num); err != nil {
+			return nil, fmt.Errorf("value must be a number")
+		}
+
+		tok := token.FLOAT
+		if num.IsInt() {
+			tok = token.INT
+		}
+		return ast.NewLit(tok, val), nil
+	case "bool":
+		if val != "true" && val != "false" {
+			return nil, fmt.Errorf("value must be 'true' or 'false'")
+		}
+		return ast.NewBool(val == "true"), nil
+	default:
+		return nil, fmt.Errorf("unknown type '%s' must be string, number or bool", valType)
+	}
 }
 
 func (in *RuntimeInjector) quoteString(s string) string {

--- a/internal/engine/runtime_injector_test.go
+++ b/internal/engine/runtime_injector_test.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"testing"
 
+	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/parser"
 	. "github.com/onsi/gomega"
@@ -89,6 +90,118 @@ secrets: {
 	result, err := vb.Inject(f, GetEnv())
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(string(result)).To(BeIdenticalTo(output))
+}
+
+func TestInjector_InvalidValues(t *testing.T) {
+	input := `package test
+
+secrets: {
+	age:     int  @timoni(runtime:number:AGE)
+	isAdmin: bool @timoni(runtime:bool:IS_ADMIN)
+}
+`
+
+	tests := []struct {
+		name string
+		vars map[string]string
+		err  string
+	}{
+		{
+			name: "number with newline",
+			vars: map[string]string{"AGE": "41\nfoo: 1"},
+			err:  "value must be a number",
+		},
+		{
+			name: "number with braces",
+			vars: map[string]string{"AGE": "41}\nfoo: {"},
+			err:  "value must be a number",
+		},
+		{
+			name: "number with expression",
+			vars: map[string]string{"AGE": "41 + 1"},
+			err:  "value must be a number",
+		},
+		{
+			name: "number with comment",
+			vars: map[string]string{"AGE": "41 // comment"},
+			err:  "value must be a number",
+		},
+		{
+			name: "number empty",
+			vars: map[string]string{"AGE": ""},
+			err:  "value must be a number",
+		},
+		{
+			name: "bool with newline",
+			vars: map[string]string{"IS_ADMIN": "true\nfoo: 1"},
+			err:  "value must be 'true' or 'false'",
+		},
+		{
+			name: "bool with braces",
+			vars: map[string]string{"IS_ADMIN": "true}\nfoo: {"},
+			err:  "value must be 'true' or 'false'",
+		},
+		{
+			name: "bool with reference",
+			vars: map[string]string{"IS_ADMIN": "someIdent"},
+			err:  "value must be 'true' or 'false'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := cuecontext.New()
+
+			f, err := parser.ParseFile("", []byte(input), parser.ParseComments)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			result, err := NewRuntimeInjector(ctx).Inject(f, tt.vars)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tt.err))
+			g.Expect(err.Error()).To(ContainSubstring("failed to parse attribute '@timoni("))
+			g.Expect(result).To(BeNil())
+		})
+	}
+}
+
+func TestInjector_NumberFormats(t *testing.T) {
+	input := `package test
+
+values: n: number @timoni(runtime:number:N)
+`
+
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{value: "41", want: "41"},
+		{value: "-41", want: "-41"},
+		{value: "4.1", want: "4.1"},
+		{value: "-4.1e-2", want: "-4.1e-2"},
+		{value: "0x1f", want: "0x1f"},
+		{value: "1_000", want: "1_000"},
+		{value: "2Mi", want: "2Mi"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := cuecontext.New()
+
+			f, err := parser.ParseFile("", []byte(input), parser.ParseComments)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			result, err := NewRuntimeInjector(ctx).Inject(f, map[string]string{"N": tt.value})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(string(result)).To(ContainSubstring("n: " + tt.want + " @timoni("))
+
+			// The injected value must round-trip as a CUE number.
+			v := ctx.CompileBytes(result).LookupPath(cue.ParsePath("values.n"))
+			g.Expect(v.Err()).ToNot(HaveOccurred())
+			g.Expect(v.Kind()).To(BeElementOf(cue.IntKind, cue.FloatKind))
+		})
+	}
 }
 
 func TestInjector_Operand(t *testing.T) {


### PR DESCRIPTION
Number values are now checked with `literal.ParseNum`, which accepts exactly what CUE accepts as a number literal, and bool values must be `true` or `false`.