### PR TITLE
fix(oci): Bind module digest to manifest

### DIFF
--- a/cmd/timoni/artifact_pull.go
+++ b/cmd/timoni/artifact_pull.go
@@ -127,8 +127,18 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid output path %s: %w", pullArtifactArgs.output, err)
 	}
 
+	opts := oci.Options(ctx, pullArtifactArgs.creds.String(), rootArgs.registryInsecure)
+
 	if pullArtifactArgs.verify != "" {
-		err := oci.VerifyArtifact(ctx, log,
+		// Resolve the reference to a digest and verify and pull that, so the
+		// signature that is checked covers the artifact that is extracted.
+		digestURL, err := oci.ResolveDigestURL(ociURL, opts)
+		if err != nil {
+			return err
+		}
+		ociURL = digestURL
+
+		err = oci.VerifyArtifact(ctx, log,
 			pullArtifactArgs.verify,
 			ociURL,
 			pullArtifactArgs.cosignKey,
@@ -146,7 +156,6 @@ func pullArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	spin := logger.StartSpinner("pulling artifact")
 	defer spin.Stop()
 
-	opts := oci.Options(ctx, pullArtifactArgs.creds.String(), rootArgs.registryInsecure)
 	err := oci.PullArtifact(ociURL, pullArtifactArgs.output, pullArtifactArgs.contentType, opts)
 	if err != nil {
 		return err

--- a/cmd/timoni/mod_pull.go
+++ b/cmd/timoni/mod_pull.go
@@ -139,8 +139,18 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
+	opts := oci.Options(ctx, pullModArgs.creds.String(), rootArgs.registryInsecure)
+
 	if pullModArgs.verify != "" {
-		err := oci.VerifyArtifact(ctx, log,
+		// Resolve the version to a digest and verify and pull that, so the
+		// signature that is checked covers the module that is extracted.
+		digestURL, err := oci.ResolveDigestURL(ociURL, opts)
+		if err != nil {
+			return err
+		}
+		ociURL = digestURL
+
+		err = oci.VerifyArtifact(ctx, log,
 			pullModArgs.verify,
 			ociURL,
 			pullModArgs.cosignKey,
@@ -156,7 +166,6 @@ func pullCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	spin := logger.StartSpinner(fmt.Sprintf("pulling %s", ociURL))
-	opts := oci.Options(ctx, pullModArgs.creds.String(), rootArgs.registryInsecure)
 	err := oci.PullArtifact(ociURL, pullModArgs.output, apiv1.AnyContentType, opts)
 	spin.Stop()
 	if err != nil {

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -290,7 +290,9 @@ module: {
 ```
 
 When both the version number and the digest are specified, Timoni will verify that the
-upstream digest of the version matches the specified `instance.module.digest`.
+digest of the pulled module matches the specified `instance.module.digest`.
+The digest is computed from the artifact manifest that Timoni pulled, so the check fails
+if the registry serves any content other than the pinned one for that version.
 
 ```cue
 module: {

--- a/internal/oci/pull_module.go
+++ b/internal/oci/pull_module.go
@@ -31,8 +31,8 @@ import (
 )
 
 // PullModule performs the following operations:
-// - determines the artifact digest corresponding to the module version
 // - fetches the manifest of the remote artifact
+// - computes the artifact digest from the fetched manifest
 // - verifies that artifact config matches Timoni's media type
 // - downloads all compressed layers matching Timoni's media type (if not cached)
 // - atomically stores the compressed layers in the local cache (if caching is enabled)
@@ -45,15 +45,20 @@ func PullModule(ociURL, dstPath, cacheDir string, opts []crane.Option) (*apiv1.M
 
 	repoURL := ref.Context().Name()
 
-	digest, err := crane.Digest(ref.String(), opts...)
-	if err != nil {
-		return nil, fmt.Errorf("resolving digest of '%s' failed: %w", ociURL, err)
-	}
-
 	manifestJSON, err := crane.Manifest(ref.String(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("pulling artifact manifest failed: %w", err)
 	}
+
+	// The digest has to be the hash of the manifest parsed below, since callers
+	// verify pinned modules against it. Resolving it with a separate request
+	// would describe whatever the tag pointed to at that moment, which is not
+	// necessarily what this pull extracted.
+	hash, _, err := gcrv1.SHA256(bytes.NewReader(manifestJSON))
+	if err != nil {
+		return nil, fmt.Errorf("computing digest of '%s' failed: %w", ociURL, err)
+	}
+	digest := hash.String()
 
 	manifest, err := gcrv1.ParseManifest(bytes.NewReader(manifestJSON))
 	if err != nil {

--- a/internal/oci/pull_module_test.go
+++ b/internal/oci/pull_module_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+// TestPullModule_DigestMatchesRegistry verifies that the digest reported for a
+// module is the one the registry reports for the same reference, which is what
+// users pin after looking it up with tools such as the crane CLI.
+func TestPullModule_DigestMatchesRegistry(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	opts := Options(ctx, "", false)
+
+	imgURL := fmt.Sprintf("oci://%s/%s", dockerRegistry, rnd("my-module", 5))
+	annotations := map[string]string{apiv1.VersionAnnotation: "1.0.0"}
+	_, err := PushModule(imgURL+":1.0.0", "testdata/module/", nil, annotations, opts)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	tagRef := strings.TrimPrefix(imgURL, apiv1.ArtifactPrefix) + ":1.0.0"
+	registryDigest, err := crane.Digest(tagRef, opts...)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	modRef, err := PullModule(imgURL+":1.0.0", filepath.Join(t.TempDir(), "module"), "", opts)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(modRef.Digest).To(Equal(registryDigest))
+}
+
+// TestPullModule_DigestFromManifest verifies that the digest reported for a
+// module is the digest of the manifest that was pulled, and not a value the
+// registry reported for the tag. Callers compare it against the digest pinned
+// by the user, so a registry that reports one digest while serving another
+// manifest must not satisfy the pin.
+func TestPullModule_DigestFromManifest(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	opts := Options(ctx, "", false)
+
+	// Publish a module and record the digest it was published under.
+	imgURL := fmt.Sprintf("oci://%s/%s", dockerRegistry, rnd("my-module", 5))
+	annotations := map[string]string{apiv1.VersionAnnotation: "1.0.0"}
+	digestURL, err := PushModule(imgURL+":1.0.0", "testdata/module/", nil, annotations, opts)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, publishedDigest, found := strings.Cut(digestURL, "@")
+	g.Expect(found).To(BeTrue())
+
+	// A registry that reports a digest of its choosing for the tag, while
+	// serving the real manifest for the same tag.
+	const reportedDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	upstream, err := url.Parse("http://" + dockerRegistry)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	proxy := httputil.NewSingleHostReverseProxy(upstream)
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if strings.Contains(resp.Request.URL.Path, "/manifests/") &&
+			resp.Header.Get("Docker-Content-Digest") != "" {
+			resp.Header.Set("Docker-Content-Digest", reportedDigest)
+		}
+		return nil
+	}
+	server := httptest.NewServer(proxy)
+	defer server.Close()
+
+	proxyHost := strings.TrimPrefix(server.URL, "http://")
+	proxyURL := strings.Replace(imgURL, dockerRegistry, proxyHost, 1)
+
+	modRef, err := PullModule(proxyURL+":1.0.0", filepath.Join(t.TempDir(), "module"), "", opts)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// The digest identifies the manifest that was pulled, so a pin against the
+	// value the registry reported does not match.
+	g.Expect(modRef.Digest).To(Equal(publishedDigest))
+	g.Expect(modRef.Digest).ToNot(Equal(reportedDigest))
+}

--- a/internal/oci/url.go
+++ b/internal/oci/url.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
@@ -57,6 +58,31 @@ func ParseDigest(ociURL string) (name.Digest, error) {
 	}
 
 	return name.NewDigest(ref.String())
+}
+
+// ResolveDigestURL resolves an OpenContainers URL to its immutable digest form.
+// A URL that already refers to a digest is returned unchanged.
+//
+// Callers that both verify and fetch an artifact resolve the reference once
+// with this function and use the result for every operation, so that a tag
+// pointing somewhere else on a later request cannot substitute the artifact
+// between the verification and the fetch.
+func ResolveDigestURL(ociURL string, opts []crane.Option) (string, error) {
+	ref, err := parseArtifactRef(ociURL)
+	if err != nil {
+		return "", err
+	}
+
+	if _, ok := ref.(name.Digest); ok {
+		return ociURL, nil
+	}
+
+	digest, err := crane.Digest(ref.String(), opts...)
+	if err != nil {
+		return "", fmt.Errorf("resolving digest of '%s' failed: %w", ociURL, err)
+	}
+
+	return apiv1.ArtifactPrefix + ref.Context().Digest(digest).String(), nil
 }
 
 // ValidateTag reports whether tag follows the OCI Distribution tag grammar.

--- a/internal/oci/url_test.go
+++ b/internal/oci/url_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package oci
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
 func TestValidateTag(t *testing.T) {
@@ -34,6 +37,32 @@ func TestValidateTag(t *testing.T) {
 	for _, tag := range []string{"", ".release", "-release", strings.Repeat("a", 129)} {
 		g.Expect(ValidateTag(tag)).To(MatchError(ContainSubstring("invalid OCI tag")))
 	}
+}
+
+// TestResolveDigestURL verifies that a mutable reference is turned into the
+// immutable digest form that callers use for every subsequent operation.
+func TestResolveDigestURL(t *testing.T) {
+	g := NewWithT(t)
+	opts := Options(context.Background(), "", false)
+
+	imgURL := fmt.Sprintf("oci://%s/%s", dockerRegistry, rnd("my-module", 5))
+	annotations := map[string]string{apiv1.VersionAnnotation: "1.0.0"}
+	digestURL, err := PushModule(imgURL+":1.0.0", "testdata/module/", nil, annotations, opts)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// A tag resolves to the digest it currently points at.
+	resolved, err := ResolveDigestURL(imgURL+":1.0.0", opts)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resolved).To(Equal(digestURL))
+	g.Expect(resolved).To(ContainSubstring("@sha256:"))
+
+	// A digest is already immutable and is left alone.
+	resolved, err = ResolveDigestURL(digestURL, opts)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resolved).To(Equal(digestURL))
+
+	_, err = ResolveDigestURL("not-an-oci-url", opts)
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestParseArtifactURLTags(t *testing.T) {


### PR DESCRIPTION
Compute the module digest from the pulled manifest and use the digest when verifying the signature. 