### PR TITLE
perf(engine): Optimize CUE values to Kubernetes objects conversion

### DIFF
--- a/internal/engine/resourceset.go
+++ b/internal/engine/resourceset.go
@@ -24,6 +24,7 @@ import (
 	"cuelang.org/go/encoding/yaml"
 	ssautil "github.com/fluxcd/pkg/ssa/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // ResourceSet is a named list of Kubernetes resource objects.
@@ -61,12 +62,7 @@ func GetResources(value cue.Value) ([]ResourceSet, error) {
 			return nil, fmt.Errorf("listing objects in resource list %q failed: %w", name, err)
 		}
 
-		data, err := yaml.EncodeStream(items)
-		if err != nil {
-			return nil, fmt.Errorf("converting objects for resource list %q failed: %w", name, err)
-		}
-
-		objects, err := ssautil.ReadObjects(bytes.NewReader(data))
+		objects, err := decodeObjects(items)
 		if err != nil {
 			return nil, fmt.Errorf("loading objects for resource list %q failed: %w", name, err)
 		}
@@ -77,4 +73,85 @@ func GetResources(value cue.Value) ([]ResourceSet, error) {
 		})
 	}
 	return sets, nil
+}
+
+// decodeObjects converts the CUE values in the given iterator to Kubernetes
+// unstructured objects. Values which are not Kubernetes objects are silently
+// dropped from the result, and Kubernetes lists are expanded to their items.
+func decodeObjects(items cue.Iterator) ([]*unstructured.Unstructured, error) {
+	objects := make([]*unstructured.Unstructured, 0)
+
+	for items.Next() {
+		item := items.Value()
+		if item.Kind() == cue.NullKind {
+			continue
+		}
+
+		if needsYAMLDecoding(item) {
+			objs, err := decodeYAMLObjects(item)
+			if err != nil {
+				return nil, err
+			}
+			objects = append(objects, objs...)
+			continue
+		}
+
+		data, err := item.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(data); err != nil {
+			return nil, err
+		}
+
+		if obj.IsList() {
+			err = obj.EachListItem(func(item runtime.Object) error {
+				objects = append(objects, item.(*unstructured.Unstructured))
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if ssautil.IsKubernetesObject(obj) && !ssautil.IsKustomization(obj) {
+			objects = append(objects, obj)
+		}
+	}
+
+	return objects, nil
+}
+
+// needsYAMLDecoding reports whether the value contains fields of a kind
+// (bytes, floats) whose JSON encoding differs from the YAML round-trip:
+// bytes decode from YAML to raw strings instead of base64, and integral
+// floats normalize to integers.
+func needsYAMLDecoding(value cue.Value) bool {
+	var found bool
+	value.Walk(func(v cue.Value) bool {
+		if found {
+			return false
+		}
+		switch v.Kind() {
+		case cue.BytesKind, cue.FloatKind:
+			found = true
+			return false
+		}
+		return true
+	}, nil)
+	return found
+}
+
+// decodeYAMLObjects converts the CUE value to Kubernetes unstructured
+// objects through a YAML round-trip, preserving the YAML decoding of
+// bytes and integral floats.
+func decodeYAMLObjects(value cue.Value) ([]*unstructured.Unstructured, error) {
+	data, err := yaml.Encode(value)
+	if err != nil {
+		return nil, err
+	}
+	return ssautil.ReadObjects(bytes.NewReader(data))
 }

--- a/internal/engine/resourceset_test.go
+++ b/internal/engine/resourceset_test.go
@@ -21,6 +21,7 @@ import (
 
 	"cuelang.org/go/cue/cuecontext"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
@@ -40,4 +41,86 @@ func TestGetResources(t *testing.T) {
 		g.Expect(sets[s].Name).To(BeEquivalentTo(expectedNames[s]))
 		g.Expect(len(set.Objects)).To(BeEquivalentTo(2))
 	}
+}
+
+func TestGetResources_BytesValue(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`app: [{
+		apiVersion: "v1"
+		kind:       "Secret"
+		metadata: name: "test"
+		stringData: key: '\x68\x69'
+	}]`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	sets, err := GetResources(value)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sets[0].Objects).To(HaveLen(1))
+
+	data, found, err := unstructured.NestedStringMap(sets[0].Objects[0].Object, "stringData")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found).To(BeTrue())
+	g.Expect(data["key"]).To(BeEquivalentTo("hi"))
+}
+
+func TestGetResources_NullItem(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`app: [null, {
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: name: "test"
+	}]`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	sets, err := GetResources(value)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sets[0].Objects).To(HaveLen(1))
+	g.Expect(sets[0].Objects[0].GetName()).To(BeEquivalentTo("test"))
+}
+
+func TestGetResources_IntegralFloat(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`app: [{
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: name: "test"
+		replicas: 1.0
+	}]`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	sets, err := GetResources(value)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sets[0].Objects).To(HaveLen(1))
+	g.Expect(sets[0].Objects[0].Object["replicas"]).To(BeEquivalentTo(int64(1)))
+}
+
+func TestGetResources_EmptyList(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`app: []`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	sets, err := GetResources(value)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(sets[0].Objects).ToNot(BeNil())
+	g.Expect(sets[0].Objects).To(BeEmpty())
+}
+
+func TestGetResources_MissingKind(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`app: [{foo: "bar"}]`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	_, err := GetResources(value)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("Kind"))
 }


### PR DESCRIPTION
Manifest-heavy modules (big ConfigMaps, CRDs, embedded files) get 2-5x faster build and 50% less memory allocation.

### Benchmarks

Apple M5 Max, measured on the `GetResources` conversion stage:

| Scenario                         | Old time | New time | Old alloc | New alloc | Memory saved | Speedup     |
|----------------------------------|----------|----------|-----------|-----------|--------------|-------------|
| 50 ConfigMaps of 10 KiB          | 25.5 ms  | 4.8 ms   | 25.0 MB   | 8.9 MB    | 64%          | 5.3x faster |
| flux-aio, 21 objects incl. CRDs  | 20.9 ms  | 9.0 ms   | 33.4 MB   | 14.5 MB   | 57%          | 2.3x faster |