### PR TITLE
perf(bundle): Optimize memory and speed of bundle operations

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -203,7 +203,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 		applyArgs.pkg.String(),
 	)
 
-	if err := builder.WriteSchemaFile(); err != nil {
+	if err := builder.OverlaySchemaFile(); err != nil {
 		return err
 	}
 
@@ -219,7 +219,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		err = builder.MergeValuesFile(valuesCue)
+		err = builder.OverlayValuesFile(valuesCue)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -154,7 +154,7 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 		buildArgs.pkg.String(),
 	)
 
-	if err := builder.WriteSchemaFile(); err != nil {
+	if err := builder.OverlaySchemaFile(); err != nil {
 		return err
 	}
 
@@ -168,7 +168,7 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		err = builder.MergeValuesFile(valuesCue)
+		err = builder.OverlayValuesFile(valuesCue)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -26,7 +26,6 @@ import (
 	"path"
 	"time"
 
-	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -226,7 +225,7 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 
 		for _, instance := range bundle.Instances {
 			instance.Cluster = cluster.Name
-			if err := applyBundleInstance(logr.NewContext(ctx, log), cuectx, instance, kubeVersion, tmpDir, cmd.OutOrStdout()); err != nil {
+			if err := applyBundleInstance(logr.NewContext(ctx, log), instance, kubeVersion, tmpDir, cmd.OutOrStdout()); err != nil {
 				return err
 			}
 		}
@@ -279,12 +278,17 @@ func fetchBundleInstanceModule(ctx context.Context, instance *apiv1.BundleInstan
 	return nil
 }
 
-func applyBundleInstance(ctx context.Context, cuectx *cue.Context, instance *apiv1.BundleInstance, kubeVersion string, rootDir string, diffOutput io.Writer) error {
+// applyBundleInstance builds an instance and reconciles its Kubernetes
+// objects onto the cluster. The instance is compiled in its own CUE context
+// so that the memory used during the build can be reclaimed once the objects
+// are extracted, keeping the peak usage constant regardless of how many
+// instances a bundle contains.
+func applyBundleInstance(ctx context.Context, instance *apiv1.BundleInstance, kubeVersion string, rootDir string, diffOutput io.Writer) error {
 	log := loggerBundleInstance(ctx, instance.Bundle, instance.Cluster, instance.Name, true)
 
 	modDir := path.Join(rootDir, instance.Name, "module")
 	builder := engine.NewModuleBuilder(
-		cuectx,
+		nil,
 		instance.Name,
 		instance.Namespace,
 		modDir,

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -146,6 +146,8 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 	ctxPull, cancel := context.WithTimeout(ctx, rootArgs.timeout)
 	defer cancel()
 
+	moduleCache := make(map[moduleCacheKey]*fetchedModule)
+
 	for _, cluster := range clusters {
 		kubeconfigArgs.Context = &cluster.KubeContext
 
@@ -198,13 +200,15 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 			}
 		}
 
+		modDirs := make(map[string]string)
 		for _, instance := range bundle.Instances {
 			spin := logger.StartSpinner(fmt.Sprintf("pulling %s", instance.Module.Repository))
-			pullErr := fetchBundleInstanceModule(ctxPull, instance, tmpDir)
+			modDir, pullErr := fetchBundleInstanceModule(ctxPull, instance, tmpDir, bundleApplyArgs.creds.String(), moduleCache)
 			spin.Stop()
 			if pullErr != nil {
 				return pullErr
 			}
+			modDirs[instance.Name] = modDir
 		}
 
 		kubeVersion, err := runtime.ServerVersion(kubeconfigArgs)
@@ -225,7 +229,7 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 
 		for _, instance := range bundle.Instances {
 			instance.Cluster = cluster.Name
-			if err := applyBundleInstance(logr.NewContext(ctx, log), instance, kubeVersion, tmpDir, cmd.OutOrStdout()); err != nil {
+			if err := applyBundleInstance(logr.NewContext(ctx, log), instance, kubeVersion, tmpDir, modDirs[instance.Name], cmd.OutOrStdout()); err != nil {
 				return err
 			}
 		}
@@ -241,52 +245,79 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func fetchBundleInstanceModule(ctx context.Context, instance *apiv1.BundleInstance, rootDir string) error {
-	modDir := path.Join(rootDir, instance.Name)
-	if err := os.MkdirAll(modDir, os.ModePerm); err != nil {
-		return err
-	}
+// fetchedModule holds the local root directory and resolved reference of a
+// module fetched during a bundle run.
+type fetchedModule struct {
+	dir string
+	mod *apiv1.ModuleReference
+}
 
+// moduleCacheKey identifies a fetched module by its repository address and
+// version, kept as separate fields so that neither can alias into the other.
+type moduleCacheKey struct {
+	repository string
+	version    string
+}
+
+// fetchBundleInstanceModule fetches the module of a bundle instance, reusing
+// the local copy when a previous instance in the same run already fetched
+// the identical module version. The instance digest pinning is verified on
+// every call, including cache hits. It returns the module root directory the
+// instance is to be built from.
+func fetchBundleInstanceModule(ctx context.Context, instance *apiv1.BundleInstance, rootDir, creds string, cache map[moduleCacheKey]*fetchedModule) (string, error) {
 	moduleVersion := instance.Module.Version
 	if moduleVersion == apiv1.LatestVersion && instance.Module.Digest != "" {
 		moduleVersion = "@" + instance.Module.Digest
 	}
 
-	f, err := fetcher.New(ctx, fetcher.Options{
-		Source:      instance.Module.Repository,
-		Version:     moduleVersion,
-		Destination: modDir,
-		CacheDir:    rootArgs.cacheDir,
-		Creds:       bundleApplyArgs.creds.String(),
-		Insecure:    rootArgs.registryInsecure,
-	})
-	if err != nil {
-		return err
+	key := moduleCacheKey{repository: instance.Module.Repository, version: moduleVersion}
+	cached, ok := cache[key]
+	if !ok {
+		dstDir := path.Join(rootDir, "modules", fmt.Sprintf("module%d", len(cache)))
+		if err := os.MkdirAll(dstDir, os.ModePerm); err != nil {
+			return "", err
+		}
+
+		f, err := fetcher.New(ctx, fetcher.Options{
+			Source:      instance.Module.Repository,
+			Version:     moduleVersion,
+			Destination: dstDir,
+			CacheDir:    rootArgs.cacheDir,
+			Creds:       creds,
+			Insecure:    rootArgs.registryInsecure,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		mod, err := f.Fetch()
+		if err != nil {
+			return "", err
+		}
+
+		cached = &fetchedModule{dir: f.GetModuleRoot(), mod: mod}
+		cache[key] = cached
 	}
 
-	mod, err := f.Fetch()
-	if err != nil {
-		return err
+	if instance.Module.Digest != "" && cached.mod.Digest != instance.Module.Digest {
+		return "", fmt.Errorf("the upstream digest %s of version %s doesn't match the specified digest %s",
+			cached.mod.Digest, instance.Module.Version, instance.Module.Digest)
 	}
 
-	if instance.Module.Digest != "" && mod.Digest != instance.Module.Digest {
-		return fmt.Errorf("the upstream digest %s of version %s doesn't match the specified digest %s",
-			mod.Digest, instance.Module.Version, instance.Module.Digest)
-	}
-
-	instance.Module = *mod
-	return nil
+	instance.Module = *cached.mod
+	return cached.dir, nil
 }
 
 // applyBundleInstance builds an instance and reconciles its Kubernetes
 // objects onto the cluster. The instance is compiled in its own CUE context
 // so that the memory used during the build can be reclaimed once the objects
 // are extracted, keeping the peak usage constant regardless of how many
-// instances a bundle contains.
-func applyBundleInstance(ctx context.Context, instance *apiv1.BundleInstance, kubeVersion string, rootDir string, diffOutput io.Writer) error {
+// instances a bundle contains. The module directory is shared between the
+// instances referencing the same module version and is never modified; the
+// instance schema and values are injected as in-memory overlays.
+func applyBundleInstance(ctx context.Context, instance *apiv1.BundleInstance, kubeVersion string, rootDir string, modDir string, diffOutput io.Writer) error {
 	log := loggerBundleInstance(ctx, instance.Bundle, instance.Cluster, instance.Name, true)
 
-	modDir := path.Join(rootDir, instance.Name, "module")
 	builder := engine.NewModuleBuilder(
 		nil,
 		instance.Name,
@@ -295,7 +326,7 @@ func applyBundleInstance(ctx context.Context, instance *apiv1.BundleInstance, ku
 		bundleApplyArgs.pkg.String(),
 	)
 
-	if err := builder.WriteSchemaFile(); err != nil {
+	if err := builder.OverlaySchemaFile(); err != nil {
 		return err
 	}
 
@@ -307,7 +338,7 @@ func applyBundleInstance(ctx context.Context, instance *apiv1.BundleInstance, ku
 
 	log.Info(fmt.Sprintf("applying module %s version %s",
 		logger.ColorizeSubject(instance.Module.Name), logger.ColorizeSubject(instance.Module.Version)))
-	err = builder.WriteValuesFileWithDefaults(instance.Values)
+	err = builder.OverlayValuesFileWithDefaults(instance.Values)
 	if err != nil {
 		return err
 	}

--- a/cmd/timoni/bundle_apply_test.go
+++ b/cmd/timoni/bundle_apply_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/fscopy"
 )
 
@@ -126,6 +127,27 @@ bundle: {
 				g.Expect(err).ToNot(HaveOccurred())
 			})
 		}
+	})
+
+	t.Run("stores the bundle values in the instance inventory", func(t *testing.T) {
+		g := NewWithT(t)
+		frontendVals, err := executeCommand(fmt.Sprintf(
+			"inspect values -n %s frontend",
+			namespace,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(frontendVals).To(MatchRegexp(`server: \{\s*enabled: false`))
+		g.Expect(frontendVals).To(ContainSubstring(`team: "test"`))
+		g.Expect(frontendVals).ToNot(ContainSubstring("client:"))
+
+		backendVals, err := executeCommand(fmt.Sprintf(
+			"inspect values -n %s backend",
+			namespace,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(backendVals).To(MatchRegexp(`client: \{\s*enabled: false`))
+		g.Expect(backendVals).To(ContainSubstring(`team: "test"`))
+		g.Expect(backendVals).ToNot(ContainSubstring("server:"))
 	})
 
 	t.Run("fails to create instances from completely overlapping bundle", func(t *testing.T) {
@@ -754,4 +776,148 @@ runtime: {
 		g.Expect(err).ToNot(HaveOccurred())
 		t.Log("\n", output)
 	})
+}
+
+func Test_FetchBundleInstanceModule_Cache(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := "testdata/module"
+	modName := rnd("my-mod", 5)
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
+
+	for _, v := range []string{"1.0.0", "1.1.0"} {
+		_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s", modPath, modURL, v))
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	digest, err := crane.Digest(fmt.Sprintf("%s:%s", modURL, "1.0.0"))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	rootDir := t.TempDir()
+	cache := make(map[moduleCacheKey]*fetchedModule)
+
+	instanceFor := func(name, version, digest string) *apiv1.BundleInstance {
+		return &apiv1.BundleInstance{
+			Name: name,
+			Module: apiv1.ModuleReference{
+				Repository: "oci://" + modURL,
+				Version:    version,
+				Digest:     digest,
+			},
+		}
+	}
+
+	t.Run("shares the module dir between instances of the same version", func(t *testing.T) {
+		g := NewWithT(t)
+		dirA, err := fetchBundleInstanceModule(context.Background(), instanceFor("a", "1.0.0", ""), rootDir, "", cache)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		instB := instanceFor("b", "1.0.0", "")
+		dirB, err := fetchBundleInstanceModule(context.Background(), instB, rootDir, "", cache)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(dirB).To(Equal(dirA))
+		g.Expect(cache).To(HaveLen(1))
+		g.Expect(instB.Module.Digest).To(Equal(digest))
+	})
+
+	t.Run("verifies the digest pinning on cache hits", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := fetchBundleInstanceModule(context.Background(), instanceFor("c", "1.0.0", "sha256:1111111111111111111111111111111111111111111111111111111111111111"), rootDir, "", cache)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("doesn't match the specified digest"))
+	})
+
+	t.Run("fetches distinct versions into distinct dirs", func(t *testing.T) {
+		g := NewWithT(t)
+		dirA := cache[moduleCacheKey{repository: "oci://" + modURL, version: "1.0.0"}].dir
+		dirD, err := fetchBundleInstanceModule(context.Background(), instanceFor("d", "1.1.0", ""), rootDir, "", cache)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(dirD).ToNot(Equal(dirA))
+		g.Expect(cache).To(HaveLen(2))
+	})
+}
+
+func Test_BundleApply_Runtime_ModuleVersionPerCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	bundleName := rnd("my-bundle", 5)
+	modPath := "testdata/module"
+	namespace := rnd("my-namespace", 5)
+	modName := rnd("my-mod", 5)
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
+
+	for _, v := range []string{"1.0.0", "2.0.0"} {
+		_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s", modPath, modURL, v))
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	bundleData := fmt.Sprintf(`
+bundle: {
+	_cluster: string @timoni(runtime:string:TIMONI_CLUSTER_NAME)
+
+	_ver: string
+	if _cluster == "staging" {
+		_ver: "1.0.0"
+	}
+	if _cluster != "staging" {
+		_ver: "2.0.0"
+	}
+
+	apiVersion: "v1alpha1"
+	name: "%[1]s"
+	instances: {
+		"\(_cluster)-app": {
+			module: {
+				url:     "oci://%[2]s"
+				version: _ver
+			}
+			namespace: "%[3]s"
+		}
+	}
+}
+`, bundleName, modURL, namespace)
+
+	runtimeCue := `
+runtime: {
+	apiVersion: "v1alpha1"
+	name:       "fleet-test"
+	clusters: {
+		"staging": {
+			group:       "staging"
+			kubeContext: "envtest"
+		}
+		"production": {
+			group:       "production"
+			kubeContext: "envtest"
+		}
+	}
+}
+`
+
+	runtimePath := filepath.Join(t.TempDir(), "runtime.cue")
+	g.Expect(os.WriteFile(runtimePath, []byte(runtimeCue), 0644)).ToNot(HaveOccurred())
+
+	_, err := executeCommandWithIn(
+		fmt.Sprintf("bundle apply -f- -r %s -p main --wait", runtimePath),
+		strings.NewReader(bundleData))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	for name, version := range map[string]string{
+		"staging-app":    "1.0.0",
+		"production-app": "2.0.0",
+	} {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name + "-server",
+				Namespace: namespace,
+			},
+		}
+		err = envTestClient.Get(context.Background(), client.ObjectKeyFromObject(cm), cm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cm.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/version", version))
+
+		output, err := executeCommand(fmt.Sprintf("inspect module -n %s %s", namespace, name))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring(version))
+	}
 }

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -23,12 +23,14 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"sort"
 	"strings"
 
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
@@ -59,10 +61,11 @@ var bundleBuildCmd = &cobra.Command{
 }
 
 type bundleBuildFlags struct {
-	pkg       flags.Package
-	files     []string
-	creds     flags.Credentials
-	outputDir string
+	pkg         flags.Package
+	files       []string
+	creds       flags.Credentials
+	outputDir   string
+	concurrency int
 }
 
 var bundleBuildArgs bundleBuildFlags
@@ -74,6 +77,8 @@ func init() {
 	bundleBuildCmd.Flags().Var(&bundleBuildArgs.creds, bundleBuildArgs.creds.Type(), bundleBuildArgs.creds.Description())
 	bundleBuildCmd.Flags().StringVar(&bundleBuildArgs.outputDir, "output-dir", "",
 		"The path to a directory where the manifests are written as a tree, one directory per instance and one file per resource.")
+	bundleBuildCmd.Flags().IntVar(&bundleBuildArgs.concurrency, "concurrency", 0,
+		"The number of instances to build concurrently, defaults to the number of CPU cores capped at 8.")
 	bundleCmd.AddCommand(bundleBuildCmd)
 }
 
@@ -178,22 +183,37 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		return writeBundleInstancesToDir(cmd, bundle.Instances, modDirs)
 	}
 
+	// Build the instances concurrently, each in its own CUE context,
+	// and assemble the manifests in the order defined by the bundle.
+	manifests := make([]string, len(bundle.Instances))
+	eg := errgroup.Group{}
+	eg.SetLimit(buildConcurrency())
+	for i, instance := range bundle.Instances {
+		eg.Go(func() error {
+			objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name])
+			if err != nil {
+				return err
+			}
+
+			m, err := marshalObjectsToYAML(objects)
+			if err != nil {
+				return err
+			}
+
+			manifests[i] = m
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
 	var sb strings.Builder
 	for i, instance := range bundle.Instances {
-		objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name])
-		if err != nil {
-			return err
-		}
-
-		manifests, err := marshalObjectsToYAML(objects)
-		if err != nil {
-			return err
-		}
-
 		sb.WriteString("---\n")
 		sb.WriteString(fmt.Sprintf("# Instance: %s\n", instance.Name))
 		sb.WriteString("---\n")
-		sb.WriteString(manifests)
+		sb.WriteString(manifests[i])
 		if i < len(bundle.Instances)-1 {
 			sb.WriteString("\n")
 		}
@@ -202,6 +222,16 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 	cmd.OutOrStdout().Write([]byte(sb.String()))
 
 	return nil
+}
+
+// buildConcurrency returns the number of instances to build concurrently,
+// by default bounded to keep the peak memory of large bundles in check as
+// every in-flight instance holds its own CUE evaluation context.
+func buildConcurrency() int {
+	if bundleBuildArgs.concurrency > 0 {
+		return bundleBuildArgs.concurrency
+	}
+	return min(goruntime.NumCPU(), 8)
 }
 
 // writeBundleInstancesToDir writes the resources of each instance to the
@@ -213,50 +243,66 @@ func writeBundleInstancesToDir(cmd *cobra.Command, instances []*apiv1.BundleInst
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	log := LoggerFrom(cmd.Context())
-	for _, instance := range instances {
-		objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name])
-		if err != nil {
-			return err
-		}
-
-		instanceDir := filepath.Join(outputDir, instance.Name)
-		if err := os.MkdirAll(instanceDir, 0o755); err != nil {
-			return fmt.Errorf("failed to create instance directory: %w", err)
-		}
-
-		// Prefix the file names with the namespace only when the instance's
-		// namespaced resources span more than one namespace, matching the
-		// behaviour of kustomize.
-		//
-		// The resource scope is approximated by the presence of
-		// metadata.namespace rather than the true cluster/namespaced scope
-		// (kustomize resolves this from type info). A cluster-scoped object
-		// that carries a stray namespace is therefore counted here and can
-		// enable the prefix for the whole instance. This is acceptable for
-		// Timoni's offline builds, where no REST mapper is available to
-		// resolve resource scopes.
-		namespaces := make(map[string]struct{})
-		for _, obj := range objects {
-			if ns := obj.GetNamespace(); ns != "" {
-				namespaces[ns] = struct{}{}
-			}
-		}
-		withNamespace := len(namespaces) > 1
-
-		for _, obj := range objects {
-			data, err := yaml.Marshal(obj)
+	// Build the instances and write their resources concurrently, each
+	// instance in its own CUE context and its own directory, then report
+	// the results in the order defined by the bundle.
+	exported := make([]string, len(instances))
+	eg := errgroup.Group{}
+	eg.SetLimit(buildConcurrency())
+	for i, instance := range instances {
+		eg.Go(func() error {
+			objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name])
 			if err != nil {
-				return fmt.Errorf("converting objects failed: %w", err)
+				return err
 			}
 
-			fileName := resourceFileName(obj, withNamespace && obj.GetNamespace() != "")
-			if err := os.WriteFile(filepath.Join(instanceDir, fileName), data, 0o644); err != nil {
-				return fmt.Errorf("failed to write manifest: %w", err)
+			instanceDir := filepath.Join(outputDir, instance.Name)
+			if err := os.MkdirAll(instanceDir, 0o755); err != nil {
+				return fmt.Errorf("failed to create instance directory: %w", err)
 			}
-		}
 
-		log.Info(fmt.Sprintf("exported %d resources to %s", len(objects), instanceDir))
+			// Prefix the file names with the namespace only when the instance's
+			// namespaced resources span more than one namespace, matching the
+			// behaviour of kustomize.
+			//
+			// The resource scope is approximated by the presence of
+			// metadata.namespace rather than the true cluster/namespaced scope
+			// (kustomize resolves this from type info). A cluster-scoped object
+			// that carries a stray namespace is therefore counted here and can
+			// enable the prefix for the whole instance. This is acceptable for
+			// Timoni's offline builds, where no REST mapper is available to
+			// resolve resource scopes.
+			namespaces := make(map[string]struct{})
+			for _, obj := range objects {
+				if ns := obj.GetNamespace(); ns != "" {
+					namespaces[ns] = struct{}{}
+				}
+			}
+			withNamespace := len(namespaces) > 1
+
+			for _, obj := range objects {
+				data, err := yaml.Marshal(obj)
+				if err != nil {
+					return fmt.Errorf("converting objects failed: %w", err)
+				}
+
+				fileName := resourceFileName(obj, withNamespace && obj.GetNamespace() != "")
+				if err := os.WriteFile(filepath.Join(instanceDir, fileName), data, 0o644); err != nil {
+					return fmt.Errorf("failed to write manifest: %w", err)
+				}
+			}
+
+			exported[i] = fmt.Sprintf("exported %d resources to %s", len(objects), instanceDir)
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	log := LoggerFrom(cmd.Context())
+	for _, msg := range exported {
+		log.Info(msg)
 	}
 
 	return nil

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -27,7 +27,6 @@ import (
 	"sort"
 	"strings"
 
-	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/spf13/cobra"
@@ -173,12 +172,12 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 	}
 
 	if bundleBuildArgs.outputDir != "" {
-		return writeBundleInstancesToDir(cmd, ctx, bundle.Instances, tmpDir)
+		return writeBundleInstancesToDir(cmd, bundle.Instances, tmpDir)
 	}
 
 	var sb strings.Builder
 	for i, instance := range bundle.Instances {
-		objects, err := buildBundleInstanceObjects(ctx, instance, tmpDir)
+		objects, err := buildBundleInstanceObjects(instance, tmpDir)
 		if err != nil {
 			return err
 		}
@@ -205,7 +204,7 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 // writeBundleInstancesToDir writes the resources of each instance to the
 // output directory as a tree: one directory per instance and one file per
 // resource, named with the same convention as 'kustomize build -o <dir>'.
-func writeBundleInstancesToDir(cmd *cobra.Command, cuectx *cue.Context, instances []*apiv1.BundleInstance, rootDir string) error {
+func writeBundleInstancesToDir(cmd *cobra.Command, instances []*apiv1.BundleInstance, rootDir string) error {
 	outputDir := bundleBuildArgs.outputDir
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
@@ -213,7 +212,7 @@ func writeBundleInstancesToDir(cmd *cobra.Command, cuectx *cue.Context, instance
 
 	log := LoggerFrom(cmd.Context())
 	for _, instance := range instances {
-		objects, err := buildBundleInstanceObjects(cuectx, instance, rootDir)
+		objects, err := buildBundleInstanceObjects(instance, rootDir)
 		if err != nil {
 			return err
 		}
@@ -284,12 +283,15 @@ func resourceFileName(obj *unstructured.Unstructured, withNamespace bool) string
 }
 
 // buildBundleInstanceObjects builds an instance and returns its sorted
-// Kubernetes objects.
-func buildBundleInstanceObjects(cuectx *cue.Context, instance *apiv1.BundleInstance, rootDir string) ([]*unstructured.Unstructured, error) {
+// Kubernetes objects. The instance is compiled in its own CUE context so
+// that the memory used during the build can be reclaimed once the objects
+// are extracted, keeping the peak usage constant regardless of how many
+// instances a bundle contains.
+func buildBundleInstanceObjects(instance *apiv1.BundleInstance, rootDir string) ([]*unstructured.Unstructured, error) {
 	modDir := path.Join(rootDir, instance.Name, "module")
 
 	builder := engine.NewModuleBuilder(
-		cuectx,
+		nil,
 		instance.Name,
 		instance.Namespace,
 		modDir,

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -165,19 +164,23 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 	ctxPull, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
+	moduleCache := make(map[moduleCacheKey]*fetchedModule)
+	modDirs := make(map[string]string)
 	for _, instance := range bundle.Instances {
-		if err := fetchBundleInstanceModule(ctxPull, instance, tmpDir); err != nil {
+		modDir, err := fetchBundleInstanceModule(ctxPull, instance, tmpDir, bundleBuildArgs.creds.String(), moduleCache)
+		if err != nil {
 			return err
 		}
+		modDirs[instance.Name] = modDir
 	}
 
 	if bundleBuildArgs.outputDir != "" {
-		return writeBundleInstancesToDir(cmd, bundle.Instances, tmpDir)
+		return writeBundleInstancesToDir(cmd, bundle.Instances, modDirs)
 	}
 
 	var sb strings.Builder
 	for i, instance := range bundle.Instances {
-		objects, err := buildBundleInstanceObjects(instance, tmpDir)
+		objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name])
 		if err != nil {
 			return err
 		}
@@ -204,7 +207,7 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 // writeBundleInstancesToDir writes the resources of each instance to the
 // output directory as a tree: one directory per instance and one file per
 // resource, named with the same convention as 'kustomize build -o <dir>'.
-func writeBundleInstancesToDir(cmd *cobra.Command, instances []*apiv1.BundleInstance, rootDir string) error {
+func writeBundleInstancesToDir(cmd *cobra.Command, instances []*apiv1.BundleInstance, modDirs map[string]string) error {
 	outputDir := bundleBuildArgs.outputDir
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
@@ -212,7 +215,7 @@ func writeBundleInstancesToDir(cmd *cobra.Command, instances []*apiv1.BundleInst
 
 	log := LoggerFrom(cmd.Context())
 	for _, instance := range instances {
-		objects, err := buildBundleInstanceObjects(instance, rootDir)
+		objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name])
 		if err != nil {
 			return err
 		}
@@ -286,10 +289,10 @@ func resourceFileName(obj *unstructured.Unstructured, withNamespace bool) string
 // Kubernetes objects. The instance is compiled in its own CUE context so
 // that the memory used during the build can be reclaimed once the objects
 // are extracted, keeping the peak usage constant regardless of how many
-// instances a bundle contains.
-func buildBundleInstanceObjects(instance *apiv1.BundleInstance, rootDir string) ([]*unstructured.Unstructured, error) {
-	modDir := path.Join(rootDir, instance.Name, "module")
-
+// instances a bundle contains. The module directory is shared between the
+// instances referencing the same module version and is never modified; the
+// instance schema and values are injected as in-memory overlays.
+func buildBundleInstanceObjects(instance *apiv1.BundleInstance, modDir string) ([]*unstructured.Unstructured, error) {
 	builder := engine.NewModuleBuilder(
 		nil,
 		instance.Name,
@@ -298,7 +301,7 @@ func buildBundleInstanceObjects(instance *apiv1.BundleInstance, rootDir string) 
 		bundleBuildArgs.pkg.String(),
 	)
 
-	if err := builder.WriteSchemaFile(); err != nil {
+	if err := builder.OverlaySchemaFile(); err != nil {
 		return nil, err
 	}
 
@@ -308,7 +311,7 @@ func buildBundleInstanceObjects(instance *apiv1.BundleInstance, rootDir string) 
 	}
 	instance.Module.Name = modName
 
-	if err := builder.WriteValuesFileWithDefaults(instance.Values); err != nil {
+	if err := builder.OverlayValuesFileWithDefaults(instance.Values); err != nil {
 		return nil, err
 	}
 

--- a/cmd/timoni/bundle_build_test.go
+++ b/cmd/timoni/bundle_build_test.go
@@ -526,3 +526,78 @@ func manifestFileNames(dir string) ([]string, error) {
 	}
 	return names, nil
 }
+
+func Test_BundleBuild_Concurrency(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := "testdata/module"
+	modName := rnd("my-mod", 5)
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
+	modVer := "1.0.0"
+
+	_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s", modPath, modURL, modVer))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	const numInstances = 6
+	var sb strings.Builder
+	sb.WriteString(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "concurrency-test"
+	instances: {
+`)
+	for i := range numInstances {
+		fmt.Fprintf(&sb, `		"app-%[1]d": {
+			module: {
+				url:     "oci://%[2]s"
+				version: "%[3]s"
+			}
+			namespace: "concurrency-test"
+			values: domain: "app-%[1]d.internal"
+		}
+`, i, modURL, modVer)
+	}
+	sb.WriteString("	}\n}\n")
+	bundleData := sb.String()
+
+	build := func(concurrency int) string {
+		output, err := executeCommandWithIn(
+			fmt.Sprintf("bundle build -f- -p main --concurrency %d", concurrency),
+			strings.NewReader(bundleData))
+		g.Expect(err).ToNot(HaveOccurred())
+		return output
+	}
+
+	concurrent := build(4)
+
+	t.Run("keeps the manifests in bundle order", func(t *testing.T) {
+		g := NewWithT(t)
+		lastIdx := -1
+		for i := range numInstances {
+			idx := strings.Index(concurrent, fmt.Sprintf("# Instance: app-%d\n", i))
+			g.Expect(idx).To(BeNumerically(">", lastIdx))
+			lastIdx = idx
+		}
+	})
+
+	t.Run("isolates the values of each instance", func(t *testing.T) {
+		g := NewWithT(t)
+		sections := strings.Split(concurrent, "# Instance: ")[1:]
+		g.Expect(sections).To(HaveLen(numInstances))
+		for i, section := range sections {
+			for j := range numInstances {
+				m := ContainSubstring(fmt.Sprintf("app-%d.internal", j))
+				if i == j {
+					g.Expect(section).To(m)
+				} else {
+					g.Expect(section).ToNot(m)
+				}
+			}
+		}
+	})
+
+	t.Run("produces identical output regardless of concurrency", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(build(1)).To(Equal(concurrent))
+	})
+}

--- a/cmd/timoni/mod_show_config.go
+++ b/cmd/timoni/mod_show_config.go
@@ -116,7 +116,7 @@ func runConfigShowModCmd(cmd *cobra.Command, args []string) error {
 		configShowModArgs.pkg.String(),
 	)
 
-	if err := builder.WriteSchemaFile(); err != nil {
+	if err := builder.OverlaySchemaFile(); err != nil {
 		return err
 	}
 

--- a/cmd/timoni/mod_vet.go
+++ b/cmd/timoni/mod_vet.go
@@ -136,7 +136,7 @@ func runVetModCmd(cmd *cobra.Command, args []string) error {
 		vetModArgs.pkg.String(),
 	)
 
-	if err := builder.WriteSchemaFile(); err != nil {
+	if err := builder.OverlaySchemaFile(); err != nil {
 		return err
 	}
 
@@ -150,7 +150,7 @@ func runVetModCmd(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		err = builder.MergeValuesFile(valuesCue)
+		err = builder.OverlayValuesFile(valuesCue)
 		if err != nil {
 			return err
 		}

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -602,6 +602,10 @@ the module version set to `0.0.0-devel`.
 By default, `timoni bundle build` prints the resulting Kubernetes resources of all
 instances to stdout. To write the manifests as files on disk, use the `--output-dir` flag.
 
+The instances are built concurrently, with the number of concurrent builds set by the
+`--concurrency` flag. It defaults to the number of CPU cores capped at 8; raising it
+can speed up large bundles at the cost of a higher peak memory usage.
+
 For example, given a bundle with two instances:
 
 ```cue

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sync v0.22.0
 	k8s.io/api v0.36.3
 	k8s.io/apiextensions-apiserver v0.36.3
 	k8s.io/apimachinery v0.36.3
@@ -162,7 +163,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/internal/engine/module_builder.go
+++ b/internal/engine/module_builder.go
@@ -54,6 +54,7 @@ type ModuleBuilder struct {
 	namespace     string
 	moduleVersion string
 	kubeVersion   string
+	overlays      map[string]string
 }
 
 // NewModuleBuilder creates a ModuleBuilder for the given module and package.
@@ -70,6 +71,7 @@ func NewModuleBuilder(ctx *cue.Context, name, namespace, moduleRoot, pkgName str
 		namespace:     namespace,
 		moduleVersion: DefaultDevelVersion,
 		kubeVersion:   defaultKubeVersion,
+		overlays:      make(map[string]string),
 	}
 
 	if kv := os.Getenv("TIMONI_KUBE_VERSION"); kv != "" {
@@ -82,8 +84,10 @@ func NewModuleBuilder(ctx *cue.Context, name, namespace, moduleRoot, pkgName str
 	return b
 }
 
-// MergeValuesFile merges the given values overlays into the module's root values.cue.
-func (b *ModuleBuilder) MergeValuesFile(overlays [][]byte) error {
+// OverlayValuesFile merges the given values overlays into the module's root
+// values.cue as an in-memory file passed to the loader at build time, leaving
+// the module directory untouched so it can be shared between instances.
+func (b *ModuleBuilder) OverlayValuesFile(overlays [][]byte) error {
 	vb := NewValuesBuilder(b.ctx)
 	defaultFile := filepath.Join(b.pkgPath, defaultValuesFile)
 
@@ -96,17 +100,27 @@ func (b *ModuleBuilder) MergeValuesFile(overlays [][]byte) error {
 		return err
 	}
 
-	cueGen := fmt.Sprintf("package %s\n%s: %v", b.pkgName, apiv1.ValuesSelector, finalVal)
-
-	// overwrite the values.cue file with the merged values
-	if err := os.MkdirAll(b.moduleRoot, os.ModePerm); err != nil {
-		return err
-	}
-	return os.WriteFile(defaultFile, []byte(cueGen), 0644)
+	b.overlays[defaultFile] = fmt.Sprintf("package %s\n%s: %v", b.pkgName, apiv1.ValuesSelector, finalVal)
+	return nil
 }
 
-// WriteValuesFileWithDefaults merges the module's root values.cue with the supplied value.
-func (b *ModuleBuilder) WriteValuesFileWithDefaults(val cue.Value) error {
+// OverlaySchemaFile generates the module's instance schema as an in-memory
+// file passed to the loader at build time, leaving the module directory
+// untouched so it can be shared between instances.
+func (b *ModuleBuilder) OverlaySchemaFile() error {
+	if fs, err := os.Stat(b.pkgPath); err != nil || !fs.IsDir() {
+		return fmt.Errorf("cannot find package %s", b.pkgPath)
+	}
+
+	b.overlays[filepath.Join(b.pkgPath, defaultSchemaFile)] = fmt.Sprintf("package %s\n%v", b.pkgName, apiv1.InstanceSchema)
+	return nil
+}
+
+// OverlayValuesFileWithDefaults merges the module's root values.cue with the
+// supplied value into an in-memory file passed to the loader at build time,
+// leaving the module directory untouched so it can be shared between
+// instances.
+func (b *ModuleBuilder) OverlayValuesFileWithDefaults(val cue.Value) error {
 	valData := []byte(fmt.Sprintf("%s: %v", apiv1.ValuesSelector.String(), val))
 
 	vb := NewValuesBuilder(b.ctx)
@@ -121,24 +135,8 @@ func (b *ModuleBuilder) WriteValuesFileWithDefaults(val cue.Value) error {
 		return err
 	}
 
-	cueGen := fmt.Sprintf("package %s\n%s: %v", b.pkgName, apiv1.ValuesSelector, finalVal)
-
-	// overwrite the values.cue file with the merged values
-	if err := os.MkdirAll(b.moduleRoot, os.ModePerm); err != nil {
-		return err
-	}
-	return os.WriteFile(defaultFile, []byte(cueGen), 0644)
-}
-
-// WriteSchemaFile generates the module's instance schema.
-func (b *ModuleBuilder) WriteSchemaFile() error {
-	if fs, err := os.Stat(b.pkgPath); err != nil || !fs.IsDir() {
-		return fmt.Errorf("cannot find package %s", b.pkgPath)
-	}
-
-	cueGen := fmt.Sprintf("package %s\n%v", b.pkgName, apiv1.InstanceSchema)
-
-	return os.WriteFile(filepath.Join(b.pkgPath, defaultSchemaFile), []byte(cueGen), 0644)
+	b.overlays[defaultFile] = fmt.Sprintf("package %s\n%s: %v", b.pkgName, apiv1.ValuesSelector, finalVal)
+	return nil
 }
 
 // SetVersionInfo allows setting the Timoni module version and Kubernetes version,
@@ -184,6 +182,13 @@ func (b *ModuleBuilder) Build(tags ...string) (cue.Value, error) {
 
 	if len(tags) > 0 {
 		cfg.Tags = append(cfg.Tags, tags...)
+	}
+
+	if len(b.overlays) > 0 {
+		cfg.Overlay = make(map[string]load.Source, len(b.overlays))
+		for path, content := range b.overlays {
+			cfg.Overlay[path] = load.FromString(content)
+		}
 	}
 
 	modInstances := load.Instances([]string{}, cfg)
@@ -233,16 +238,22 @@ func (b *ModuleBuilder) GetApplySets(value cue.Value) ([]ResourceSet, error) {
 	return GetResources(steps)
 }
 
-// GetDefaultValues extracts the default values from the module.
+// GetDefaultValues extracts the values from the module's root values.cue,
+// preferring the in-memory overlay set with OverlayValuesFile or
+// OverlayValuesFileWithDefaults over the file on disk.
 func (b *ModuleBuilder) GetDefaultValues() (string, error) {
 	filePath := filepath.Join(b.pkgPath, defaultValuesFile)
-	var value cue.Value
-	vData, err := os.ReadFile(filePath)
-	if err != nil {
-		return "", err
+
+	vData := []byte(b.overlays[filePath])
+	if len(vData) == 0 {
+		var err error
+		vData, err = os.ReadFile(filePath)
+		if err != nil {
+			return "", err
+		}
 	}
 
-	value = b.ctx.CompileBytes(vData)
+	value := b.ctx.CompileBytes(vData)
 	if value.Err() != nil {
 		return "", value.Err()
 	}

--- a/internal/engine/module_builder_test.go
+++ b/internal/engine/module_builder_test.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestModuleBuilder(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(moduleName).To(BeEquivalentTo("timoni.sh/test"))
 
-	err = mb.MergeValuesFile([][]byte{mustReadFile(g, "testdata/module-values/overlay.cue")})
+	err = mb.OverlayValuesFile([][]byte{mustReadFile(g, "testdata/module-values/overlay.cue")})
 	g.Expect(err).ToNot(HaveOccurred())
 
 	mb.SetVersionInfo("", "1.25.3")
@@ -79,7 +80,57 @@ func TestModuleBuilder_InvalidValues(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(moduleName).To(BeEquivalentTo("timoni.sh/test"))
 
-	err = mb.MergeValuesFile([][]byte{mustReadFile(g, "testdata/module-values/overlay-invalid.cue")})
+	err = mb.OverlayValuesFile([][]byte{mustReadFile(g, "testdata/module-values/overlay-invalid.cue")})
 	g.Expect(err).ToNot(BeNil())
 	g.Expect(err.Error()).To(Equal("values.list: incompatible list lengths (0 and 1)"))
+}
+
+func TestModuleBuilder_GetDefaultValuesPrefersOverlay(t *testing.T) {
+	g := NewWithT(t)
+	moduleRoot := path.Join(t.TempDir(), "module")
+
+	err := CopyModule("testdata/module", moduleRoot)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	mb := NewModuleBuilder(cuecontext.New(), "test-name", "test-namespace", moduleRoot, "main")
+
+	diskVals, err := mb.GetDefaultValues()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(diskVals).ToNot(ContainSubstring("test.internal"))
+
+	err = mb.OverlayValuesFile([][]byte{mustReadFile(g, "testdata/module-values/overlay.cue")})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	overlayVals, err := mb.GetDefaultValues()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(overlayVals).To(ContainSubstring("test.internal"))
+}
+
+func TestModuleBuilder_OverlayKeepsModuleDirUnchanged(t *testing.T) {
+	g := NewWithT(t)
+	moduleRoot := path.Join(t.TempDir(), "module")
+
+	err := CopyModule("testdata/module", moduleRoot)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	valuesFile := path.Join(moduleRoot, "values.cue")
+	valuesBefore, err := os.ReadFile(valuesFile)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	mb := NewModuleBuilder(cuecontext.New(), "test-name", "test-namespace", moduleRoot, "main")
+
+	g.Expect(mb.OverlaySchemaFile()).ToNot(HaveOccurred())
+	g.Expect(mb.OverlayValuesFile([][]byte{mustReadFile(g, "testdata/module-values/overlay.cue")})).ToNot(HaveOccurred())
+
+	val, err := mb.Build()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	objects := val.LookupPath(cue.ParsePath(apiv1.ApplySelector.String() + ".all"))
+	g.Expect(objects.Err()).ToNot(HaveOccurred())
+	g.Expect(fmt.Sprintf("%v", objects)).To(ContainSubstring("test.internal"))
+
+	valuesAfter, err := os.ReadFile(valuesFile)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(valuesAfter).To(Equal(valuesBefore))
+	g.Expect(path.Join(moduleRoot, "timoni.schema.cue")).ToNot(BeAnExistingFile())
 }


### PR DESCRIPTION
This PR restructures the bundle instance pipeline in three steps:

1. **Dedicated CUE context per instance.** Each instance is compiled in its own context, so peak memory no longer grows with instance count. 
2. **Fetch modules once and inject instance settings in-memory.** Each unique module version is fetched once per run and shared read-only between the instances that reference it. 
3. **Concurrent instance builds.** `bundle build` builds instances concurrently, each in its own context, with manifests assembled in the order defined by the bundle. The new `--concurrency` flag defaults to the number of CPU cores capped at 8, so peak memory is bounded by the concurrency level instead of the instance count. `bundle apply` remains sequential by design.

### Benchmarks

Building a bundle of 50 redis instances on Apple M5 Max:

| Scenario                          | Old time | New time | Old memory | New memory | Memory saved | Speedup     |
|-----------------------------------|----------|----------|------------|------------|--------------|-------------|
| bundle build, default concurrency | 2.19 s   | 334 ms   | 613 MB     | 206 MB     | 66%          | 6.5x faster |
| bundle build, --concurrency 4     | 2.19 s   | 460 ms   | 613 MB     | 124 MB     | 80%          | 4.8x faster |

 `bundle apply` gains the memory reduction but little wall-clock time, as server round-trips and readiness waiting dominate there.
