### PR TITLE
perf(engine): Build bundle and runtime workspaces in memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 docs/cmd/
 venv/
 .vscode
+workspace/

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -171,19 +171,15 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 		// add cluster info
 		maps.Copy(clusterValues, cluster.NameGroupValues())
 
-		// create cluster workspace
-		workspace := path.Join(tmpDir, cluster.Name)
-		if err := os.MkdirAll(workspace, os.ModePerm); err != nil {
-			return err
-		}
-
+		// init the in-memory cluster workspace
+		workspace := cluster.Name
 		if err := bm.InitWorkspace(workspace, clusterValues); err != nil {
-			return describeErr(workspace, "failed to parse bundle", err)
+			return describeErr(bm.WorkspaceDir(workspace), "failed to parse bundle", err)
 		}
 
 		v, err := bm.Build(workspace)
 		if err != nil {
-			return describeErr(tmpDir, "failed to build bundle", err)
+			return describeErr(bm.WorkspaceDir(workspace), "failed to build bundle", err)
 		}
 
 		bundle, err := bm.GetBundle(v)

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -111,6 +111,7 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 	ctx := cuecontext.New()
 	bm := engine.NewBundleBuilder(ctx, files)
 
+	workspace := apiv1.RuntimeDefaultName
 	runtimeValues := make(map[string]string)
 
 	if bundleArgs.runtimeFromEnv {
@@ -135,6 +136,7 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		}
 
 		cluster := clusters[0]
+		workspace = cluster.Name
 		kubeconfigArgs.Context = &cluster.KubeContext
 
 		rm, err := runtime.NewResourceManager(kubeconfigArgs)
@@ -152,13 +154,13 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		maps.Copy(runtimeValues, cluster.NameGroupValues())
 	}
 
-	if err := bm.InitWorkspace(tmpDir, runtimeValues); err != nil {
-		return describeErr(tmpDir, "failed to parse bundle", err)
+	if err := bm.InitWorkspace(workspace, runtimeValues); err != nil {
+		return describeErr(bm.WorkspaceDir(workspace), "failed to parse bundle", err)
 	}
 
-	v, err := bm.Build(tmpDir)
+	v, err := bm.Build(workspace)
 	if err != nil {
-		return describeErr(tmpDir, "failed to build bundle", err)
+		return describeErr(bm.WorkspaceDir(workspace), "failed to build bundle", err)
 	}
 
 	bundle, err := bm.GetBundle(v)

--- a/cmd/timoni/bundle_vet.go
+++ b/cmd/timoni/bundle_vet.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"path"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
@@ -98,12 +97,6 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 		defer os.Remove(stdinFile)
 	}
 
-	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(tmpDir)
-
 	cuectx := cuecontext.New()
 	bm := engine.NewBundleBuilder(cuectx, files)
 
@@ -149,19 +142,15 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 		// add cluster info
 		maps.Copy(clusterValues, cluster.NameGroupValues())
 
-		// create cluster workspace
-		workspace := path.Join(tmpDir, cluster.Name)
-		if err := os.MkdirAll(workspace, os.ModePerm); err != nil {
-			return err
-		}
-
+		// init the in-memory cluster workspace
+		workspace := cluster.Name
 		if err := bm.InitWorkspace(workspace, clusterValues); err != nil {
-			return describeErr(workspace, "failed to parse bundle", err)
+			return describeErr(bm.WorkspaceDir(workspace), "failed to parse bundle", err)
 		}
 
 		v, err := bm.Build(workspace)
 		if err != nil {
-			return describeErr(workspace, "failed to build bundle", err)
+			return describeErr(bm.WorkspaceDir(workspace), "failed to build bundle", err)
 		}
 
 		bundle, err := bm.GetBundle(v)

--- a/cmd/timoni/runtime_build.go
+++ b/cmd/timoni/runtime_build.go
@@ -134,22 +134,17 @@ func buildRuntime(files []string) (*apiv1.Runtime, error) {
 		return defaultRuntime, nil
 	}
 
-	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(tmpDir)
-
 	ctx := cuecontext.New()
 	rb := engine.NewRuntimeBuilder(ctx, files)
 
-	if err := rb.InitWorkspace(tmpDir); err != nil {
-		return nil, describeErr(tmpDir, "failed to init runtime", err)
+	workspace := apiv1.RuntimeDefaultName
+	if err := rb.InitWorkspace(workspace); err != nil {
+		return nil, describeErr(rb.WorkspaceDir(workspace), "failed to init runtime", err)
 	}
 
-	v, err := rb.Build(tmpDir)
+	v, err := rb.Build(workspace)
 	if err != nil {
-		return nil, describeErr(tmpDir, "failed to parse runtime", err)
+		return nil, describeErr(rb.WorkspaceDir(workspace), "failed to parse runtime", err)
 	}
 
 	rt, err := rb.GetRuntime(v)

--- a/docs/cue/module/publishing.md
+++ b/docs/cue/module/publishing.md
@@ -103,7 +103,6 @@ then it will tag the version as `latest` in the container registry.
 
 To automate the publishing of module versions, please see the [Timoni GitHub Actions doc](github-actions.md).
 
-
 ### Ignoring files
 
 Timoni modules can contain files that are not meant to be published.
@@ -137,17 +136,18 @@ debug_values.cue
 When packaging a module, Timoni resolves symbolic links and includes
 their targets in the artifact as regular files and directories.
 This allows sharing files between modules in a monorepo, for example
-by symlinking the vendored CUE schemas under `cue.mod/pkg`.
-Symlink cycles are detected and reported as errors.
+by symlinking the vendored CUE schemas under `cue.mod/gen`.
+
 The `timoni.ignore` rules apply to the resolved content at its
 in-module path, the same as for regular files and directories.
 
-The same resolution is applied when building a module from a local path,
-so `timoni build`, `timoni apply` and `timoni mod vet` see the exact same
-files as the published artifact.
+When building a module from a local path, `timoni build`, `timoni apply`
+and `timoni mod vet` read the module files in place from the source
+directory, following symbolic links the same way.
 
-To opt out of symlink resolution, set the `TIMONI_FOLLOW_SYMLINKS=false`
-env var, in which case symbolic links are skipped.
+To opt out of symlink resolution when packaging, set the
+`TIMONI_FOLLOW_SYMLINKS=false` env var, in which case symbolic links
+are skipped.
 
 !!! warning "Symlinks in CI"
 

--- a/internal/engine/bundle_builder.go
+++ b/internal/engine/bundle_builder.go
@@ -37,7 +37,9 @@ import (
 type BundleBuilder struct {
 	ctx               *cue.Context
 	files             []string
+	root              string
 	workspacesFiles   map[string][]string
+	workspacesSources map[string]map[string][]byte
 	mapSourceToOrigin map[string]string
 	injector          *RuntimeInjector
 }
@@ -50,18 +52,31 @@ func NewBundleBuilder(ctx *cue.Context, files []string) *BundleBuilder {
 	b := &BundleBuilder{
 		ctx:               ctx,
 		files:             files,
+		root:              NewVirtualRoot(),
 		workspacesFiles:   make(map[string][]string),
+		workspacesSources: make(map[string]map[string][]byte),
 		mapSourceToOrigin: make(map[string]string, len(files)),
 		injector:          NewRuntimeInjector(ctx),
 	}
 	return b
 }
 
-// InitWorkspace copies the bundle definitions to the specified workspace,
-// sets the bundle schema, and then it injects the runtime values based on @timoni() attributes.
-// A workspace must be initialised before calling Build.
+// WorkspaceDir returns the virtual directory under which the workspace
+// files are laid out. The directory does not exist on disk; it serves
+// as the base for rendering error positions relative.
+func (b *BundleBuilder) WorkspaceDir(workspace string) string {
+	return filepath.Join(b.root, workspace)
+}
+
+// InitWorkspace loads the bundle definitions into the in-memory workspace
+// identified by the given name, sets the bundle schema, and then it injects
+// the runtime values based on @timoni() attributes. Nothing is written to
+// disk; the workspace files are kept in memory and served to the CUE loader
+// as overlays. A workspace must be initialised before calling Build.
 func (b *BundleBuilder) InitWorkspace(workspace string, runtimeValues map[string]string) error {
 	var files []string
+	sources := make(map[string][]byte, len(b.files)+1)
+	workspaceDir := b.WorkspaceDir(workspace)
 	for i, file := range b.files {
 		_, fn := filepath.Split(file)
 		content, err := os.ReadFile(file)
@@ -95,32 +110,38 @@ func (b *BundleBuilder) InitWorkspace(workspace string, runtimeValues map[string
 			return fmt.Errorf("failed to inject %s: %w", fn, err)
 		}
 
-		dstFile := filepath.Join(workspace, fmt.Sprintf("%v.%s.cue", i, fn))
-		if err := os.WriteFile(dstFile, data, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to write %s: %w", fn, err)
-		}
+		dstFile := filepath.Join(workspaceDir, fmt.Sprintf("%v.%s.cue", i, strings.TrimSuffix(fn, ".cue")))
+		sources[dstFile] = data
 		b.mapSourceToOrigin[dstFile] = file
 
 		files = append(files, dstFile)
 	}
 
-	schemaFile := filepath.Join(workspace, fmt.Sprintf("%v.schema.cue", len(b.workspacesFiles[workspace])+1))
+	// The bundle files are indexed 0..len(files)-1, so naming the generated
+	// schema after len(files) cannot collide with a user file named schema.cue.
+	schemaFile := filepath.Join(workspaceDir, fmt.Sprintf("%v.schema.cue", len(b.files)))
 	files = append(files, schemaFile)
-	if err := os.WriteFile(schemaFile, []byte(apiv1.BundleSchema), os.ModePerm); err != nil {
-		return err
-	}
+	sources[schemaFile] = []byte(apiv1.BundleSchema)
 
 	b.workspacesFiles[workspace] = files
+	b.workspacesSources[workspace] = sources
 	return nil
 }
 
-// Build builds a CUE instance for the specified files and returns the CUE value.
+// Build builds a CUE instance for the specified workspace and returns the CUE value.
+// The workspace files are served to the CUE loader as in-memory overlays.
 // A workspace must be initialised with InitWorkspace before calling this function.
 func (b *BundleBuilder) Build(workspace string) (cue.Value, error) {
 	var value cue.Value
+	overlay := make(map[string]load.Source, len(b.workspacesSources[workspace]))
+	for f, data := range b.workspacesSources[workspace] {
+		overlay[f] = load.FromBytes(data)
+	}
+
 	cfg := &load.Config{
 		Package:   "_",
 		DataFiles: true,
+		Overlay:   overlay,
 	}
 
 	ix := load.Instances(b.workspacesFiles[workspace], cfg)

--- a/internal/engine/bundle_builder_test.go
+++ b/internal/engine/bundle_builder_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package engine
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
+	cueerrors "cuelang.org/go/cue/errors"
 	. "github.com/onsi/gomega"
 )
 
@@ -61,5 +65,116 @@ bundle: {
 		g.Expect(b.Instances).To(HaveLen(2))
 		g.Expect(b.Instances[0].Name).To(Equal("pod-info"))
 		g.Expect(b.Instances[1].Name).To(Equal("podinfo"))
+	})
+}
+
+func TestBundleBuilderWorkspace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	srcDir := t.TempDir()
+	bundleFile := filepath.Join(srcDir, "bundle.cue")
+	bundleData := `
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "test"
+	instances: {
+		app: {
+			module: url:     "file://./modules/app"
+			module: version: "1.0.0"
+			namespace: "apps"
+			values: message: string @timoni(runtime:string:TEST_WORKSPACE_MSG)
+		}
+	}
+}
+`
+	g.Expect(os.WriteFile(bundleFile, []byte(bundleData), 0o644)).To(Succeed())
+
+	builder := NewBundleBuilder(ctx, []string{bundleFile})
+
+	t.Run("builds workspace in memory", func(t *testing.T) {
+		g := NewWithT(t)
+		workspace := "cluster-1"
+		err := builder.InitWorkspace(workspace, map[string]string{"TEST_WORKSPACE_MSG": "from-runtime"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, err = os.Lstat(builder.WorkspaceDir(workspace))
+		g.Expect(err).To(MatchError(os.ErrNotExist))
+
+		v, err := builder.Build(workspace)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		msg := v.LookupPath(cue.ParsePath("bundle.instances.app.values.message"))
+		g.Expect(msg.Err()).ToNot(HaveOccurred())
+		g.Expect(msg).To(WithTransform(func(v cue.Value) string {
+			s, _ := v.String()
+			return s
+		}, Equal("from-runtime")))
+	})
+
+	t.Run("resolves relative file URLs against the origin", func(t *testing.T) {
+		g := NewWithT(t)
+		workspace := "cluster-2"
+		err := builder.InitWorkspace(workspace, map[string]string{"TEST_WORKSPACE_MSG": "from-runtime"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		v, err := builder.Build(workspace)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		b, err := builder.GetBundle(v)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(b.Name).To(Equal("test"))
+		g.Expect(b.Instances).To(HaveLen(1))
+		g.Expect(b.Instances[0].Module.Repository).To(Equal("file://" + filepath.Join(srcDir, "modules", "app")))
+	})
+
+	t.Run("isolates workspaces per cluster", func(t *testing.T) {
+		g := NewWithT(t)
+		for _, cluster := range []string{"east", "west"} {
+			err := builder.InitWorkspace(cluster, map[string]string{"TEST_WORKSPACE_MSG": cluster})
+			g.Expect(err).ToNot(HaveOccurred())
+		}
+		for _, cluster := range []string{"east", "west"} {
+			v, err := builder.Build(cluster)
+			g.Expect(err).ToNot(HaveOccurred())
+			msg, err := v.LookupPath(cue.ParsePath("bundle.instances.app.values.message")).String()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(msg).To(Equal(cluster))
+		}
+	})
+
+	t.Run("keeps a user file named schema.cue", func(t *testing.T) {
+		g := NewWithT(t)
+		userSchemaFile := filepath.Join(srcDir, "schema.cue")
+		userSchemaData := `
+bundle: instances: app: values: extra: "from-user-schema-file"
+`
+		g.Expect(os.WriteFile(userSchemaFile, []byte(userSchemaData), 0o644)).To(Succeed())
+
+		builder := NewBundleBuilder(ctx, []string{bundleFile, userSchemaFile})
+		workspace := "cluster-1"
+		err := builder.InitWorkspace(workspace, map[string]string{"TEST_WORKSPACE_MSG": "from-runtime"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		v, err := builder.Build(workspace)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		extra, err := v.LookupPath(cue.ParsePath("bundle.instances.app.values.extra")).String()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(extra).To(Equal("from-user-schema-file"))
+	})
+
+	t.Run("reports error positions relative to the workspace", func(t *testing.T) {
+		g := NewWithT(t)
+		workspace := "cluster-err"
+		err := builder.InitWorkspace(workspace, nil)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, err = builder.Build(workspace)
+		g.Expect(err).To(HaveOccurred())
+
+		details := cueerrors.Details(err, &cueerrors.Config{Cwd: builder.WorkspaceDir(workspace)})
+		g.Expect(details).To(ContainSubstring("0.bundle.cue"))
+		g.Expect(details).ToNot(ContainSubstring(builder.WorkspaceDir(workspace)))
 	})
 }

--- a/internal/engine/fetcher/fetcher.go
+++ b/internal/engine/fetcher/fetcher.go
@@ -54,10 +54,10 @@ func New(ctx context.Context, opts Options) (Fetcher, error) {
 	case strings.HasPrefix(opts.Source, apiv1.ArtifactPrefix):
 		return NewOCI(ctx, opts.Source, opts.Version, opts.Destination, opts.CacheDir, opts.Creds, opts.Insecure), nil
 	case strings.HasPrefix(opts.Source, apiv1.LocalPrefix):
-		return NewLocal(opts.Source, opts.Destination), nil
+		return NewLocal(opts.Source), nil
 	default:
 		if opts.DefaultLocal {
-			return NewLocal(opts.Source, opts.Destination), nil
+			return NewLocal(opts.Source), nil
 		}
 		return nil, fmt.Errorf("unsupported module source %s", opts.Source)
 	}

--- a/internal/engine/fetcher/local.go
+++ b/internal/engine/fetcher/local.go
@@ -29,31 +29,54 @@ import (
 
 type Local struct {
 	src           string
-	dst           string
+	root          string
+	rootErr       error
 	requiredFiles []string
 }
 
-// NewLocal creates a local Fetcher for the given module.
-func NewLocal(src, dst string) *Local {
+// NewLocal creates a local Fetcher for the given module source directory.
+// The source is resolved to an absolute path at construction time, so a
+// later working directory change does not alter which module is fetched.
+func NewLocal(src string) *Local {
 	src = strings.TrimPrefix(src, apiv1.LocalPrefix)
+	root, rootErr := filepath.Abs(src)
+	if rootErr != nil {
+		root = src
+	}
 	requiredFiles := []string{
-		path.Join(src, "cue.mod", "module.cue"),
-		path.Join(src, "timoni.cue"),
-		path.Join(src, "values.cue"),
+		path.Join(root, "cue.mod", "module.cue"),
+		path.Join(root, "timoni.cue"),
+		path.Join(root, "values.cue"),
 	}
 	return &Local{
 		src:           src,
-		dst:           dst,
+		root:          root,
+		rootErr:       rootErr,
 		requiredFiles: requiredFiles,
 	}
 }
 
+// GetModuleRoot returns the absolute path of the module source directory.
+// Local modules build in place: the CUE loader reads the imported files
+// lazily from the source directory and build errors carry the positions
+// of the files the user is editing.
 func (f *Local) GetModuleRoot() string {
-	return filepath.Join(f.dst, "module")
+	return f.root
 }
 
+// Fetch validates the module source directory and returns the module
+// reference. The module is not copied; instance values are injected at
+// build time as in-memory overlays, leaving the directory untouched.
 func (f *Local) Fetch() (*apiv1.ModuleReference, error) {
-	if fs, err := os.Stat(f.src); err != nil || !fs.IsDir() {
+	if f.src == "" {
+		return nil, fmt.Errorf("module not found at path %s", f.src)
+	}
+
+	if f.rootErr != nil {
+		return nil, fmt.Errorf("failed to resolve module path %s: %w", f.src, f.rootErr)
+	}
+
+	if fs, err := os.Stat(f.root); err != nil || !fs.IsDir() {
 		return nil, fmt.Errorf("module not found at path %s", f.src)
 	}
 
@@ -69,5 +92,5 @@ func (f *Local) Fetch() (*apiv1.ModuleReference, error) {
 		Digest:     "unknown",
 	}
 
-	return &mr, engine.CopyModule(f.src, f.GetModuleRoot())
+	return &mr, nil
 }

--- a/internal/engine/fetcher/local_test.go
+++ b/internal/engine/fetcher/local_test.go
@@ -17,16 +17,16 @@ limitations under the License.
 package fetcher
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/stefanprodan/timoni/internal/fscopy"
 	. "github.com/stefanprodan/timoni/internal/testutils"
 )
 
 func TestNewLocal(t *testing.T) {
 	g := NewWithT(t)
-	lf := NewLocal("src", "dst")
+	lf := NewLocal("src")
 
 	g.Expect(lf).ToNot(BeNil())
 	g.Expect(lf).To(Implement((*Fetcher)(nil)))
@@ -34,21 +34,30 @@ func TestNewLocal(t *testing.T) {
 
 func TestLocalGetModuleRoot(t *testing.T) {
 	g := NewWithT(t)
-	lf := NewLocal("src", "dst")
+	cwd, err := os.Getwd()
+	g.Expect(err).ToNot(HaveOccurred())
 
-	g.Expect(lf.GetModuleRoot()).To(Equal("dst/module"))
+	t.Run("resolves relative source", func(t *testing.T) {
+		g := NewWithT(t)
+		lf := NewLocal("src")
+
+		g.Expect(lf.GetModuleRoot()).To(Equal(filepath.Join(cwd, "src")))
+	})
+
+	t.Run("strips the file scheme", func(t *testing.T) {
+		g := NewWithT(t)
+		lf := NewLocal("file://src")
+
+		g.Expect(lf.GetModuleRoot()).To(Equal(filepath.Join(cwd, "src")))
+	})
 }
 
 func TestLocalFetch(t *testing.T) {
 	t.Run("nominal", func(t *testing.T) {
 		g := NewWithT(t)
-		src := filepath.Join(t.TempDir(), "src")
-		dst := filepath.Join(t.TempDir(), "dst")
-		testmod := "testdata/module"
+		src := "testdata/module"
 
-		g.Expect(fscopy.CopyDir(testmod, src, fscopy.Options{FollowSymlinks: true})).To(Succeed())
-
-		lf := NewLocal(src, dst)
+		lf := NewLocal(src)
 		mr, err := lf.Fetch()
 
 		g.Expect(err).To(BeNil())
@@ -56,12 +65,34 @@ func TestLocalFetch(t *testing.T) {
 		g.Expect(filepath.Join(lf.GetModuleRoot(), "cue.mod/module.cue")).To(BeARegularFile())
 	})
 
+	t.Run("builds in place without applying timoni.ignore", func(t *testing.T) {
+		g := NewWithT(t)
+		src := "testdata/module"
+
+		lf := NewLocal(src)
+		_, err := lf.Fetch()
+
+		g.Expect(err).To(BeNil())
+		g.Expect(filepath.Join(lf.GetModuleRoot(), "timoni.ignore")).To(BeARegularFile())
+		g.Expect(filepath.Join(lf.GetModuleRoot(), "ignore/ignore.txt")).To(BeARegularFile())
+	})
+
+	t.Run("resolves source at construction time", func(t *testing.T) {
+		g := NewWithT(t)
+		lf := NewLocal("testdata/module")
+		t.Chdir(t.TempDir())
+
+		mr, err := lf.Fetch()
+
+		g.Expect(err).To(BeNil())
+		g.Expect(mr.Repository).To(Equal("testdata/module"))
+	})
+
 	t.Run("lack of required files", func(t *testing.T) {
 		g := NewWithT(t)
 		src := t.TempDir()
-		dst := filepath.Join(t.TempDir(), "dst")
 
-		lf := NewLocal(src, dst)
+		lf := NewLocal(src)
 		_, err := lf.Fetch()
 
 		g.Expect(err).To(HaveOccurred())
@@ -70,7 +101,7 @@ func TestLocalFetch(t *testing.T) {
 
 	t.Run("non existent source", func(t *testing.T) {
 		g := NewWithT(t)
-		lf := NewLocal("", "dst")
+		lf := NewLocal("")
 		_, err := lf.Fetch()
 
 		g.Expect(err).To(HaveOccurred())

--- a/internal/engine/runtime_builder.go
+++ b/internal/engine/runtime_builder.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/ast"
@@ -35,9 +36,11 @@ import (
 
 // RuntimeBuilder compiles CUE definitions to Go Runtime objects.
 type RuntimeBuilder struct {
-	ctx             *cue.Context
-	files           []string
-	workspacesFiles map[string][]string
+	ctx               *cue.Context
+	files             []string
+	root              string
+	workspacesFiles   map[string][]string
+	workspacesSources map[string]map[string][]byte
 }
 
 // NewRuntimeBuilder creates a RuntimeBuilder for the given module and package.
@@ -46,17 +49,30 @@ func NewRuntimeBuilder(ctx *cue.Context, files []string) *RuntimeBuilder {
 		ctx = cuecontext.New()
 	}
 	b := &RuntimeBuilder{
-		ctx:             ctx,
-		files:           files,
-		workspacesFiles: make(map[string][]string),
+		ctx:               ctx,
+		files:             files,
+		root:              NewVirtualRoot(),
+		workspacesFiles:   make(map[string][]string),
+		workspacesSources: make(map[string]map[string][]byte),
 	}
 	return b
 }
 
-// InitWorkspace extracts the runtime definitions to the specified workspace.
-// A workspace must be initialised before calling Build.
+// WorkspaceDir returns the virtual directory under which the workspace
+// files are laid out. The directory does not exist on disk; it serves
+// as the base for rendering error positions relative.
+func (b *RuntimeBuilder) WorkspaceDir(workspace string) string {
+	return filepath.Join(b.root, workspace)
+}
+
+// InitWorkspace extracts the runtime definitions into the in-memory
+// workspace identified by the given name. Nothing is written to disk;
+// the workspace files are kept in memory and served to the CUE loader
+// as overlays. A workspace must be initialised before calling Build.
 func (b *RuntimeBuilder) InitWorkspace(workspace string) error {
 	var files []string
+	sources := make(map[string][]byte, len(b.files)+1)
+	workspaceDir := b.WorkspaceDir(workspace)
 	for i, file := range b.files {
 		_, fn := filepath.Split(file)
 		content, err := os.ReadFile(file)
@@ -90,31 +106,37 @@ func (b *RuntimeBuilder) InitWorkspace(workspace string) error {
 			return fmt.Errorf("failed to format node %s: %w", fn, err)
 		}
 
-		dstFile := filepath.Join(workspace, fmt.Sprintf("%v.%s.cue", i, fn))
-		if err := os.WriteFile(dstFile, data, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to write %s: %w", fn, err)
-		}
+		dstFile := filepath.Join(workspaceDir, fmt.Sprintf("%v.%s.cue", i, strings.TrimSuffix(fn, ".cue")))
+		sources[dstFile] = data
 
 		files = append(files, dstFile)
 	}
 
-	schemaFile := filepath.Join(workspace, fmt.Sprintf("%v.schema.cue", len(b.workspacesFiles[workspace])+1))
+	// The runtime files are indexed 0..len(files)-1, so naming the generated
+	// schema after len(files) cannot collide with a user file named schema.cue.
+	schemaFile := filepath.Join(workspaceDir, fmt.Sprintf("%v.schema.cue", len(b.files)))
 	files = append(files, schemaFile)
-	if err := os.WriteFile(schemaFile, []byte(apiv1.RuntimeSchema), os.ModePerm); err != nil {
-		return err
-	}
+	sources[schemaFile] = []byte(apiv1.RuntimeSchema)
 
 	b.workspacesFiles[workspace] = files
+	b.workspacesSources[workspace] = sources
 	return nil
 }
 
-// Build builds a CUE instance for the specified files and returns the CUE value.
+// Build builds a CUE instance for the specified workspace and returns the CUE value.
+// The workspace files are served to the CUE loader as in-memory overlays.
 // A workspace must be initialised with InitWorkspace before calling this function.
 func (b *RuntimeBuilder) Build(workspace string) (cue.Value, error) {
 	var value cue.Value
+	overlay := make(map[string]load.Source, len(b.workspacesSources[workspace]))
+	for f, data := range b.workspacesSources[workspace] {
+		overlay[f] = load.FromBytes(data)
+	}
+
 	cfg := &load.Config{
 		Package:   "_",
 		DataFiles: true,
+		Overlay:   overlay,
 	}
 
 	ix := load.Instances(b.workspacesFiles[workspace], cfg)

--- a/internal/engine/runtime_builder_test.go
+++ b/internal/engine/runtime_builder_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package engine
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"cuelang.org/go/cue/cuecontext"
@@ -143,4 +145,64 @@ runtime: {
 		Group:       "production",
 		KubeContext: "us-west-1:production",
 	}))
+}
+
+func TestRuntimeBuilderWorkspace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	srcDir := t.TempDir()
+	runtimeFile := filepath.Join(srcDir, "runtime.cue")
+	runtimeData := `
+runtime: {
+	apiVersion: "v1alpha1"
+	name:       "fleet"
+	clusters: {
+		"staging": {
+			group:       "staging"
+			kubeContext: "eu-central-1:staging"
+		}
+	}
+}
+`
+	g.Expect(os.WriteFile(runtimeFile, []byte(runtimeData), 0o644)).To(Succeed())
+
+	builder := NewRuntimeBuilder(ctx, []string{runtimeFile})
+
+	workspace := apiv1.RuntimeDefaultName
+	g.Expect(builder.InitWorkspace(workspace)).To(Succeed())
+
+	_, err := os.Lstat(builder.WorkspaceDir(workspace))
+	g.Expect(err).To(MatchError(os.ErrNotExist))
+
+	v, err := builder.Build(workspace)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	rt, err := builder.GetRuntime(v)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(rt.Name).To(Equal("fleet"))
+	g.Expect(rt.Clusters).To(HaveLen(1))
+	g.Expect(rt.Clusters[0].KubeContext).To(Equal("eu-central-1:staging"))
+
+	t.Run("keeps a user file named schema.cue", func(t *testing.T) {
+		g := NewWithT(t)
+		userSchemaFile := filepath.Join(srcDir, "schema.cue")
+		userSchemaData := `
+runtime: clusters: "production": {
+	group:       "production"
+	kubeContext: "eu-central-1:production"
+}
+`
+		g.Expect(os.WriteFile(userSchemaFile, []byte(userSchemaData), 0o644)).To(Succeed())
+
+		builder := NewRuntimeBuilder(ctx, []string{runtimeFile, userSchemaFile})
+		g.Expect(builder.InitWorkspace(workspace)).To(Succeed())
+
+		v, err := builder.Build(workspace)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		rt, err := builder.GetRuntime(v)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rt.Clusters).To(HaveLen(2))
+	})
 }

--- a/internal/engine/virtual_root.go
+++ b/internal/engine/virtual_root.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+)
+
+// NewVirtualRoot returns an OS-native absolute path that does not exist
+// on the host filesystem and is never created, for use as the root
+// directory of CUE loads backed entirely by load.Config.Overlay.
+// Overlay entries shadow the host filesystem but paths without an entry
+// fall through to it, so the root must be guaranteed absent from disk.
+func NewVirtualRoot() string {
+	base := os.TempDir()
+	if abs, err := filepath.Abs(base); err == nil {
+		base = abs
+	}
+	for {
+		root := filepath.Join(base, fmt.Sprintf("timoni-vfs-%016x", rand.Uint64()))
+		// Accept the candidate on any Lstat error: a path that cannot be
+		// inspected cannot be read by the loader fallthrough either.
+		if _, err := os.Lstat(root); err != nil {
+			return root
+		}
+	}
+}

--- a/internal/engine/virtual_root_test.go
+++ b/internal/engine/virtual_root_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewVirtualRoot(t *testing.T) {
+	g := NewWithT(t)
+
+	root := NewVirtualRoot()
+	g.Expect(filepath.IsAbs(root)).To(BeTrue())
+	_, err := os.Lstat(root)
+	g.Expect(err).To(MatchError(os.ErrNotExist))
+
+	t.Run("absolute with relative TMPDIR", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("TMPDIR", ".")
+
+		root := NewVirtualRoot()
+		g.Expect(filepath.IsAbs(root)).To(BeTrue())
+		_, err := os.Lstat(root)
+		g.Expect(err).To(MatchError(os.ErrNotExist))
+	})
+}


### PR DESCRIPTION
Assemble bundle and runtime workspaces in an in-memory CUE loader overlay instead of writing them to a temp dir, so values read from the cluster (e.g. Kubernetes Secrets) never touch disk.

As a follow-up optimization to #601, which made instance values injected in-memory instead of written into the module, local modules are now built in place from the source directory rather than copied to a temp dir.