### PR TITLE
feat(oci): opt-in symlink resolution when pushing artifacts

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
         run: make install
       - name: Push module
         run: |
-          timoni mod push ./examples/minimal oci://localhost:5000/minimal -v 1.0.0 --latest
+          timoni mod push ./examples/minimal oci://localhost:5000/minimal -v 1.0.0 --latest --resolve-symlinks
       - name: Install module
         run: |
           timoni -n test apply nginx oci://localhost:5000/minimal
@@ -86,7 +86,7 @@ jobs:
         run: make install
       - name: Push module
         run: |
-          timoni mod push ./blueprints/starter ${NGINX_MODULE_URL} -v 1.0.0 --latest
+          timoni mod push ./blueprints/starter ${NGINX_MODULE_URL} -v 1.0.0 --latest --resolve-symlinks
       - name: Vet bundle
         run: |
           timoni bundle vet -f hack/tests/nginx_bundle.cue --runtime-from-env

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Push blueprint starter
         run: |
           timoni mod push ./blueprints/starter oci://ghcr.io/stefanprodan/timoni/blueprints/starter \
-          -v ${{ github.event.inputs.version }} --latest \
+          -v ${{ github.event.inputs.version }} --latest --resolve-symlinks \
           -a 'org.opencontainers.image.licenses=Apache-2.0' \
           -a 'org.opencontainers.image.source=https://github.com/stefanprodan/timoni'  \
           -a 'org.opencontainers.image.description=Get started blueprint for timoni.sh modules.' \
@@ -41,7 +41,7 @@ jobs:
       - name: Push minimal module
         run: |
           timoni mod push ./examples/minimal oci://ghcr.io/stefanprodan/timoni/minimal \
-          -v ${{ github.event.inputs.version }} --latest \
+          -v ${{ github.event.inputs.version }} --latest --resolve-symlinks \
           -a 'org.opencontainers.image.licenses=Apache-2.0' \
           -a 'org.opencontainers.image.source=https://github.com/stefanprodan/timoni' \
           -a 'org.opencontainers.image.description=A minimal timoni.sh module.' \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Push minimal module
         run: |
           timoni mod push ./examples/minimal oci://ghcr.io/stefanprodan/timoni/minimal \
-          -v ${{ steps.info.outputs.version }} --latest \
+          -v ${{ steps.info.outputs.version }} --latest --resolve-symlinks \
           -a 'org.opencontainers.image.licenses=Apache-2.0' \
           -a 'org.opencontainers.image.source=https://github.com/stefanprodan/timoni'  \
           -a 'org.opencontainers.image.description=A minimal timoni.sh module.' \
@@ -90,7 +90,7 @@ jobs:
       - name: Push blueprint starter
         run: |
           timoni mod push ./blueprints/starter oci://ghcr.io/stefanprodan/timoni/blueprints/starter \
-          -v ${{ steps.info.outputs.version }} --latest \
+          -v ${{ steps.info.outputs.version }} --latest --resolve-symlinks \
           -a 'org.opencontainers.image.licenses=Apache-2.0' \
           -a 'org.opencontainers.image.source=https://github.com/stefanprodan/timoni'  \
           -a 'org.opencontainers.image.description=Get started blueprint for timoni.sh modules.' \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ cue-vet: build ## Vet and fmt CUE files.
 
 REDIS_VER=$(shell grep 'tag:' examples/redis/values.cue | awk '{ print $$2 }' | tr -d '"' | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
 push-redis: build
-	./bin/timoni mod push ./examples/redis oci://ghcr.io/stefanprodan/modules/redis -v $(REDIS_VER) --latest \
+	./bin/timoni mod push ./examples/redis oci://ghcr.io/stefanprodan/modules/redis -v $(REDIS_VER) --latest --resolve-symlinks \
 		-a 'org.opencontainers.image.source=https://github.com/stefanprodan/timoni/tree/main/examples/redis'  \
 		-a 'org.opencontainers.image.description=A timoni.sh module for deploying Redis master-replica clusters.' \
 		-a 'org.opencontainers.image.documentation=https://github.com/stefanprodan/timoni/blob/main/examples/redis/README.md'

--- a/cmd/timoni/apply_test.go
+++ b/cmd/timoni/apply_test.go
@@ -194,7 +194,7 @@ func TestApply_WithDigest(t *testing.T) {
 
 	// Push the module to registry
 	pushOut, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s -o json",
+		"mod push %s oci://%s -v %s -o json --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -265,7 +265,7 @@ func TestApply_WithBundleConflicts(t *testing.T) {
 
 	// Push the module to registry
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -50,6 +51,10 @@ the ignore rules will be used to exclude files from the artifact.`,
 	--annotation="org.opencontainers.image.revision=$(git rev-parse HEAD)' \
 	--content-type="timoni.sh/bundles"
 
+  # Push a dir contents including the targets of the symbolic links it contains
+  timoni artifact push oci://docker.io/org/app -t latest -f ./path/to/dir \
+	--resolve-symlinks
+
   # Push and sign with Cosign (the cosign binary must be present in PATH)
   echo $GITHUB_TOKEN | timoni registry login ghcr.io -u timoni --password-stdin
   export COSIGN_PASSWORD=password
@@ -63,14 +68,15 @@ the ignore rules will be used to exclude files from the artifact.`,
 }
 
 type pushArtifactFlags struct {
-	path        string
-	creds       flags.Credentials
-	ignorePaths []string
-	tags        []string
-	annotations []string
-	contentType string
-	sign        string
-	cosignKey   string
+	path            string
+	creds           flags.Credentials
+	ignorePaths     []string
+	tags            []string
+	annotations     []string
+	contentType     string
+	resolveSymlinks bool
+	sign            string
+	cosignKey       string
 }
 
 var pushArtifactArgs pushArtifactFlags
@@ -85,6 +91,8 @@ func init() {
 		"Annotation in the format '<key>=<value>'.")
 	pushArtifactCmd.Flags().StringVar(&pushArtifactArgs.contentType, "content-type", "generic",
 		"The content type of this artifact.")
+	pushArtifactCmd.Flags().BoolVar(&pushArtifactArgs.resolveSymlinks, "resolve-symlinks", false,
+		"Resolve symbolic links and package their targets as regular files and directories.")
 	pushArtifactCmd.Flags().StringVar(&pushArtifactArgs.sign, "sign", "",
 		"Signs the module with the specified provider.")
 	pushArtifactCmd.Flags().StringVar(&pushArtifactArgs.cosignKey, "cosign-key", "",
@@ -145,13 +153,37 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	}
 	oci.AppendGitMetadata(cmd.Context(), pushArtifactArgs.path, annotations)
 
+	// When symlink resolution is enabled, stage the directory in a temp dir
+	// so that the artifact contains the symlink targets as regular files
+	// and directories, since the archiver skips symbolic links.
+	contentPath := pushArtifactArgs.path
+	if pushArtifactArgs.resolveSymlinks {
+		if fi.IsDir() {
+			tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+			if err != nil {
+				return err
+			}
+			defer os.RemoveAll(tmpDir)
+
+			contentPath = filepath.Join(tmpDir, "artifact")
+			if err := engine.CopyDir(pushArtifactArgs.path, contentPath, true); err != nil {
+				return err
+			}
+		} else {
+			contentPath, err = filepath.EvalSymlinks(contentPath)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	spin := logger.StartSpinner("pushing artifact")
 	defer spin.Stop()
 
 	opts := oci.Options(ctx, pushArtifactArgs.creds.String(), rootArgs.registryInsecure)
 	ociURL := fmt.Sprintf("%s:%s", args[0], pushArtifactArgs.tags[0])
 	digestURL, err := oci.PushArtifact(ociURL,
-		pushArtifactArgs.path,
+		contentPath,
 		pushArtifactArgs.ignorePaths,
 		pushArtifactArgs.contentType,
 		annotations,

--- a/cmd/timoni/artifact_push_test.go
+++ b/cmd/timoni/artifact_push_test.go
@@ -18,6 +18,9 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -78,6 +81,48 @@ func Test_PushArtifact(t *testing.T) {
 	g.Expect(len(manifest.Layers)).To(BeEquivalentTo(1))
 	g.Expect(manifest.Layers[0].MediaType).To(BeEquivalentTo(apiv1.ContentMediaType))
 	g.Expect(manifest.Layers[0].Annotations[apiv1.ContentTypeAnnotation]).To(BeEquivalentTo("generic"))
+}
+
+func Test_PushArtifact_Symlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	g := NewWithT(t)
+
+	// Create a dir with a relative symlink to a file living outside of it.
+	tmpDir := t.TempDir()
+	aPath := filepath.Join(tmpDir, "artifact")
+	g.Expect(os.MkdirAll(aPath, 0o755)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(aPath, "main.cue"), []byte("main"), 0o644)).To(Succeed())
+	sharedFile := filepath.Join(tmpDir, "shared", "extra.cue")
+	g.Expect(os.MkdirAll(filepath.Dir(sharedFile), 0o755)).To(Succeed())
+	g.Expect(os.WriteFile(sharedFile, []byte("extra"), 0o644)).To(Succeed())
+	g.Expect(os.Symlink(filepath.Join("..", "shared", "extra.cue"),
+		filepath.Join(aPath, "extra.cue"))).To(Succeed())
+
+	aURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-artifact", 5))
+
+	// By default the symlinked file is left out of the artifact.
+	_, err := executeCommand(fmt.Sprintf("artifact push oci://%s -f %s -t skip --content-type=generic", aURL, aPath))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	pullDir := filepath.Join(t.TempDir(), "skip")
+	g.Expect(os.MkdirAll(pullDir, 0o755)).To(Succeed())
+	_, err = executeCommand(fmt.Sprintf("artifact pull oci://%s:skip -o %s", aURL, pullDir))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(filepath.Join(pullDir, "main.cue")).To(BeARegularFile())
+	g.Expect(filepath.Join(pullDir, "extra.cue")).ToNot(BeAnExistingFile())
+
+	// With the opt-in, the symlinked file is materialized in the artifact.
+	_, err = executeCommand(fmt.Sprintf("artifact push oci://%s -f %s -t resolve --content-type=generic --resolve-symlinks", aURL, aPath))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	pullDir = filepath.Join(t.TempDir(), "resolve")
+	g.Expect(os.MkdirAll(pullDir, 0o755)).To(Succeed())
+	_, err = executeCommand(fmt.Sprintf("artifact pull oci://%s:resolve -o %s", aURL, pullDir))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(filepath.Join(pullDir, "main.cue")).To(BeARegularFile())
+	g.Expect(filepath.Join(pullDir, "extra.cue")).To(BeARegularFile())
 }
 
 func TestPushArtifactRejectsInvalidTagsBeforeInput(t *testing.T) {

--- a/cmd/timoni/build_test.go
+++ b/cmd/timoni/build_test.go
@@ -250,7 +250,7 @@ func TestBuild_WithDigest(t *testing.T) {
 
 	// Push the module to registry
 	pushOut, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s -o json",
+		"mod push %s oci://%s -v %s -o json --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,

--- a/cmd/timoni/bundle_apply_test.go
+++ b/cmd/timoni/bundle_apply_test.go
@@ -47,7 +47,7 @@ func Test_BundleApply(t *testing.T) {
 
 	// Push the module to registry
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -287,7 +287,7 @@ func Test_BundleApply_Digest(t *testing.T) {
 	modVer2 := "2.0.0"
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer1,
@@ -298,7 +298,7 @@ func Test_BundleApply_Digest(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	_, err = executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s --latest",
+		"mod push %s oci://%s -v %s --latest --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer2,
@@ -446,7 +446,7 @@ func Test_BundleApply_Runtime(t *testing.T) {
 
 	// Push the module to registry
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -786,7 +786,7 @@ func Test_FetchBundleInstanceModule_Cache(t *testing.T) {
 	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
 
 	for _, v := range []string{"1.0.0", "1.1.0"} {
-		_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s", modPath, modURL, v))
+		_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s --resolve-symlinks", modPath, modURL, v))
 		g.Expect(err).ToNot(HaveOccurred())
 	}
 
@@ -847,7 +847,7 @@ func Test_BundleApply_Runtime_ModuleVersionPerCluster(t *testing.T) {
 	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
 
 	for _, v := range []string{"1.0.0", "2.0.0"} {
-		_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s", modPath, modURL, v))
+		_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s --resolve-symlinks", modPath, modURL, v))
 		g.Expect(err).ToNot(HaveOccurred())
 	}
 

--- a/cmd/timoni/bundle_build_test.go
+++ b/cmd/timoni/bundle_build_test.go
@@ -26,7 +26,7 @@ func Test_BundleBuild(t *testing.T) {
 
 	// Push the module to registry
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -168,7 +168,7 @@ bundle: {
 	cuePath := filepath.Join(wd, "bundle.cue")
 	g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
 
-	err := engine.CopyModule(modPath, filepath.Join(wd, modPath))
+	err := engine.CopyDir(modPath, filepath.Join(wd, modPath), true)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	output, err := executeCommand(fmt.Sprintf(
@@ -203,7 +203,7 @@ func Test_BundleBuild_Runtime(t *testing.T) {
 	modVer := "1.0.0"
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -328,7 +328,7 @@ bundle: {
 			wd := t.TempDir()
 			cuePath := filepath.Join(wd, "bundle.cue")
 			g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
-			g.Expect(engine.CopyModule("testdata/module", filepath.Join(wd, "testdata/module"))).ToNot(HaveOccurred())
+			g.Expect(engine.CopyDir("testdata/module", filepath.Join(wd, "testdata/module"), true)).ToNot(HaveOccurred())
 
 			_, err := executeCommand(fmt.Sprintf("bundle build -f %s -p main", cuePath))
 			g.Expect(err).To(HaveOccurred())
@@ -371,7 +371,7 @@ bundle: {
 	wd := t.TempDir()
 	cuePath := filepath.Join(wd, "bundle.cue")
 	g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
-	g.Expect(engine.CopyModule(modPath, filepath.Join(wd, modPath))).ToNot(HaveOccurred())
+	g.Expect(engine.CopyDir(modPath, filepath.Join(wd, modPath), true)).ToNot(HaveOccurred())
 
 	outDir := filepath.Join(wd, "out")
 	_, err := executeCommand(fmt.Sprintf(
@@ -443,7 +443,7 @@ bundle: {
 	wd := t.TempDir()
 	cuePath := filepath.Join(wd, "bundle.cue")
 	g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
-	g.Expect(engine.CopyModule(modPath, filepath.Join(wd, modPath))).ToNot(HaveOccurred())
+	g.Expect(engine.CopyDir(modPath, filepath.Join(wd, modPath), true)).ToNot(HaveOccurred())
 
 	outDir := filepath.Join(wd, "out")
 	_, err := executeCommand(fmt.Sprintf(
@@ -535,7 +535,7 @@ func Test_BundleBuild_Concurrency(t *testing.T) {
 	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
 	modVer := "1.0.0"
 
-	_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s", modPath, modURL, modVer))
+	_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s --resolve-symlinks", modPath, modURL, modVer))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	const numInstances = 6

--- a/cmd/timoni/bundle_delete_test.go
+++ b/cmd/timoni/bundle_delete_test.go
@@ -48,7 +48,7 @@ func Test_BundleDelete(t *testing.T) {
 	modVer := "1.0.0"
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -118,7 +118,7 @@ func Test_BundleDelete_MultiNamespace(t *testing.T) {
 	modVer := "1.0.0"
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -200,7 +200,7 @@ func Test_BundleDelete_Runtime(t *testing.T) {
 	modVer := "1.0.0"
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,

--- a/cmd/timoni/bundle_status_test.go
+++ b/cmd/timoni/bundle_status_test.go
@@ -40,7 +40,7 @@ func Test_BundleStatus(t *testing.T) {
 	modVer := "1.0.0"
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -137,7 +137,7 @@ func Test_BundleStatus_Images(t *testing.T) {
 	modVer := "1.0.0"
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -185,7 +185,7 @@ func Test_BundleStatus_Runtime(t *testing.T) {
 	modVer := "1.0.0"
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,

--- a/cmd/timoni/inspect_test.go
+++ b/cmd/timoni/inspect_test.go
@@ -40,7 +40,7 @@ func TestInspect(t *testing.T) {
 
 	// Package the module as an OCI artifact and push it to registry
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s %s -v %s -a org.opencontainers.image.licenses=%s",
+		"mod push %s %s -v %s -a org.opencontainers.image.licenses=%s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -115,7 +115,7 @@ func TestInspect_Latest(t *testing.T) {
 
 	// Package the module as an OCI artifact and push it to registry
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s %s -v %s --latest",
+		"mod push %s %s -v %s --latest --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,
@@ -154,7 +154,7 @@ func TestInspect_StorageType(t *testing.T) {
 	namespace := rnd("my-namespace", 5)
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s %s -v %s --latest",
+		"mod push %s %s -v %s --latest --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,

--- a/cmd/timoni/mod_list_test.go
+++ b/cmd/timoni/mod_list_test.go
@@ -33,7 +33,7 @@ func Test_ListMod(t *testing.T) {
 
 	for _, v := range modVers {
 		_, err := executeCommand(fmt.Sprintf(
-			"mod push %s oci://%s -v %s --latest",
+			"mod push %s oci://%s -v %s --latest --resolve-symlinks",
 			modPath,
 			modURL,
 			v,

--- a/cmd/timoni/mod_pull_test.go
+++ b/cmd/timoni/mod_pull_test.go
@@ -35,7 +35,7 @@ func Test_PullMod(t *testing.T) {
 
 	// Package the module as an OCI artifact and push it to registry
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -53,6 +53,11 @@ container registry using the version as the image tag.`,
 	--version=2.0.0-rc.1 \
 	--latest=false
 
+  # Push a module that shares files with other modules using symbolic links
+  timoni mod push ./path/to/module oci://docker.io/org/app-module \
+	--version=1.0.0 \
+	--resolve-symlinks
+
   # Push a module with custom OCI annotations
   timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
 	--version=1.0.0 \
@@ -78,15 +83,16 @@ container registry using the version as the image tag.`,
 }
 
 type pushModFlags struct {
-	module      string
-	version     flags.Version
-	latest      bool
-	creds       flags.Credentials
-	ignorePaths []string
-	output      string
-	annotations []string
-	sign        string
-	cosignKey   string
+	module          string
+	version         flags.Version
+	latest          bool
+	creds           flags.Credentials
+	ignorePaths     []string
+	output          string
+	annotations     []string
+	resolveSymlinks bool
+	sign            string
+	cosignKey       string
 }
 
 var pushModArgs pushModFlags
@@ -100,6 +106,8 @@ func init() {
 		"Set custom OCI annotations in the format '<key>=<value>'.")
 	pushModCmd.Flags().StringVarP(&pushModArgs.output, "output", "o", "",
 		"The format in which the artifact digest should be printed, can be 'yaml' or 'json'.")
+	pushModCmd.Flags().BoolVar(&pushModArgs.resolveSymlinks, "resolve-symlinks", false,
+		"Resolve symbolic links and package their targets as regular files and directories.")
 	pushModCmd.Flags().StringVar(&pushModArgs.sign, "sign", "",
 		"Signs the module with the specified provider.")
 	pushModCmd.Flags().StringVar(&pushModArgs.cosignKey, "cosign-key", "",
@@ -158,10 +166,10 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 
 	// When symlink resolution is enabled, stage the module in a temp dir
 	// so that the artifact contains the resolved file set local builds
-	// see. With TIMONI_FOLLOW_SYMLINKS=false the archiver skips symlinks
-	// by itself, so the module is packaged straight from its source dir.
+	// see. Without it the archiver skips symlinks by itself, so the
+	// module is packaged straight from its source dir.
 	moduleDir := pushModArgs.module
-	if engine.FollowSymlinks() {
+	if pushModArgs.resolveSymlinks {
 		tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
 		if err != nil {
 			return err
@@ -169,7 +177,7 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 		defer os.RemoveAll(tmpDir)
 
 		moduleDir = path.Join(tmpDir, "module")
-		if err := engine.CopyModule(pushModArgs.module, moduleDir); err != nil {
+		if err := engine.CopyDir(pushModArgs.module, moduleDir, true); err != nil {
 			return err
 		}
 	}

--- a/cmd/timoni/mod_push_test.go
+++ b/cmd/timoni/mod_push_test.go
@@ -118,27 +118,26 @@ func Test_PushMod_Symlinks(t *testing.T) {
 	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
 	modVer := "1.0.0"
 
-	// By default the symlinked file is materialized in the artifact.
+	// By default the symlinked file is left out of the artifact.
 	_, err := executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s", modPath, modURL, modVer))
 	g.Expect(err).ToNot(HaveOccurred())
 
-	pullDir := filepath.Join(t.TempDir(), "follow")
-	g.Expect(os.MkdirAll(pullDir, 0o755)).To(Succeed())
-	_, err = executeCommand(fmt.Sprintf("mod pull oci://%s -v %s -o %s", modURL, modVer, pullDir))
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(filepath.Join(pullDir, "extra.txt")).To(BeARegularFile())
-
-	// With the opt-out, the symlinked file is left out of the artifact.
-	t.Setenv("TIMONI_FOLLOW_SYMLINKS", "false")
-	modVer = "1.0.1"
-	_, err = executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s", modPath, modURL, modVer))
-	g.Expect(err).ToNot(HaveOccurred())
-
-	pullDir = filepath.Join(t.TempDir(), "skip")
+	pullDir := filepath.Join(t.TempDir(), "skip")
 	g.Expect(os.MkdirAll(pullDir, 0o755)).To(Succeed())
 	_, err = executeCommand(fmt.Sprintf("mod pull oci://%s -v %s -o %s", modURL, modVer, pullDir))
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(filepath.Join(pullDir, "extra.txt")).ToNot(BeAnExistingFile())
+
+	// With the opt-in, the symlinked file is materialized in the artifact.
+	modVer = "1.0.1"
+	_, err = executeCommand(fmt.Sprintf("mod push %s oci://%s -v %s --resolve-symlinks", modPath, modURL, modVer))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	pullDir = filepath.Join(t.TempDir(), "resolve")
+	g.Expect(os.MkdirAll(pullDir, 0o755)).To(Succeed())
+	_, err = executeCommand(fmt.Sprintf("mod pull oci://%s -v %s -o %s", modURL, modVer, pullDir))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(filepath.Join(pullDir, "extra.txt")).To(BeARegularFile())
 }
 
 func Test_PushModRejectsBuildMetadataVersion(t *testing.T) {

--- a/cmd/timoni/status_test.go
+++ b/cmd/timoni/status_test.go
@@ -37,7 +37,7 @@ func TestInstanceStatus(t *testing.T) {
 
 	// Package the module as an OCI artifact and push it to registry
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s %s -v %s",
+		"mod push %s %s -v %s --resolve-symlinks",
 		modPath,
 		modURL,
 		modVer,

--- a/docs/cue/module/publishing.md
+++ b/docs/cue/module/publishing.md
@@ -133,31 +133,32 @@ debug_values.cue
 
 ### Symbolic links
 
-When packaging a module, Timoni resolves symbolic links and includes
-their targets in the artifact as regular files and directories.
+When packaging a module, Timoni skips symbolic links by default.
+To include the link targets in the artifact as regular files and
+directories, run `timoni mod push` with the `--resolve-symlinks` flag:
+
+```shell
+timoni mod push ./path/to/module oci://docker.io/org/app-module \
+  --version=1.0.0 \
+  --resolve-symlinks
+```
+
 This allows sharing files between modules in a monorepo, for example
 by symlinking the vendored CUE schemas under `cue.mod/gen`.
 
 The `timoni.ignore` rules apply to the resolved content at its
 in-module path, the same as for regular files and directories.
 
-When building a module from a local path, `timoni build`, `timoni apply`
-and `timoni mod vet` read the module files in place from the source
-directory, following symbolic links the same way.
+The `timoni artifact push` command takes the same flag for packaging
+the symlink targets found in the pushed directory.
 
-To opt out of symlink resolution when packaging, set the
-`TIMONI_FOLLOW_SYMLINKS=false` env var, in which case symbolic links
-are skipped.
+!!! tip "Local modules"
 
-!!! warning "Symlinks in CI"
-
-    Symlink resolution follows links to any file readable by the user
-    running Timoni, including files outside the module directory and the
-    repository. When running `timoni mod push` in CI for repositories that
-    accept contributions from untrusted parties, a pull request could add
-    a symlink to a file on the CI runner, e.g. a credentials file, and get
-    it published inside the module artifact. In such pipelines, set
-    `TIMONI_FOLLOW_SYMLINKS=false` to skip symbolic links altogether.
+    When building a module from a local path, `timoni build`, `timoni apply`
+    and `timoni mod vet` read the module files in place from the source
+    directory, following symbolic links the same way as the operating system.
+    Note that a module which relies on symlinked files builds locally but
+    is published incomplete unless pushed with `--resolve-symlinks`.
 
 ## Listing module versions
 

--- a/internal/engine/module_builder_test.go
+++ b/internal/engine/module_builder_test.go
@@ -33,7 +33,7 @@ func TestModuleBuilder(t *testing.T) {
 	g := NewWithT(t)
 	moduleRoot := path.Join(t.TempDir(), "module")
 
-	err := CopyModule("testdata/module", moduleRoot)
+	err := CopyDir("testdata/module", moduleRoot, true)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	ctx := cuecontext.New()
@@ -69,7 +69,7 @@ func TestModuleBuilder_InvalidValues(t *testing.T) {
 	g := NewWithT(t)
 	moduleRoot := path.Join(t.TempDir(), "module")
 
-	err := CopyModule("testdata/module-invalid", moduleRoot)
+	err := CopyDir("testdata/module-invalid", moduleRoot, true)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	ctx := cuecontext.New()
@@ -89,7 +89,7 @@ func TestModuleBuilder_GetDefaultValuesPrefersOverlay(t *testing.T) {
 	g := NewWithT(t)
 	moduleRoot := path.Join(t.TempDir(), "module")
 
-	err := CopyModule("testdata/module", moduleRoot)
+	err := CopyDir("testdata/module", moduleRoot, true)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	mb := NewModuleBuilder(cuecontext.New(), "test-name", "test-namespace", moduleRoot, "main")
@@ -110,7 +110,7 @@ func TestModuleBuilder_OverlayKeepsModuleDirUnchanged(t *testing.T) {
 	g := NewWithT(t)
 	moduleRoot := path.Join(t.TempDir(), "module")
 
-	err := CopyModule("testdata/module", moduleRoot)
+	err := CopyDir("testdata/module", moduleRoot, true)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	valuesFile := path.Join(moduleRoot, "values.cue")

--- a/internal/engine/utils.go
+++ b/internal/engine/utils.go
@@ -51,22 +51,14 @@ func GetEnv() map[string]string {
 	return vars
 }
 
-// FollowSymlinks reports whether symbolic links should be resolved
-// when copying modules, which is the default behavior unless the
-// TIMONI_FOLLOW_SYMLINKS env var is set to false.
-func FollowSymlinks() bool {
-	return os.Getenv("TIMONI_FOLLOW_SYMLINKS") != "false"
-}
-
-// CopyModule copies the given module to the destination directory,
+// CopyDir copies the given directory to the destination directory,
 // while excluding files that match the timoni.ignore patterns.
-// Symbolic links are resolved and their targets copied in place of
-// the links, unless FollowSymlinks reports false,
-// in which case symlinks are skipped.
-func CopyModule(srcDir string, dstDir string) (err error) {
+// When resolveSymlinks is true, symbolic links are resolved and their
+// targets copied in place of the links, otherwise symlinks are skipped.
+func CopyDir(srcDir string, dstDir string, resolveSymlinks bool) (err error) {
 	// The ignore matcher domain must be built from the same form of the
 	// source path that fscopy passes to the Skip callback: absolute, and
-	// fully resolved when following symlinks.
+	// fully resolved when resolving symlinks.
 	srcDir, err = filepath.Abs(srcDir)
 	if err != nil {
 		return err
@@ -85,7 +77,7 @@ func CopyModule(srcDir string, dstDir string) (err error) {
 	matcher := sourceignore.NewMatcher(ps)
 
 	opt := fscopy.Options{
-		FollowSymlinks: FollowSymlinks(),
+		FollowSymlinks: resolveSymlinks,
 		Skip: func(src string, isDir bool) bool {
 			return matcher.Match(strings.Split(src, string(filepath.Separator)), isDir)
 		},

--- a/internal/engine/utils_test.go
+++ b/internal/engine/utils_test.go
@@ -31,11 +31,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCopyModule_Ignore(t *testing.T) {
+func TestCopyDir_Ignore(t *testing.T) {
 	g := NewWithT(t)
 	moduleRoot := path.Join(t.TempDir(), "module")
 
-	err := CopyModule("testdata/module", moduleRoot)
+	err := CopyDir("testdata/module", moduleRoot, true)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Walk the original module and check that all files exist in tmp excluding ignored
@@ -61,7 +61,7 @@ func TestCopyModule_Ignore(t *testing.T) {
 	g.Expect(fsErr).ToNot(HaveOccurred())
 }
 
-func TestCopyModule_Symlinks(t *testing.T) {
+func TestCopyDir_Symlinks(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires privileges on Windows")
 	}
@@ -80,23 +80,22 @@ func TestCopyModule_Symlinks(t *testing.T) {
 		return srcDir
 	}
 
-	t.Run("resolves symlinks by default", func(t *testing.T) {
+	t.Run("resolves symlinks on opt-in", func(t *testing.T) {
 		g := NewWithT(t)
 		srcDir := makeModule(t)
 		dstDir := filepath.Join(t.TempDir(), "module")
 
-		g.Expect(CopyModule(srcDir, dstDir)).To(Succeed())
+		g.Expect(CopyDir(srcDir, dstDir, true)).To(Succeed())
 
 		g.Expect(filepath.Join(dstDir, "schema.cue")).To(BeARegularFile())
 	})
 
-	t.Run("skips symlinks on opt-out", func(t *testing.T) {
+	t.Run("skips symlinks by default", func(t *testing.T) {
 		g := NewWithT(t)
-		t.Setenv("TIMONI_FOLLOW_SYMLINKS", "false")
 		srcDir := makeModule(t)
 		dstDir := filepath.Join(t.TempDir(), "module")
 
-		g.Expect(CopyModule(srcDir, dstDir)).To(Succeed())
+		g.Expect(CopyDir(srcDir, dstDir, false)).To(Succeed())
 
 		g.Expect(filepath.Join(dstDir, "schema.cue")).ToNot(BeAnExistingFile())
 	})
@@ -120,7 +119,7 @@ func TestCopyModule_Symlinks(t *testing.T) {
 			[]byte("dropped/\nlinked/secret.txt\n"), 0o644)).To(Succeed())
 
 		dstDir := filepath.Join(t.TempDir(), "module")
-		g.Expect(CopyModule(srcDir, dstDir)).To(Succeed())
+		g.Expect(CopyDir(srcDir, dstDir, true)).To(Succeed())
 
 		g.Expect(filepath.Join(dstDir, "linked", "keep.txt")).To(BeARegularFile())
 		g.Expect(filepath.Join(dstDir, "linked", "secret.txt")).ToNot(BeAnExistingFile())


### PR DESCRIPTION
Add a `--resolve-symlinks` flag (defaults to false) to `timoni mod push` and `timoni artifact push`.

With #602 local modules are built in-place so symlinks for local module dev work by default. The symlink resolution is only need when publishing modules to the registry to make the Timoni module artifact self-contained. This PR supersedes #594 replacing the env var with an explicit command flag. xref #467
