### PR TITLE
ci(release): Migrate to GoReleaser v2 and attest release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,14 +14,16 @@ jobs:
       version: ${{ steps.hash.outputs.version }}
     runs-on: ubuntu-latest
     permissions:
+      artifact-metadata: write
+      attestations: write
       contents: write
       id-token: write
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -29,15 +31,22 @@ jobs:
           cache: false
       - name: Setup Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - name: Version info
+        id: ver
+        run: |
+          echo "SEMVER=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - name: Run GoReleaser
         id: run-goreleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: latest
-          args: release --skip=validate
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
+      - name: Attest release assets
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-checksums: '${{ github.workspace }}/dist/${{ github.event.repository.name }}_${{ steps.ver.outputs.SEMVER }}_checksums.txt'
       - name: Generate SLSA subject
         id: hash
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,76 +1,77 @@
-project_name: timoni
+version: 2
+
+# xref: https://goreleaser.com/customization/hooks/
+before:
+  hooks:
+    - go mod download
+
+# xref: https://goreleaser.com/customization/env/
+env:
+  - CGO_ENABLED=0
+
+# xref: https://goreleaser.com/customization/changelog/
 changelog:
   use: github-native
+
+# xref: https://goreleaser.com/customization/build/
 builds:
   - <<: &build_defaults
-      binary: timoni
-      main: ./cmd/timoni
+      main: ./cmd/{{ .ProjectName }}
       ldflags:
         - -s -w -X main.VERSION={{ .Version }}
-      env:
-        - CGO_ENABLED=0
-    id: linux
+    id: linux-build
     goos:
       - linux
     goarch:
       - amd64
       - arm64
   - <<: *build_defaults
-    id: darwin
+    id: darwin-build
     goos:
       - darwin
     goarch:
       - amd64
       - arm64
   - <<: *build_defaults
-    id: windows
+    id: windows-build
     goos:
       - windows
     goarch:
       - amd64
+      - arm64
+
+# xref: https://goreleaser.com/customization/archive/
 archives:
   - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    id: nix
-    builds: [darwin, linux]
-    format: tar.gz
+    id: unix-cli
+    ids:
+      - darwin-build
+      - linux-build
+    formats:
+      - tar.gz
     files:
       - LICENSE
   - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    id: windows
-    builds: [windows]
-    format: zip
+    id: windows-cli
+    ids:
+      - windows-build
+    formats:
+      - zip
     files:
       - LICENSE
+
+# xref: https://goreleaser.com/customization/checksum/
+checksum:
+  algorithm: sha256
+
+# xref: https://goreleaser.com/customization/source/
 source:
   enabled: true
   name_template: '{{ .ProjectName }}_{{ .Version }}_source_code'
+
+# xref: https://goreleaser.com/customization/sbom/
 sboms:
   - id: source
     artifacts: source
     documents:
       - "{{ .ProjectName }}_{{ .Version }}_sbom.spdx.json"
-brews:
-  - name: timoni
-    repository:
-      owner: stefanprodan
-      name: homebrew-tap
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
-    homepage: "https://timoni.sh"
-    description: "Timoni CLI"
-    dependencies:
-      - name: cue
-        type: optional
-      - name: diffutils
-        type: optional
-    install: |
-      bin.install "timoni"
-      bash_output = Utils.safe_popen_read(bin/"timoni", "completion", "bash")
-      (bash_completion/"timoni").write bash_output
-      zsh_output = Utils.safe_popen_read(bin/"timoni", "completion", "zsh")
-      (zsh_completion/"_timoni").write zsh_output
-      fish_output = Utils.safe_popen_read(bin/"timoni", "completion", "fish")
-      (fish_completion/"timoni.fish").write fish_output
-    test: |
-      system "#{bin}/timoni version"


### PR DESCRIPTION
Update the GoReleaser config to the version 2 schema, add windows/arm64 builds, and attest the release checksums file with GitHub artifact attestations, complementing the existing SLSA provenance job.