### PR TITLE
feat(cli): introduce `timoni fmt` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,14 @@ vet: ## Vet Go code.
 	go vet ./...
 
 cue-vet: build ## Vet and fmt CUE files.
-	cue fmt ./schemas/...
+	./bin/timoni fmt ./schemas
 	cue vet ./schemas/...
 	for dir in ./blueprints/* ; do
-		cue fmt $$dir/...
+		./bin/timoni fmt $$dir
 		./bin/timoni mod vet $$dir
 	done
 	for dir in ./examples/* ; do
-		cue fmt $$dir/...
+		./bin/timoni fmt $$dir
 		if [ $$dir != "./examples/bundles" ]; then
 			./bin/timoni mod vet $$dir
 		fi
@@ -49,7 +49,7 @@ cue-vet: build ## Vet and fmt CUE files.
 	./bin/timoni mod vet ./cmd/timoni/testdata/module
 	./bin/timoni mod vet ./internal/engine/testdata/module
 	./bin/timoni mod vet ./internal/engine/fetcher/testdata/module
-	cue fmt ./internal/engine/testdata/module-values
+	./bin/timoni fmt ./internal/engine/testdata/module-values
 
 REDIS_VER=$(shell grep 'tag:' examples/redis/values.cue | awk '{ print $$2 }' | tr -d '"' | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
 push-redis: build

--- a/cmd/timoni/fmt.go
+++ b/cmd/timoni/fmt.go
@@ -1,0 +1,350 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	cueerrors "cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/format"
+	"cuelang.org/go/cue/parser"
+	"cuelang.org/go/mod/modfile"
+	"github.com/go-logr/logr"
+	"github.com/rogpeppe/go-internal/diff"
+	"github.com/spf13/cobra"
+)
+
+var fmtCmd = &cobra.Command{
+	Use:   "fmt [PATH ...]",
+	Short: "Format CUE files",
+	Long: `The fmt command rewrites CUE files in the standard format.
+
+Arguments are files or directories, defaulting to the current directory.
+Directories are formatted recursively; during the walk, directories named
+"cue.mod" and those with a "." or "_" prefix are skipped unless given as
+explicit arguments.
+
+Files inside a module are parsed under the language version declared in
+the module's cue.mod/module.cue, matching the behavior of Timoni's module
+builds; files outside any module use the CUE version built into Timoni.
+
+When run with --diff, no files are rewritten, the pending changes are
+printed as unified diffs and the command fails if any file is not well
+formatted.`,
+	Example: `  # Format the current directory recursively
+  timoni fmt
+
+  # Verify formatting and print a diff for each file that needs changes
+  timoni fmt --diff
+
+  # Show the changes formatting would make to a bundle
+  timoni fmt --diff bundle.cue
+
+  # Format standard input, for editor integration
+  timoni fmt -
+`,
+	RunE: runFmtCmd,
+}
+
+type fmtFlags struct {
+	diff bool
+}
+
+var fmtArgs fmtFlags
+
+func init() {
+	fmtCmd.Flags().BoolVarP(&fmtArgs.diff, "diff", "d", false,
+		"Print the diffs and exits 1 if any file needs formatting.")
+	rootCmd.AddCommand(fmtCmd)
+}
+
+type fmtRunner struct {
+	cmd         *cobra.Command
+	log         logr.Logger
+	versions    map[string]string
+	unformatted bool
+	failed      int
+}
+
+func runFmtCmd(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		args = []string{"."}
+	}
+
+	runner := &fmtRunner{
+		cmd:      cmd,
+		log:      LoggerFrom(cmd.Context()),
+		versions: map[string]string{},
+	}
+	for _, arg := range args {
+		if arg == "-" {
+			if err := runner.formatStdin(); err != nil {
+				runner.reportError(err)
+			}
+			continue
+		}
+
+		target, err := resolveFmtArg(arg)
+		if err != nil {
+			return err
+		}
+
+		info, err := os.Stat(target)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			if err := runner.walkDir(target); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if !strings.HasSuffix(target, ".cue") {
+			return fmt.Errorf("not a CUE file: %s", arg)
+		}
+		// Resolve explicit symlinked files so the language version
+		// comes from the target's module, not the link's location.
+		resolved, err := filepath.EvalSymlinks(target)
+		if err != nil {
+			return err
+		}
+		if err := runner.formatFile(resolved); err != nil {
+			runner.reportError(err)
+		}
+	}
+
+	if runner.failed > 0 {
+		return fmt.Errorf("formatting failed for %d file(s)", runner.failed)
+	}
+	if fmtArgs.diff && runner.unformatted {
+		return fmt.Errorf("formatting differences found")
+	}
+	return nil
+}
+
+// reportError logs a per-file failure and keeps the run going,
+// gofmt-style, so one malformed file does not block the rest of the
+// tree. The run still exits non-zero at the end.
+func (r *fmtRunner) reportError(err error) {
+	r.failed++
+	r.log.Error(nil, err.Error())
+}
+
+// resolveFmtArg cleans an argument path, accepting a trailing "/..."
+// (or a bare "...") as an alias for the directory it follows.
+func resolveFmtArg(arg string) (string, error) {
+	if !strings.Contains(arg, "...") {
+		return filepath.Clean(arg), nil
+	}
+
+	trimmed, found := strings.CutSuffix(arg, "...")
+	if !found || strings.Contains(trimmed, "...") {
+		return "", fmt.Errorf("invalid path %q: %q is only accepted as a trailing directory alias", arg, "...")
+	}
+	switch {
+	case trimmed == "":
+		trimmed = "."
+	case strings.HasSuffix(trimmed, "/") || strings.HasSuffix(trimmed, string(filepath.Separator)):
+		trimmed = filepath.Clean(trimmed)
+	default:
+		return "", fmt.Errorf("invalid path %q: %q must follow a directory separator", arg, "...")
+	}
+
+	info, err := os.Stat(trimmed)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("invalid path %q: %s is not a directory", arg, trimmed)
+	}
+	return trimmed, nil
+}
+
+// walkDir formats every regular CUE file under root, skipping cue.mod,
+// dot and underscore directories, and symlinks. A symlinked root is
+// resolved first so that explicitly named symlinked directories are
+// walked instead of silently ignored.
+func (r *fmtRunner) walkDir(root string) error {
+	if li, err := os.Lstat(root); err == nil && li.Mode()&os.ModeSymlink != 0 {
+		resolved, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			return err
+		}
+		root = resolved
+	}
+
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			name := d.Name()
+			isMod := name == "cue.mod"
+			isDot := strings.HasPrefix(name, ".") && name != "." && name != ".."
+			if path != root && (isMod || isDot || strings.HasPrefix(name, "_")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if !strings.HasSuffix(path, ".cue") || !d.Type().IsRegular() {
+			return nil
+		}
+		if err := r.formatFile(path); err != nil {
+			r.reportError(err)
+		}
+		return nil
+	})
+}
+
+// formatFile formats a single CUE file in place. With --diff the
+// changes are displayed instead of written.
+func (r *fmtRunner) formatFile(filename string) error {
+	src, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	formatted, err := formatCUE(filename, src, r.versionFor(filepath.Dir(filename)))
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(formatted, src) {
+		return nil
+	}
+	r.unformatted = true
+
+	if fmtArgs.diff {
+		path := fmtRelPath(filename)
+		_, err = fmt.Fprintln(r.cmd.OutOrStdout(), string(diff.Diff(path+".orig", src, path, formatted)))
+		return err
+	}
+	return os.WriteFile(filename, formatted, 0644)
+}
+
+// formatStdin formats CUE read from standard input and writes the
+// result to standard output. With --diff the changes are displayed
+// instead.
+func (r *fmtRunner) formatStdin() error {
+	src, err := io.ReadAll(r.cmd.InOrStdin())
+	if err != nil {
+		return err
+	}
+
+	formatted, err := formatCUE("-", src, "")
+	if err != nil {
+		return err
+	}
+
+	if !fmtArgs.diff {
+		_, err = r.cmd.OutOrStdout().Write(formatted)
+		return err
+	}
+	if bytes.Equal(formatted, src) {
+		return nil
+	}
+	r.unformatted = true
+
+	_, err = fmt.Fprintln(r.cmd.OutOrStdout(), string(diff.Diff("-.orig", src, "-", formatted)))
+	return err
+}
+
+// formatCUE returns the given CUE source in the standard format,
+// parsing it under langVersion when one is declared. Parse errors are
+// rendered with their source positions.
+func formatCUE(filename string, src []byte, langVersion string) ([]byte, error) {
+	opts := []parser.Option{parser.ParseComments}
+	if langVersion != "" {
+		opts = append(opts, parser.Version(langVersion))
+	}
+	syntax, err := parser.ParseFile(filename, src, opts...)
+	if err != nil {
+		cwd, _ := os.Getwd()
+		return nil, fmt.Errorf("%s", strings.TrimSpace(cueerrors.Details(err, &cueerrors.Config{Cwd: cwd})))
+	}
+	return format.Node(syntax)
+}
+
+// versionFor returns the language version declared by the module
+// enclosing dir, or an empty string when dir is outside any module or
+// the version cannot be determined, in which case parsing falls back
+// to the CUE version built into timoni.
+func (r *fmtRunner) versionFor(dir string) string {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return ""
+	}
+	return r.lookupVersion(abs)
+}
+
+// lookupVersion resolves the language version for an absolute
+// directory by finding the nearest ancestor containing cue.mod. The
+// search stops at the first cue.mod so a nested module never inherits
+// a parent module's version. Results are memoized per directory.
+func (r *fmtRunner) lookupVersion(dir string) string {
+	if v, ok := r.versions[dir]; ok {
+		return v
+	}
+
+	var v string
+	if _, err := os.Stat(filepath.Join(dir, "cue.mod")); err == nil {
+		v = readLanguageVersion(filepath.Join(dir, "cue.mod", "module.cue"))
+	} else if parent := filepath.Dir(dir); parent != dir {
+		v = r.lookupVersion(parent)
+	}
+	r.versions[dir] = v
+	return v
+}
+
+// readLanguageVersion returns the language.version declared in a
+// cue.mod/module.cue file, or an empty string when the file is
+// missing, unparseable, or declares no version.
+func readLanguageVersion(modFilePath string) string {
+	data, err := os.ReadFile(modFilePath)
+	if err != nil {
+		return ""
+	}
+	mf, err := modfile.ParseNonStrict(data, modFilePath)
+	if err != nil || mf.Language == nil {
+		return ""
+	}
+	return mf.Language.Version
+}
+
+// fmtRelPath returns filename relative to the working directory for
+// display. Files outside the working directory keep the name as
+// given, avoiding long "../" chains.
+func fmtRelPath(filename string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return filename
+	}
+	rel, err := filepath.Rel(cwd, filename)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return filename
+	}
+	return rel
+}

--- a/cmd/timoni/fmt_test.go
+++ b/cmd/timoni/fmt_test.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	fmtTestUnformatted = "hello:   \"world\"\n"
+	fmtTestFormatted   = "hello: \"world\"\n"
+)
+
+// writeFmtFixture writes content at path, creating parent directories.
+func writeFmtFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeFmtModule writes a cue.mod/module.cue declaring the given
+// language version under dir.
+func writeFmtModule(t *testing.T, dir, version string) {
+	t.Helper()
+	writeFmtFixture(t, filepath.Join(dir, "cue.mod", "module.cue"),
+		fmt.Sprintf("module: \"example.com/test\"\nlanguage: version: %q\n", version))
+}
+
+func readFmtFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestFmtModuleDir(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeFmtModule(t, dir, "v0.17.1")
+	writeFmtFixture(t, filepath.Join(dir, "values.cue"), fmtTestUnformatted)
+	writeFmtFixture(t, filepath.Join(dir, "templates", "config.cue"), fmtTestUnformatted)
+	writeFmtFixture(t, filepath.Join(dir, "cue.mod", "gen", "vendored.cue"), fmtTestUnformatted)
+	writeFmtFixture(t, filepath.Join(dir, "_tools", "skip.cue"), fmtTestUnformatted)
+	writeFmtFixture(t, filepath.Join(dir, ".hidden", "skip.cue"), fmtTestUnformatted)
+
+	_, err := executeCommand("fmt " + dir)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(readFmtFile(t, filepath.Join(dir, "values.cue"))).To(Equal(fmtTestFormatted))
+	g.Expect(readFmtFile(t, filepath.Join(dir, "templates", "config.cue"))).To(Equal(fmtTestFormatted))
+	g.Expect(readFmtFile(t, filepath.Join(dir, "cue.mod", "gen", "vendored.cue"))).To(Equal(fmtTestUnformatted))
+	g.Expect(readFmtFile(t, filepath.Join(dir, "_tools", "skip.cue"))).To(Equal(fmtTestUnformatted))
+	g.Expect(readFmtFile(t, filepath.Join(dir, ".hidden", "skip.cue"))).To(Equal(fmtTestUnformatted))
+}
+
+func TestFmtSingleFile(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "bundle.cue")
+	writeFmtFixture(t, bundle, fmtTestUnformatted)
+
+	_, err := executeCommand("fmt " + bundle)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(readFmtFile(t, bundle)).To(Equal(fmtTestFormatted))
+}
+
+func TestFmtExplicitSkippedDirs(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	genFile := filepath.Join(dir, "cue.mod", "gen", "vendored.cue")
+	toolsDir := filepath.Join(dir, "_tools")
+	writeFmtFixture(t, genFile, fmtTestUnformatted)
+	writeFmtFixture(t, filepath.Join(toolsDir, "tool.cue"), fmtTestUnformatted)
+
+	_, err := executeCommand("fmt " + genFile + " " + toolsDir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(readFmtFile(t, genFile)).To(Equal(fmtTestFormatted))
+	g.Expect(readFmtFile(t, filepath.Join(toolsDir, "tool.cue"))).To(Equal(fmtTestFormatted))
+}
+
+func TestFmtDiff(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	app := filepath.Join(dir, "app.cue")
+	writeFmtFixture(t, app, fmtTestUnformatted)
+
+	// Like flux diff: print the drift, then fail with a non-zero
+	// exit; the closing error is logged by main like any other error.
+	// The fixture lives outside the working directory, so the diff
+	// header shows its full path.
+	output, err := executeCommand("fmt --diff " + dir)
+	g.Expect(err).To(MatchError(ContainSubstring("formatting differences found")))
+	g.Expect(output).To(ContainSubstring(app))
+	g.Expect(output).To(ContainSubstring("-" + fmtTestUnformatted))
+	g.Expect(output).To(ContainSubstring("+" + fmtTestFormatted))
+	g.Expect(readFmtFile(t, app)).To(Equal(fmtTestUnformatted))
+
+	writeFmtFixture(t, app, fmtTestFormatted)
+	output, err = executeCommand("fmt --diff " + dir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(BeEmpty())
+}
+
+func TestFmtStdin(t *testing.T) {
+	g := NewWithT(t)
+
+	output, err := executeCommandWithIn("fmt -", strings.NewReader(fmtTestUnformatted))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(Equal(fmtTestFormatted))
+}
+
+func TestFmtStdinMixedWithPaths(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	app := filepath.Join(dir, "app.cue")
+	writeFmtFixture(t, app, fmtTestUnformatted)
+
+	output, err := executeCommandWithIn("fmt - "+app, strings.NewReader(fmtTestUnformatted))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(Equal(fmtTestFormatted))
+	g.Expect(readFmtFile(t, app)).To(Equal(fmtTestFormatted))
+}
+
+func TestFmtIdempotent(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeFmtFixture(t, filepath.Join(dir, "app.cue"), fmtTestUnformatted)
+
+	_, err := executeCommand("fmt " + dir)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = executeCommand("fmt --diff " + dir)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestFmtMalformed(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	app := filepath.Join(dir, "bad.cue")
+	other := filepath.Join(dir, "good.cue")
+	writeFmtFixture(t, app, "a: {\n")
+	writeFmtFixture(t, other, fmtTestUnformatted)
+
+	output, err := executeCommand("fmt " + dir)
+	g.Expect(err).To(MatchError(ContainSubstring("formatting failed for 1 file(s)")))
+	// The logged error must carry the file position, e.g. "bad.cue:1:6".
+	g.Expect(output).To(MatchRegexp(`bad\.cue:\d+:\d+`))
+	g.Expect(readFmtFile(t, app)).To(Equal("a: {\n"))
+	// The run continues past the malformed file, gofmt-style.
+	g.Expect(readFmtFile(t, other)).To(Equal(fmtTestFormatted))
+}
+
+func TestFmtRejectsNonCUEFile(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	readme := filepath.Join(dir, "README.md")
+	writeFmtFixture(t, readme, "# readme\n")
+
+	_, err := executeCommand("fmt " + readme)
+	g.Expect(err).To(MatchError(ContainSubstring("not a CUE file")))
+}
+
+func TestFmtDotsAlias(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeFmtFixture(t, filepath.Join(dir, "app.cue"), fmtTestUnformatted)
+
+	_, err := executeCommand("fmt " + dir + "/...")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(readFmtFile(t, filepath.Join(dir, "app.cue"))).To(Equal(fmtTestFormatted))
+}
+
+func TestFmtDotsInvalid(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	app := filepath.Join(dir, "app.cue")
+	writeFmtFixture(t, app, fmtTestUnformatted)
+
+	for _, arg := range []string{app + "/...", dir + "/...suffix", dir + "/pre...", dir + "/a...b"} {
+		_, err := executeCommand("fmt " + arg)
+		g.Expect(err).To(HaveOccurred(), "expected error for arg %s", arg)
+	}
+	g.Expect(readFmtFile(t, app)).To(Equal(fmtTestUnformatted))
+}
+
+func TestFmtSymlinks(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "outside")
+	tree := filepath.Join(dir, "tree")
+	writeFmtFixture(t, filepath.Join(outside, "target.cue"), fmtTestUnformatted)
+	writeFmtFixture(t, filepath.Join(tree, "app.cue"), fmtTestUnformatted)
+	g.Expect(os.Symlink(filepath.Join(outside, "target.cue"), filepath.Join(tree, "link.cue"))).To(Succeed())
+	g.Expect(os.Symlink(outside, filepath.Join(dir, "treelink"))).To(Succeed())
+
+	// Walks skip symlinked files, so the target stays untouched.
+	_, err := executeCommand("fmt " + tree)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(readFmtFile(t, filepath.Join(tree, "app.cue"))).To(Equal(fmtTestFormatted))
+	g.Expect(readFmtFile(t, filepath.Join(outside, "target.cue"))).To(Equal(fmtTestUnformatted))
+
+	// An explicit symlinked directory argument is walked.
+	_, err = executeCommand("fmt " + filepath.Join(dir, "treelink"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(readFmtFile(t, filepath.Join(outside, "target.cue"))).To(Equal(fmtTestFormatted))
+}
+
+func TestFmtExplicitSymlinkedFile(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+
+	// The target lives in a v0.17 module and uses newline-separated
+	// list elements, which do not parse under v0.9 rules. The link
+	// lives in a v0.9 module: formatting through it must use the
+	// target module's version.
+	target := filepath.Join(dir, "target")
+	writeFmtModule(t, target, "v0.17.1")
+	writeFmtFixture(t, filepath.Join(target, "versioned.cue"), "x: [\n1\n2\n]\n")
+	linksite := filepath.Join(dir, "linksite")
+	writeFmtModule(t, linksite, "v0.9.0")
+	g.Expect(os.Symlink(filepath.Join(target, "versioned.cue"), filepath.Join(linksite, "versioned.cue"))).To(Succeed())
+
+	_, err := executeCommand("fmt " + filepath.Join(linksite, "versioned.cue"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(readFmtFile(t, filepath.Join(target, "versioned.cue"))).To(Equal("x: [\n\t1\n\t2\n]\n"))
+}
+
+func TestFmtVersionWiring(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+
+	// Newline-separated list elements parse only under v0.17+ rules,
+	// proving the resolved module version reaches the parser.
+	oldMod := filepath.Join(dir, "old")
+	writeFmtModule(t, oldMod, "v0.9.0")
+	writeFmtFixture(t, filepath.Join(oldMod, "app.cue"), "x: [\n1\n2\n]\n")
+	newMod := filepath.Join(dir, "new")
+	writeFmtModule(t, newMod, "v0.17.1")
+	writeFmtFixture(t, filepath.Join(newMod, "app.cue"), "x: [\n1\n2\n]\n")
+
+	_, err := executeCommand("fmt " + oldMod)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(readFmtFile(t, filepath.Join(oldMod, "app.cue"))).To(Equal("x: [\n1\n2\n]\n"))
+
+	_, err = executeCommand("fmt " + newMod)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(readFmtFile(t, filepath.Join(newMod, "app.cue"))).To(Equal("x: [\n\t1\n\t2\n]\n"))
+}
+
+func TestFmtResolveArgAlias(t *testing.T) {
+	g := NewWithT(t)
+
+	for _, tt := range []struct {
+		arg  string
+		want string
+	}{
+		{"...", "."},
+		{"./...", "."},
+		{"/...", "/"},
+	} {
+		got, err := resolveFmtArg(tt.arg)
+		g.Expect(err).ToNot(HaveOccurred(), "arg %s", tt.arg)
+		g.Expect(got).To(Equal(tt.want), "arg %s", tt.arg)
+	}
+}
+
+func TestFmtVersionResolution(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+
+	outer := filepath.Join(dir, "outer")
+	writeFmtModule(t, outer, "v0.17.1")
+	nested := filepath.Join(outer, "nested")
+	writeFmtModule(t, nested, "v0.9.0")
+	noVersion := filepath.Join(dir, "noversion")
+	writeFmtFixture(t, filepath.Join(noVersion, "cue.mod", "module.cue"),
+		"module: \"example.com/noversion\"\n")
+	broken := filepath.Join(dir, "broken")
+	writeFmtFixture(t, filepath.Join(broken, "cue.mod", "module.cue"), "not valid {{{\n")
+	empty := filepath.Join(dir, "empty", "cue.mod")
+	g.Expect(os.MkdirAll(empty, 0755)).To(Succeed())
+
+	runner := &fmtRunner{versions: map[string]string{}}
+	g.Expect(runner.versionFor(outer)).To(Equal("v0.17.1"))
+	g.Expect(runner.versionFor(filepath.Join(outer, "templates"))).To(Equal("v0.17.1"))
+	// The nearest cue.mod wins; a nested module never inherits the parent's version.
+	g.Expect(runner.versionFor(nested)).To(Equal("v0.9.0"))
+	g.Expect(runner.versionFor(filepath.Join(nested, "templates"))).To(Equal("v0.9.0"))
+	// Fallbacks: no language.version, unparseable module.cue,
+	// cue.mod without module.cue, and no module at all.
+	g.Expect(runner.versionFor(noVersion)).To(BeEmpty())
+	g.Expect(runner.versionFor(broken)).To(BeEmpty())
+	g.Expect(runner.versionFor(filepath.Join(dir, "empty"))).To(BeEmpty())
+	g.Expect(runner.versionFor(dir)).To(BeEmpty())
+}
+
+func TestFmtNestedModules(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	writeFmtModule(t, dir, "v0.17.1")
+	writeFmtFixture(t, filepath.Join(dir, "app.cue"), fmtTestUnformatted)
+	nested := filepath.Join(dir, "nested")
+	writeFmtModule(t, nested, "v0.9.0")
+	writeFmtFixture(t, filepath.Join(nested, "app.cue"), fmtTestUnformatted)
+
+	_, err := executeCommand("fmt " + dir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(readFmtFile(t, filepath.Join(dir, "app.cue"))).To(Equal(fmtTestFormatted))
+	g.Expect(readFmtFile(t, filepath.Join(nested, "app.cue"))).To(Equal(fmtTestFormatted))
+}

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -35,10 +35,7 @@ import (
 	"github.com/stefanprodan/timoni/internal/logger"
 )
 
-var (
-	VERSION     = "0.0.0-dev.0"
-	CUE_VERSION = "0.17.1"
-)
+var VERSION = "0.0.0-dev.0"
 
 var rootCmd = &cobra.Command{
 	Use:           "timoni",

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -125,9 +125,12 @@ func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
 	rootCmd.SetArgs(args)
-	if in != nil {
-		rootCmd.SetIn(in)
+	// Always set the input stream so a reader injected by a previous
+	// test does not leak into commands that read stdin.
+	if in == nil {
+		in = os.Stdin
 	}
+	rootCmd.SetIn(in)
 
 	zcfg := zerolog.ConsoleWriter{Out: buf, NoColor: true}
 	zcfg.PartsExclude = []string{
@@ -146,6 +149,7 @@ func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
 
 func resetCmdArgs() {
 	applyArgs = applyFlags{}
+	fmtArgs = fmtFlags{}
 	buildArgs = buildFlags{output: "yaml"}
 	deleteArgs = deleteFlags{}
 	statusArgs = statusFlags{}

--- a/cmd/timoni/version.go
+++ b/cmd/timoni/version.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 
+	"cuelang.org/go/cue"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
@@ -53,7 +55,7 @@ func runVersionCmd(cmd *cobra.Command, args []string) error {
 	info := map[string]string{}
 	info["client"] = VERSION
 	info["api"] = apiv1.GroupVersion.String()
-	info["cue"] = CUE_VERSION
+	info["cue"] = strings.TrimPrefix(cue.LanguageVersion(), "v")
 
 	var marshalled []byte
 	var err error

--- a/cmd/timoni/version_test.go
+++ b/cmd/timoni/version_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
+	"cuelang.org/go/cue"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
 
@@ -37,7 +40,17 @@ func TestVersion(t *testing.T) {
 	expectedAPIVersion := apiv1.GroupVersion.String()
 	g.Expect(data).To(HaveKeyWithValue("api", expectedAPIVersion))
 	g.Expect(data).To(HaveKey("client"))
-	g.Expect(data).To(HaveKey("cue"))
+	g.Expect(data).To(HaveKeyWithValue("cue", strings.TrimPrefix(cue.LanguageVersion(), "v")))
+}
+
+func TestVersionJSON(t *testing.T) {
+	g := NewWithT(t)
+	output, err := executeCommand("version -o json")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var data map[string]string
+	g.Expect(json.Unmarshal([]byte(output), &data)).To(Succeed())
+	g.Expect(data).To(HaveKeyWithValue("cue", strings.TrimPrefix(cue.LanguageVersion(), "v")))
 }
 
 func TestVersionRejectsInvalidOutput(t *testing.T) {

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -545,13 +545,17 @@ Printing the computed value is particular useful when debugging runtime attribut
 
 ### Format
 
-To format Bundle files, you can use the `cue fmt` command.
+To format Bundle files, you can use the `timoni fmt` command.
 
 Example:
 
 ```shell
-cue fmt bundle.cue
+timoni fmt bundle.cue
 ```
+
+To verify formatting without rewriting the file, e.g. in CI,
+use `timoni fmt --diff bundle.cue`, which prints the pending changes
+and exits with a non-zero status if the file is not well formatted.
 
 ### Referencing local modules
 

--- a/docs/cue/module/initialization.md
+++ b/docs/cue/module/initialization.md
@@ -183,16 +183,17 @@ the file and line number where the error occurred.
 
 ### Format the module files
 
-Similar to Go, CUE has a built-in code formatter that can be used to format CUE files.
-
-To format all files in a module, run the following command:
+To format all files in a module:
 
 ```shell
-cue fmt ./...
+timoni fmt
 ```
 
-It is recommended to run this command after making changes to a module. Most editors
-have a CUE plugin that can run the `cue fmt` command automatically when saving a file.
+In CI, `timoni fmt --diff` prints the pending changes and exits with an error if
+any file needs formating.
+
+For editors, `timoni fmt -` reads CUE from standard input and writes the formatted
+result to standard output, so it can be wired up as a format-on-save command.
 
 ### Update the Kubernetes schemas
 

--- a/docs/cue/walkthrough.md
+++ b/docs/cue/walkthrough.md
@@ -22,17 +22,15 @@ which can be found by running: `timoni version`.
 
 !!! tip "Timoni CUE dependency"
 
-    Note that Timoni embeds the CUE engine, so you don't need to install
-    it separately in order to use Timoni. The CUE CLI is only required
-    when developing modules to format the CUE files before publishing the
-    modules to container registries.
+    Note that Timoni embeds the CUE engine and the CUE formatter
+    (`timoni fmt`), so you don't need to install CUE separately in order
+    to use Timoni or to develop modules. The CUE CLI is only used in
+    this guide for evaluating and validating standalone CUE expressions.
 
 CUE comes with a rich set of CLI commands. Throughout this guide, we'll be using the following commands:
 
-- `cue fmt` - format CUE files
 - `cue eval` - evaluate CUE expressions
 - `cue vet` - validate CUE definitions
-
 
 ## Builtin Types
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/onsi/gomega v1.42.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
+	github.com/rogpeppe/go-internal v1.15.0
 	github.com/rs/zerolog v1.35.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
@@ -121,7 +122,6 @@ require (
 	github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 // indirect
 	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect

--- a/internal/engine/fetcher/testdata/module/templates/namespace.cue
+++ b/internal/engine/fetcher/testdata/module/templates/namespace.cue
@@ -5,8 +5,8 @@ package templates
 	apiVersion: "v1"
 	kind:       "Namespace"
 	metadata: {
-		name:      "\(_config.metadata.name)-ns"
-		labels:    _config.metadata.labels
+		name:   "\(_config.metadata.name)-ns"
+		labels: _config.metadata.labels
 		if _config.metadata.annotations != _|_ {
 			annotations: _config.metadata.annotations
 		}

--- a/internal/engine/testdata/api/apply-steps.cue
+++ b/internal/engine/testdata/api/apply-steps.cue
@@ -125,7 +125,7 @@ instance: tests: {
 }
 
 timoni: {
-	apply: app: [ for obj in instance.app {obj}]
-	apply: addons: [ for obj in instance.addons {obj}]
-	apply: tests: [ for obj in instance.tests {obj}]
+	apply: app: [for obj in instance.app {obj}]
+	apply: addons: [for obj in instance.addons {obj}]
+	apply: tests: [for obj in instance.tests {obj}]
 }

--- a/internal/engine/testdata/module-invalid/timoni.cue
+++ b/internal/engine/testdata/module-invalid/timoni.cue
@@ -39,5 +39,5 @@ timoni: {
 
 	// Pass Kubernetes resources outputted by the instance
 	// to Timoni's multi-step apply.
-	apply: all: [ for obj in instance.objects {obj}]
+	apply: all: [for obj in instance.objects {obj}]
 }

--- a/internal/engine/testdata/module/timoni.cue
+++ b/internal/engine/testdata/module/timoni.cue
@@ -39,5 +39,5 @@ timoni: {
 
 	// Pass Kubernetes resources outputted by the instance
 	// to Timoni's multi-step apply.
-	apply: all: [ for obj in instance.objects {obj}]
+	apply: all: [for obj in instance.objects {obj}]
 }

--- a/internal/oci/testdata/module/timoni.cue
+++ b/internal/oci/testdata/module/timoni.cue
@@ -20,5 +20,5 @@ timoni: {
 		}
 	}
 
-	apply: all: [ for obj in instance.objects {obj}]
+	apply: all: [for obj in instance.objects {obj}]
 }


### PR DESCRIPTION
Format all modules, bundles and runtime files recursively by simply running `timoni fmt` from the repo root.

Check in CI which files need formatting by printing a unified diff with `timoni fmt --diff`. If a diff is found, the command exits `1` to stop the CI job.