### PR TITLE
feat: Unit testing framework for Timoni modules

### DIFF
--- a/api/v1alpha1/ignore.go
+++ b/api/v1alpha1/ignore.go
@@ -17,7 +17,13 @@ limitations under the License.
 package v1alpha1
 
 const (
-	IgnoreFile            = "timoni.ignore"
+	IgnoreFile = "timoni.ignore"
+
+	// TestFilePattern matches the CUE files holding a module's test cases.
+	// These files are an input to 'timoni mod test' and are always excluded
+	// from the published module, regardless of the module's ignore rules.
+	TestFilePattern = "*_test.cue"
+
 	DefaultIgnorePatterns = `# VCS
 .git/
 .gitignore
@@ -31,6 +37,7 @@ go.sum
 
 # CUE
 *_tool.cue
+*_test.cue
 debug_values.cue
 `
 )

--- a/api/v1alpha1/instance.go
+++ b/api/v1alpha1/instance.go
@@ -36,6 +36,33 @@ const (
 
 	// ValuesSelector is the CUE path for the Timoni's module values.
 	ValuesSelector Selector = "values"
+
+	// TestCasesSelector is the CUE path for the test cases
+	// declared in a module's '*_test.cue' files.
+	TestCasesSelector Selector = "cases"
+
+	// TestNameSelector is the CUE path for the instance name a test case is built with.
+	TestNameSelector Selector = "name"
+
+	// TestNamespaceSelector is the CUE path for the instance namespace a test case is built with.
+	TestNamespaceSelector Selector = "namespace"
+
+	// TestModuleVersionSelector is the CUE path for the module version a test case is built with.
+	TestModuleVersionSelector Selector = "moduleVersion"
+
+	// TestKubeVersionSelector is the CUE path for the Kubernetes version a test case is built with.
+	TestKubeVersionSelector Selector = "kubeVersion"
+
+	// TestValuesSelector is the CUE path for the values a test case is built with.
+	TestValuesSelector Selector = "values"
+
+	// TestObjectsSelector is the CUE path for the Kubernetes objects a test case
+	// expects, keyed by '<kind>/<name>'.
+	TestObjectsSelector Selector = "objects"
+
+	// TestAssertSelector is the CUE path for the named predicates a test case
+	// requires to hold.
+	TestAssertSelector Selector = "assert"
 )
 
 // Instance holds the information about the module, values

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -159,6 +159,7 @@ func resetCmdArgs() {
 	vetModArgs = vetModFlags{
 		name: "default",
 	}
+	testModArgs = testModFlags{}
 	listArgs = listFlags{}
 	pullModArgs = pullModFlags{}
 	pushModArgs = pushModFlags{}

--- a/cmd/timoni/mod_test_cmd.go
+++ b/cmd/timoni/mod_test_cmd.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/flags"
+	"github.com/stefanprodan/timoni/internal/logger"
+)
+
+var testModCmd = &cobra.Command{
+	Use:   "test [MODULE PATH]",
+	Args:  cobra.MaximumNArgs(1),
+	Short: "Run the test cases of a local module",
+	Long: `The test command runs the test cases declared in the module's '*_test.cue' files.
+Each case is built in isolation with its own values, and its expectations are
+checked against the resulting Kubernetes objects.`,
+	Example: `  # run all test cases of a module in the current directory
+  timoni mod test
+
+  # run the test cases matching a regular expression
+  timoni mod test ./path/to/module --run '^service'
+`,
+	RunE: runTestModCmd,
+}
+
+type testModFlags struct {
+	path string
+	pkg  flags.Package
+	run  string
+}
+
+var testModArgs testModFlags
+
+func init() {
+	testModCmd.Flags().VarP(&testModArgs.pkg, testModArgs.pkg.Type(), testModArgs.pkg.Shorthand(), testModArgs.pkg.Description())
+	testModCmd.Flags().StringVar(&testModArgs.run, "run", "",
+		"Regular expression matching the names of the test cases to run.")
+	modCmd.AddCommand(testModCmd)
+}
+
+func runTestModCmd(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		testModArgs.path = "."
+	} else {
+		testModArgs.path = args[0]
+	}
+
+	if fs, err := os.Stat(testModArgs.path); err != nil || !fs.IsDir() {
+		return fmt.Errorf("module not found at path %s", testModArgs.path)
+	}
+
+	// The CUE loader requires absolute paths for the in-memory overlays
+	// the module builder passes it.
+	moduleRoot, err := filepath.Abs(testModArgs.path)
+	if err != nil {
+		return err
+	}
+
+	var filter *regexp.Regexp
+	if testModArgs.run != "" {
+		filter, err = regexp.Compile(testModArgs.run)
+		if err != nil {
+			return fmt.Errorf("invalid --run expression: %w", err)
+		}
+	}
+
+	tester := engine.NewModuleTester(cuecontext.New(), moduleRoot, testModArgs.pkg.String())
+
+	cases, err := tester.LoadCases()
+	if err != nil {
+		return describeErr(moduleRoot, "loading tests failed", err)
+	}
+
+	out := cmd.OutOrStdout()
+	var run, failed int
+
+	for _, tc := range cases {
+		if filter != nil && !filter.MatchString(tc.Name) {
+			continue
+		}
+
+		run++
+		result := tester.Run(tc)
+		if result.Passed() {
+			fmt.Fprintf(out, "%s %s\n", logger.ColorizeInfo("PASS"), tc.Name)
+			continue
+		}
+
+		failed++
+		fmt.Fprintf(out, "%s %s\n", logger.ColorizeFailure("FAIL"), tc.Name)
+		fmt.Fprintln(out, describeTestErr(moduleRoot, result.Err))
+	}
+
+	if len(cases) == 0 {
+		fmt.Fprintln(out, "no test cases found")
+		return nil
+	}
+
+	// A filter that matches nothing is a typo more often than an empty
+	// selection, and passing on it would turn a mistyped run into a green one.
+	if run == 0 {
+		return fmt.Errorf("no test cases match the --run expression %q", testModArgs.run)
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("%d of %d test cases failed", failed, run)
+	}
+
+	fmt.Fprintf(out, "%s %d test cases passed\n", logger.ColorizeInfo("OK"), run)
+	return nil
+}
+
+// describeTestErr renders a test case failure indented under the case name.
+// CUE errors are expanded so that every field that did not hold is reported
+// with its position in the test file, rather than only the first.
+func describeTestErr(moduleRoot string, err error) string {
+	details := errors.Details(err, &errors.Config{Cwd: moduleRoot})
+
+	lines := strings.Split(strings.TrimRight(details, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = "     " + line
+	}
+
+	return logger.ColorizeFailure(strings.Join(lines, "\n"))
+}

--- a/cmd/timoni/mod_test_cmd_test.go
+++ b/cmd/timoni/mod_test_cmd_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/stefanprodan/timoni/internal/fscopy"
+)
+
+// newTestModule copies the testdata module to a temporary directory
+// and writes the given CUE test cases to its templates package.
+func newTestModule(t *testing.T, cases string) string {
+	t.Helper()
+	g := NewWithT(t)
+
+	modPath := filepath.Join(t.TempDir(), "module")
+	// The module vendors the core schemas as relative symlinks under cue.mod/pkg,
+	// which must be materialized for the copy to build on its own.
+	err := fscopy.CopyDir("testdata/module", modPath, fscopy.Options{FollowSymlinks: true})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = os.WriteFile(filepath.Join(modPath, "templates", "cases_test.cue"), []byte(cases), 0644)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	return modPath
+}
+
+func Test_ModTest(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := newTestModule(t, `package templates
+
+cases: "client config points at the default domain": {
+	objects: "ConfigMap/test/test-client": data: server: "tcp://example.internal:9090"
+}
+
+cases: "domain is configurable": {
+	values: domain: "example.com"
+	objects: "ConfigMap/test/test-client": data: server: "tcp://example.com:9090"
+}
+
+cases: "server config is rendered alongside the client": {
+	objects: {...}
+	assert: "both config maps are rendered":
+		objects["ConfigMap/test/test-client"].kind == objects["ConfigMap/test/test-server"].kind
+}
+`)
+
+	output, err := executeCommand(fmt.Sprintf("mod test %s", modPath))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(output).To(ContainSubstring("client config points at the default domain"))
+	g.Expect(output).To(ContainSubstring("domain is configurable"))
+	g.Expect(output).To(ContainSubstring("3 test cases passed"))
+}
+
+func Test_ModTestFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		cases    string
+		contains string
+	}{
+		{
+			name: "conflicting object field",
+			cases: `cases: "wrong domain": {
+	objects: "ConfigMap/test/test-client": data: server: "tcp://wrong:9090"
+}`,
+			contains: "conflicting values",
+		},
+		{
+			name: "object the module does not render",
+			cases: `cases: "missing object": {
+	objects: "Deployment/test/test": spec: replicas: 1
+}`,
+			contains: "the module renders",
+		},
+		{
+			name: "field the module does not render",
+			cases: `cases: "misspelled field": {
+	objects: "ConfigMap/test/test-client": data: sever: "tcp://example.internal:9090"
+}`,
+			contains: `expected field(s) "ConfigMap/test/test-client".data.sever not rendered`,
+		},
+		{
+			name: "unknown case field",
+			cases: `cases: "misspelled case field": {
+	kubeVerison: "1.23.0"
+	objects: "ConfigMap/test/test-client": kind: "ConfigMap"
+}`,
+			contains: "unknown field(s) kubeVerison",
+		},
+		{
+			name: "case field that is not a string",
+			cases: `cases: "kube version as a number": {
+	kubeVersion: 123
+	objects: "ConfigMap/test/test-client": kind: "ConfigMap"
+}`,
+			contains: "kubeVersion: cannot use value 123 (type int) as string",
+		},
+		{
+			name: "assertion that does not hold",
+			cases: `cases: "false assertion": {
+	objects: {...}
+	assert: "client is a Deployment": objects["ConfigMap/test/test-client"].kind == "Deployment"
+}`,
+			contains: `assertion "client is a Deployment" does not hold`,
+		},
+		{
+			name: "values rejected by the config schema",
+			cases: `cases: "invalid values": {
+	values: domain: 42
+}`,
+			contains: `values.domain: conflicting values 42 and "example.internal"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			modPath := newTestModule(t, "package templates\n\n"+tt.cases+"\n")
+
+			output, err := executeCommand(fmt.Sprintf("mod test %s", modPath))
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring("test cases failed"))
+			g.Expect(output).To(ContainSubstring(tt.contains))
+		})
+	}
+}
+
+// Test_ModTestDefaultsAreCompared guards against an expectation being absorbed
+// by a disjunction instead of compared against the rendered value. The module's
+// port is declared as a default, so unifying an expectation with the unresolved
+// template would hold rather than conflict.
+func Test_ModTestDefaultsAreCompared(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := newTestModule(t, `package templates
+
+cases: "a wrong port must not be absorbed by the default": {
+	objects: "ConfigMap/test/test-client": data: server: "tcp://example.internal:1234"
+}
+`)
+
+	output, err := executeCommand(fmt.Sprintf("mod test %s", modPath))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("conflicting values"))
+}
+
+func Test_ModTestRunFilter(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := newTestModule(t, `package templates
+
+cases: "alpha case": {
+	objects: "ConfigMap/test/test-client": kind: "ConfigMap"
+}
+
+cases: "beta case": {
+	objects: "ConfigMap/test/test-server": kind: "ConfigMap"
+}
+`)
+
+	output, err := executeCommand(fmt.Sprintf("mod test %s --run ^alpha", modPath))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(output).To(ContainSubstring("alpha case"))
+	g.Expect(output).ToNot(ContainSubstring("beta case"))
+	g.Expect(output).To(ContainSubstring("1 test cases passed"))
+}
+
+// Test_ModTestReportsEveryConflict checks that a case with several failing
+// expectations reports all of them, so that a fix does not have to be found
+// one run at a time.
+func Test_ModTestReportsEveryConflict(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := newTestModule(t, `package templates
+
+cases: "every field is wrong": {
+	objects: "ConfigMap/test/test-client": {
+		kind: "Secret"
+		data: server: "tcp://wrong:9090"
+	}
+}
+`)
+
+	output, err := executeCommand(fmt.Sprintf("mod test %s", modPath))
+	g.Expect(err).To(HaveOccurred())
+
+	g.Expect(output).To(ContainSubstring(`.kind: conflicting values "ConfigMap" and "Secret"`))
+	g.Expect(output).To(ContainSubstring(`.data.server: conflicting values`))
+	// The position of each conflict is reported relative to the module root.
+	g.Expect(output).To(ContainSubstring("./templates/cases_test.cue:"))
+}
+
+func Test_ModTestRunFilterNoMatch(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := newTestModule(t, `package templates
+
+cases: "alpha case": {
+	objects: "ConfigMap/test/test-client": kind: "ConfigMap"
+}
+`)
+
+	output, err := executeCommand(fmt.Sprintf("mod test %s --run ^gamma", modPath))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring(`no test cases match the --run expression "^gamma"`))
+	g.Expect(output).ToNot(ContainSubstring("no test cases found"))
+}
+
+func Test_ModTestNoCases(t *testing.T) {
+	g := NewWithT(t)
+
+	output, err := executeCommand("mod test testdata/module")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("no test cases found"))
+}

--- a/docs/cue/module/unit-tests.md
+++ b/docs/cue/module/unit-tests.md
@@ -1,0 +1,217 @@
+# Unit testing
+
+Module authors can write unit tests in CUE that check what a module renders for a
+given set of values. The tests run offline with `timoni mod test`, without a
+Kubernetes cluster.
+
+## Test files
+
+Test cases live in files ending in `_test.cue`, placed next to the templates they
+cover, in the same CUE package:
+
+```text
+my-module/
+├── templates/
+│   ├── config.cue
+│   ├── service.cue
+│   └── service_test.cue
+├── timoni.cue
+└── values.cue
+```
+
+Like Go, CUE excludes `*_test.cue` files from regular package loads. They are
+invisible to `timoni build`, `timoni apply` and `timoni mod vet`, they are read
+only by `timoni mod test`, and they are never included in the published module
+artifact.
+
+## Test cases
+
+Each case is a field under `cases`, keyed by the test name:
+
+```cue
+package templates
+
+cases: "service defaults to ClusterIP on port 80": {
+	objects: "Service/test/test": {
+		apiVersion: "v1"
+		spec: {
+			type: "ClusterIP"
+			ports: [{name: "http", port: 80, protocol: "TCP", targetPort: "http"}]
+		}
+	}
+}
+```
+
+Timoni builds the module with the case's inputs, then unifies the case's
+`objects` with the Kubernetes objects the module rendered. A case passes when
+every expectation holds. Cases are independent: one case cannot influence the
+outcome of another.
+
+Only the fields named in a case are checked, so an expectation is a partial
+object rather than a full manifest. Lists are an exception: their lengths must
+match, so `ports: [{port: 80}]` asserts both that there is exactly one port and
+that its number is 80.
+
+Every field a case names must be one the module actually renders. An expectation
+for an object or a field that does not exist fails the case:
+
+```text
+FAIL service defaults to ClusterIP on port 80
+     expected field(s) "Service/test/test".spec.typ not rendered by the module
+```
+
+A case that names no expectations at all is still built, and checks that a given
+set of values renders successfully.
+
+### Addressing objects
+
+Objects are keyed by `<kind>/<namespace>/<name>`, the same identifier Timoni
+prints for a resource in the output of `timoni build`, `timoni apply` and
+`timoni mod vet`. Cluster-scoped objects have no namespace segment:
+
+```cue
+objects: "Deployment/test/test": spec: replicas: 2
+objects: "ClusterRole/test":     rules: [{verbs: ["get"], resources: ["pods"], apiGroups: [""]}]
+```
+
+When a module renders two objects of the same kind from different API groups,
+such as a core `Service` and a Knative `Service`, the kind is qualified with the
+API group. Objects in the core group have no group to add:
+
+```cue
+objects: "Service/test/test": spec: type: "ClusterIP"
+objects: "Service.serving.knative.dev/test/test": spec: template: spec: containers: [{image: "app:1.0.0"}]
+```
+
+An expectation for an object the module does not render fails the case, and the
+error lists the keys the module does render.
+
+### Case fields
+
+| Field           | Description                                                             |
+|-----------------|-------------------------------------------------------------------------|
+| `values`        | Values to build the module with, merged over the module's `values.cue`. |
+| `objects`       | Expected Kubernetes objects, keyed by `<kind>/<namespace>/<name>`.      |
+| `assert`        | Named predicates that must evaluate to `true`.                          |
+| `name`          | Instance name to build with, defaults to `test`.                        |
+| `namespace`     | Instance namespace to build with, defaults to `test`.                   |
+| `moduleVersion` | Module version to build with.                                           |
+| `kubeVersion`   | Kubernetes version to build with.                                       |
+
+A case may declare no other field. An unknown field fails the case. Helpers and
+the values under test belong in hidden fields, which are not part of a case's
+field set.
+
+### Testing with values
+
+Set `values` to build the case with a configuration other than the module defaults:
+
+```cue
+cases: "service port is configurable": {
+	values: service: port: 9898
+	objects: "Service/test/test": spec: ports: [{port: 9898}]
+}
+```
+
+### Testing across Kubernetes versions
+
+Modules that select an API version based on the cluster version can pin
+`kubeVersion` per case:
+
+```cue
+cases: "uses autoscaling/v2 on Kubernetes 1.23 and later": {
+	values: autoscaling: enabled: true
+	kubeVersion: "1.23.0"
+	objects: "HorizontalPodAutoscaler/test/test": apiVersion: "autoscaling/v2"
+}
+```
+
+## Assertions
+
+Expectations that cannot be expressed as a partial object go under `assert`, where
+each field is a description and its value must evaluate to `true`. A case using
+`assert` must declare the objects it reads, both so that the reference resolves
+and so that the keys are checked against what the module renders:
+
+```cue
+cases: "service selector targets the deployment pods": {
+	objects: {
+		"Service/test/test": kind:    "Service"
+		"Deployment/test/test": kind: "Deployment"
+	}
+	assert: "selector matches the pod template labels":
+		objects["Service/test/test"].spec.selector ==
+		objects["Deployment/test/test"].spec.template.metadata.labels
+}
+```
+
+Use assertions for cross-object invariants, for quantified checks over a list of
+resources, and for the absence of a field:
+
+```cue
+cases: "service has no annotations by default": {
+	objects: "Service/test/test": kind: "Service"
+	assert: "annotations are absent": objects["Service/test/test"].metadata.annotations == _|_
+}
+```
+
+A path that does not resolve is bottom, and bottom satisfies `== _|_`, so an
+absence assertion holds whether the field is absent or its name is misspelled.
+Pair it with a positive assertion on the same object when the distinction
+matters.
+
+## Testing the config schema
+
+A module's `#Config` is its public contract, and the values it rejects are worth
+testing. Because the config is reachable from the test file's package, these cases
+need no rendering at all:
+
+```cue
+cases: "service port outside the valid range is rejected": {
+	_config: #Config & {service: port: 70000}
+	assert: "port 70000 is rejected": _config == _|_
+}
+```
+
+The value under test must be assigned to a hidden field, so that the intentional
+error does not affect the rest of the evaluation.
+
+Note that a missing required field is incomplete rather than invalid, so it does
+not satisfy `== _|_`. To check that a field is required, assert on the field the
+schema leaves unresolved instead.
+
+## Running tests
+
+```shell
+timoni mod test ./path/to/module
+```
+
+```text
+PASS service annotations are propagated
+PASS service defaults to ClusterIP on port 80
+PASS service has no annotations by default
+PASS service port is configurable
+PASS service port outside the valid range is rejected
+PASS service selector targets the deployment pods
+OK 6 test cases passed
+```
+
+The command exits non-zero when a case fails. Every expectation that did not
+hold is reported, with the path to the field and its position in the test file:
+
+```text
+FAIL service defaults to ClusterIP on port 80
+     cases."service defaults to ClusterIP on port 80".objects."Service/test/test".spec.ports.0.port: conflicting values 80 and 443:
+         ./templates/service_test.cue:6:33
+     cases."service defaults to ClusterIP on port 80".objects."Service/test/test".spec.type: conflicting values "ClusterIP" and "LoadBalancer":
+         ./templates/service_test.cue:5:9
+```
+
+To run a subset of the cases, filter them by name with a regular expression:
+
+```shell
+timoni mod test ./path/to/module --run '^service'
+```
+
+A module with no test cases at all passes. An expression that matches none of
+the cases a module does have is an error.

--- a/examples/minimal/templates/service_test.cue
+++ b/examples/minimal/templates/service_test.cue
@@ -1,0 +1,43 @@
+package templates
+
+cases: "service defaults to ClusterIP on port 80": {
+	objects: "Service/test/test": {
+		apiVersion: "v1"
+		metadata: labels: "app.kubernetes.io/managed-by": "timoni"
+		spec: {
+			type: "ClusterIP"
+			selector: "app.kubernetes.io/name": "test"
+			ports: [{name: "http", port: 80, protocol: "TCP", targetPort: "http"}]
+		}
+	}
+}
+
+cases: "service port is configurable": {
+	values: service: port: 9898
+	objects: "Service/test/test": spec: ports: [{port: 9898}]
+}
+
+cases: "service annotations are propagated": {
+	values: service: annotations: "external-dns.alpha.kubernetes.io/hostname": "app.example.com"
+	objects: "Service/test/test": metadata: annotations: "external-dns.alpha.kubernetes.io/hostname": "app.example.com"
+}
+
+cases: "service has no annotations by default": {
+	objects: "Service/test/test": kind: "Service"
+	assert: "annotations are absent": objects["Service/test/test"].metadata.annotations == _|_
+}
+
+cases: "service selector targets the deployment pods": {
+	objects: {
+		"Service/test/test": kind:    "Service"
+		"Deployment/test/test": kind: "Deployment"
+	}
+	assert: "selector matches the pod template labels":
+		objects["Service/test/test"].spec.selector ==
+		objects["Deployment/test/test"].spec.template.metadata.labels
+}
+
+cases: "service port outside the valid range is rejected": {
+	_config: #Config & {service: port: 70000}
+	assert: "port 70000 is rejected": _config == _|_
+}

--- a/internal/engine/module_tester.go
+++ b/internal/engine/module_tester.go
@@ -1,0 +1,646 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/load"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+const (
+	// testFileSuffix is the suffix of the CUE files holding a module's test cases.
+	// The CUE loader excludes these files from regular package loads, so they are
+	// invisible to build, apply and vet, and are only read when Tests is enabled.
+	testFileSuffix = "_test.cue"
+
+	// defaultTestName is the instance name a test case is built with
+	// unless the case overrides it.
+	defaultTestName = "test"
+
+	// defaultTestNamespace is the instance namespace a test case is built with
+	// unless the case overrides it.
+	defaultTestNamespace = "test"
+)
+
+// caseFields are the fields a test case may declare. Hidden fields are not
+// part of this set: they are excluded from a case's field set and are where
+// helpers and the values under test belong.
+var caseFields = []apiv1.Selector{
+	apiv1.TestNameSelector,
+	apiv1.TestNamespaceSelector,
+	apiv1.TestModuleVersionSelector,
+	apiv1.TestKubeVersionSelector,
+	apiv1.TestValuesSelector,
+	apiv1.TestObjectsSelector,
+	apiv1.TestAssertSelector,
+}
+
+// TestCase is a single test case declared under the 'cases' field
+// of a module's *_test.cue file.
+type TestCase struct {
+	// Name is the case name as declared in CUE.
+	Name string
+
+	// Dir is the directory holding the CUE package the case was declared in,
+	// relative to the module root.
+	Dir string
+
+	// value holds the case declaration, before the rendered objects are filled in.
+	value cue.Value
+}
+
+// TestResult is the outcome of running a TestCase.
+type TestResult struct {
+	// Case is the test case that produced this result.
+	Case TestCase
+
+	// Err is nil when the case passed, and holds the reason it failed otherwise.
+	Err error
+}
+
+// Passed reports whether the test case succeeded.
+func (r TestResult) Passed() bool {
+	return r.Err == nil
+}
+
+// ModuleTester runs the test cases declared in a module's *_test.cue files.
+// Each case is checked against a build made with its own inputs, so a case
+// cannot influence the outcome of another. A tester is not safe for concurrent
+// use.
+type ModuleTester struct {
+	ctx        *cue.Context
+	moduleRoot string
+	pkgName    string
+	builds     map[string]*moduleBuild
+}
+
+// NewModuleTester creates a ModuleTester for the module at the given root.
+func NewModuleTester(ctx *cue.Context, moduleRoot, pkgName string) *ModuleTester {
+	if ctx == nil {
+		ctx = cuecontext.New()
+	}
+	return &ModuleTester{
+		ctx:        ctx,
+		moduleRoot: moduleRoot,
+		pkgName:    pkgName,
+		builds:     make(map[string]*moduleBuild),
+	}
+}
+
+// LoadCases finds the module's *_test.cue files, loads the CUE packages holding
+// them, and returns the test cases declared under their 'cases' field.
+// The cases are returned sorted by directory and name so that runs are reproducible.
+func (t *ModuleTester) LoadCases() ([]TestCase, error) {
+	dirs, err := t.testDirs()
+	if err != nil {
+		return nil, err
+	}
+
+	var cases []TestCase
+	for _, dir := range dirs {
+		found, err := t.loadCasesFromDir(dir)
+		if err != nil {
+			return nil, fmt.Errorf("loading tests from %s failed: %w", dir, err)
+		}
+		cases = append(cases, found...)
+	}
+
+	sort.SliceStable(cases, func(i, j int) bool {
+		if cases[i].Dir != cases[j].Dir {
+			return cases[i].Dir < cases[j].Dir
+		}
+		return cases[i].Name < cases[j].Name
+	})
+
+	return cases, nil
+}
+
+// testDirs returns the module directories containing at least one *_test.cue file,
+// relative to the module root. The CUE module metadata directory is skipped.
+func (t *ModuleTester) testDirs() ([]string, error) {
+	seen := make(map[string]bool)
+	var dirs []string
+
+	err := filepath.WalkDir(t.moduleRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "cue.mod" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), testFileSuffix) {
+			return nil
+		}
+
+		dir := filepath.Dir(path)
+		rel, err := filepath.Rel(t.moduleRoot, dir)
+		if err != nil {
+			return err
+		}
+		if !seen[rel] {
+			seen[rel] = true
+			dirs = append(dirs, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(dirs)
+	return dirs, nil
+}
+
+// loadCasesFromDir loads the CUE package in the given module directory with test
+// files included, and extracts the cases declared under its 'cases' field.
+func (t *ModuleTester) loadCasesFromDir(dir string) ([]TestCase, error) {
+	cfg := &load.Config{
+		AcceptLegacyModules: true,
+		Dir:                 t.moduleRoot,
+		DataFiles:           true,
+		Tests:               true,
+	}
+
+	instances := load.Instances([]string{"./" + filepath.ToSlash(dir)}, cfg)
+	if len(instances) == 0 {
+		return nil, errors.New("no instances found")
+	}
+
+	instance := instances[0]
+	if instance.Err != nil {
+		return nil, instance.Err
+	}
+
+	// The build value is not checked for errors here: a case that asserts a
+	// value is rejected holds an intentional bottom, which would otherwise be
+	// reported as a failure to load the package. Errors are instead scoped to
+	// each case when it runs.
+	value := t.ctx.BuildInstance(instance)
+
+	cases := value.LookupPath(cue.ParsePath(apiv1.TestCasesSelector.String()))
+	if !cases.Exists() {
+		// A package may hold test helpers without declaring any case.
+		return nil, nil
+	}
+
+	iter, err := cases.Fields()
+	if err != nil {
+		return nil, fmt.Errorf("lookup %s failed: %w", apiv1.TestCasesSelector, err)
+	}
+
+	var result []TestCase
+	for iter.Next() {
+		result = append(result, TestCase{
+			Name:  iter.Selector().Unquoted(),
+			Dir:   dir,
+			value: iter.Value(),
+		})
+	}
+
+	return result, nil
+}
+
+// Run builds the module with the case's values and checks its expectations
+// against the resulting Kubernetes objects.
+func (t *ModuleTester) Run(tc TestCase) TestResult {
+	if err := checkCaseFields(tc.value); err != nil {
+		return TestResult{Case: tc, Err: err}
+	}
+
+	rendered := t.render(tc)
+	if rendered.err != nil {
+		return TestResult{Case: tc, Err: rendered.err}
+	}
+
+	if err := checkExpectedObjectsExist(tc.value, rendered.objects); err != nil {
+		return TestResult{Case: tc, Err: err}
+	}
+
+	if err := checkExpectedFields(tc.value, rendered.value); err != nil {
+		return TestResult{Case: tc, Err: err}
+	}
+
+	// Fill the rendered objects into the case. The objects are concrete data, so
+	// unifying an expectation with them is a comparison rather than a refinement:
+	// a field the module leaves as a disjunction with a default would otherwise
+	// absorb the expected value instead of conflicting with it.
+	// The filled value is not checked for errors as a whole: a case that asserts
+	// a value is rejected holds an intentional bottom. Only the expectations and
+	// the assertions are validated.
+	filled := tc.value.FillPath(cue.ParsePath(apiv1.TestObjectsSelector.String()), rendered.value)
+
+	if err := checkObjects(filled); err != nil {
+		return TestResult{Case: tc, Err: err}
+	}
+
+	if err := checkAssertions(filled); err != nil {
+		return TestResult{Case: tc, Err: err}
+	}
+
+	return TestResult{Case: tc}
+}
+
+// objectKey returns the identifier a test case addresses an object by.
+// The unqualified form is the '<kind>/<namespace>/<name>' identifier Timoni
+// prints for an object everywhere else, with the namespace omitted when the
+// object is cluster-scoped. The qualified form carries the API group, and is
+// used for the objects that would otherwise share an identifier.
+func objectKey(object *unstructured.Unstructured, qualified bool) string {
+	kind := object.GetKind()
+	if group := object.GroupVersionKind().Group; qualified && group != "" {
+		kind = fmt.Sprintf("%s.%s", kind, group)
+	}
+
+	if namespace := object.GetNamespace(); namespace != "" {
+		return fmt.Sprintf("%s/%s/%s", kind, namespace, object.GetName())
+	}
+
+	return fmt.Sprintf("%s/%s", kind, object.GetName())
+}
+
+// buildInputs are the inputs a test case builds the module with.
+type buildInputs struct {
+	name          string
+	namespace     string
+	moduleVersion string
+	kubeVersion   string
+	values        cue.Value
+}
+
+// key identifies a set of build inputs. The values are keyed by their CUE text,
+// the form the module builder overlays them as, so that two cases configured
+// the same way share a key and any difference between them does not.
+func (in buildInputs) key() string {
+	var values string
+	if in.values.Exists() {
+		values = fmt.Sprintf("%v", in.values)
+	}
+
+	return strings.Join([]string{
+		in.name,
+		in.namespace,
+		in.moduleVersion,
+		in.kubeVersion,
+		values,
+	}, "\x00")
+}
+
+// caseInputs reads the build inputs a test case declares, falling back to the
+// defaults for the ones it leaves out.
+func caseInputs(tc TestCase) (buildInputs, error) {
+	var inputs buildInputs
+	var err error
+
+	if inputs.name, err = stringField(tc.value, apiv1.TestNameSelector, defaultTestName); err != nil {
+		return inputs, err
+	}
+
+	if inputs.namespace, err = stringField(tc.value, apiv1.TestNamespaceSelector, defaultTestNamespace); err != nil {
+		return inputs, err
+	}
+
+	if inputs.moduleVersion, err = stringField(tc.value, apiv1.TestModuleVersionSelector, ""); err != nil {
+		return inputs, err
+	}
+
+	if inputs.kubeVersion, err = stringField(tc.value, apiv1.TestKubeVersionSelector, ""); err != nil {
+		return inputs, err
+	}
+
+	inputs.values = tc.value.LookupPath(cue.ParsePath(apiv1.TestValuesSelector.String()))
+
+	return inputs, nil
+}
+
+// moduleBuild is the outcome of building the module with one set of inputs.
+type moduleBuild struct {
+	// objects are the rendered Kubernetes objects, keyed by test identifier.
+	objects map[string]any
+
+	// value holds the same objects encoded as CUE, ready to be unified
+	// with a case's expectations.
+	value cue.Value
+
+	// err is nil when the module built, and holds the reason it did not otherwise.
+	err error
+}
+
+// render returns the objects the module renders for the given case. A build is
+// a function of its inputs alone, so the cases that declare the same ones are
+// served the build made for the first of them, failures included.
+func (t *ModuleTester) render(tc TestCase) *moduleBuild {
+	inputs, err := caseInputs(tc)
+	if err != nil {
+		return &moduleBuild{err: err}
+	}
+
+	key := inputs.key()
+	if cached, ok := t.builds[key]; ok {
+		return cached
+	}
+
+	build := t.build(inputs)
+	t.builds[key] = build
+
+	return build
+}
+
+// build compiles the module with the given inputs and encodes the Kubernetes
+// objects it renders.
+func (t *ModuleTester) build(inputs buildInputs) *moduleBuild {
+	builder := NewModuleBuilder(t.ctx, inputs.name, inputs.namespace, t.moduleRoot, t.pkgName)
+	builder.SetVersionInfo(inputs.moduleVersion, inputs.kubeVersion)
+
+	if err := builder.OverlaySchemaFile(); err != nil {
+		return &moduleBuild{err: err}
+	}
+
+	if inputs.values.Exists() {
+		if err := builder.OverlayValuesFileWithDefaults(inputs.values); err != nil {
+			return &moduleBuild{err: fmt.Errorf("invalid values: %w", err)}
+		}
+	}
+
+	buildResult, err := builder.Build()
+	if err != nil {
+		return &moduleBuild{err: fmt.Errorf("build failed: %w", err)}
+	}
+
+	applySets, err := builder.GetApplySets(buildResult)
+	if err != nil {
+		return &moduleBuild{err: fmt.Errorf("build failed: %w", err)}
+	}
+
+	var objects []*unstructured.Unstructured
+	for _, set := range applySets {
+		objects = append(objects, set.Objects...)
+	}
+
+	keyed, err := keyObjects(objects)
+	if err != nil {
+		return &moduleBuild{err: err}
+	}
+
+	value := t.ctx.Encode(keyed)
+	if value.Err() != nil {
+		return &moduleBuild{err: value.Err()}
+	}
+
+	return &moduleBuild{objects: keyed, value: value}
+}
+
+// keyObjects returns the given objects keyed by their test identifier. The same
+// kind can be served by more than one API group, so the identifier Timoni prints
+// for an object is not unique on its own. The objects that would share one are
+// keyed by their group-qualified identifier instead, which keeps every object
+// addressable under exactly one key.
+func keyObjects(objects []*unstructured.Unstructured) (map[string]any, error) {
+	shared := make(map[string]int, len(objects))
+	for _, object := range objects {
+		shared[objectKey(object, false)]++
+	}
+
+	keyed := make(map[string]any, len(objects))
+	for _, object := range objects {
+		key := objectKey(object, shared[objectKey(object, false)] > 1)
+		if _, ok := keyed[key]; ok {
+			return nil, fmt.Errorf("the module renders more than one object identified by %s", key)
+		}
+		keyed[key] = object.Object
+	}
+
+	return keyed, nil
+}
+
+// checkCaseFields reports the fields a case declares that are not part of the
+// test case schema. Cases are open structs, so without this check a misspelled
+// field would be ignored and the case would run with the defaults it was
+// written to override.
+func checkCaseFields(value cue.Value) error {
+	iter, err := value.Fields()
+	if err != nil {
+		return fmt.Errorf("reading the case fields failed: %w", err)
+	}
+
+	var unknown []string
+	for iter.Next() {
+		name := iter.Selector().Unquoted()
+		if !slices.Contains(caseFields, apiv1.Selector(name)) {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	known := make([]string, 0, len(caseFields))
+	for _, field := range caseFields {
+		known = append(known, field.String())
+	}
+
+	sort.Strings(unknown)
+	return fmt.Errorf("unknown field(s) %s, a test case may declare %s",
+		strings.Join(unknown, ", "), strings.Join(known, ", "))
+}
+
+// checkExpectedFields reports the fields a case expects under an object that
+// the module does not render. The rendered objects are open structs, so an
+// expectation naming a field that does not exist would be added to the object
+// instead of compared against it, and the case would hold without checking it.
+func checkExpectedFields(value, rendered cue.Value) error {
+	objects := value.LookupPath(cue.ParsePath(apiv1.TestObjectsSelector.String()))
+	if !objects.Exists() {
+		return nil
+	}
+
+	var missing []string
+	if err := collectMissingFields(objects, rendered, nil, &missing); err != nil {
+		return fmt.Errorf("reading the expected objects failed: %w", err)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	sort.Strings(missing)
+	return fmt.Errorf("expected field(s) %s not rendered by the module", strings.Join(missing, ", "))
+}
+
+// collectMissingFields walks an expectation alongside the value it is about to
+// be unified with, and records the paths that value does not hold. The walk
+// stops where the two differ in kind or where the list is shorter than
+// expected, so that a mismatch is left to be reported as a conflict, which
+// names both sides.
+func collectMissingFields(expected, actual cue.Value, prefix []cue.Selector, missing *[]string) error {
+	switch expected.IncompleteKind() {
+	case cue.StructKind:
+		if actual.IncompleteKind() != cue.StructKind {
+			return nil
+		}
+
+		iter, err := expected.Fields()
+		if err != nil {
+			return err
+		}
+
+		for iter.Next() {
+			selector := iter.Selector()
+			path := append(slices.Clone(prefix), selector)
+
+			field := actual.LookupPath(cue.MakePath(selector))
+			if !field.Exists() {
+				*missing = append(*missing, cue.MakePath(path...).String())
+				continue
+			}
+
+			if err := collectMissingFields(iter.Value(), field, path, missing); err != nil {
+				return err
+			}
+		}
+	case cue.ListKind:
+		if actual.IncompleteKind() != cue.ListKind {
+			return nil
+		}
+
+		iter, err := expected.List()
+		if err != nil {
+			return err
+		}
+
+		for index := 0; iter.Next(); index++ {
+			selector := cue.Index(index)
+			path := append(slices.Clone(prefix), selector)
+
+			element := actual.LookupPath(cue.MakePath(selector))
+			if !element.Exists() {
+				return nil
+			}
+
+			if err := collectMissingFields(iter.Value(), element, path, missing); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkExpectedObjectsExist reports the object keys a case expects that the
+// module did not render. Without this check an expectation naming an object
+// that does not exist would unify with nothing and silently hold.
+func checkExpectedObjectsExist(value cue.Value, rendered map[string]any) error {
+	objects := value.LookupPath(cue.ParsePath(apiv1.TestObjectsSelector.String()))
+	if !objects.Exists() {
+		return nil
+	}
+
+	iter, err := objects.Fields()
+	if err != nil {
+		return fmt.Errorf("lookup %s failed: %w", apiv1.TestObjectsSelector, err)
+	}
+
+	var missing []string
+	for iter.Next() {
+		key := iter.Selector().Unquoted()
+		if _, ok := rendered[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	sort.Strings(missing)
+	available := make([]string, 0, len(rendered))
+	for key := range rendered {
+		available = append(available, key)
+	}
+	sort.Strings(available)
+
+	return fmt.Errorf("expected object(s) %s not rendered, the module renders %s",
+		strings.Join(missing, ", "), strings.Join(available, ", "))
+}
+
+// checkObjects validates the case's object expectations against the rendered
+// objects they were unified with.
+func checkObjects(filled cue.Value) error {
+	objects := filled.LookupPath(cue.ParsePath(apiv1.TestObjectsSelector.String()))
+	if !objects.Exists() {
+		return nil
+	}
+
+	return objects.Validate(cue.Concrete(true), cue.All())
+}
+
+// checkAssertions requires every field declared under the case's 'assert'
+// struct to evaluate to true.
+func checkAssertions(filled cue.Value) error {
+	assertions := filled.LookupPath(cue.ParsePath(apiv1.TestAssertSelector.String()))
+	if !assertions.Exists() {
+		return nil
+	}
+
+	iter, err := assertions.Fields()
+	if err != nil {
+		return fmt.Errorf("lookup %s failed: %w", apiv1.TestAssertSelector, err)
+	}
+
+	for iter.Next() {
+		name := iter.Selector().Unquoted()
+		holds, err := iter.Value().Bool()
+		if err != nil {
+			return fmt.Errorf("assertion %q could not be evaluated: %w", name, err)
+		}
+		if !holds {
+			return fmt.Errorf("assertion %q does not hold", name)
+		}
+	}
+
+	return nil
+}
+
+// stringField returns the string at the given selector, or the fallback when
+// the field is absent. A field that is present but is not a concrete string is
+// an error: falling back would build the case with a configuration other than
+// the one its author asked for.
+func stringField(value cue.Value, selector apiv1.Selector, fallback string) (string, error) {
+	field := value.LookupPath(cue.ParsePath(selector.String()))
+	if !field.Exists() {
+		return fallback, nil
+	}
+
+	str, err := field.String()
+	if err != nil {
+		return "", fmt.Errorf("invalid %s: %w", selector, err)
+	}
+
+	return str, nil
+}

--- a/internal/engine/module_tester_test.go
+++ b/internal/engine/module_tester_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func newTestObject(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	object := &unstructured.Unstructured{}
+	object.SetAPIVersion(apiVersion)
+	object.SetKind(kind)
+	object.SetNamespace(namespace)
+	object.SetName(name)
+	return object
+}
+
+func Test_KeyObjects(t *testing.T) {
+	g := NewWithT(t)
+
+	keyed, err := keyObjects([]*unstructured.Unstructured{
+		newTestObject("v1", "Service", "test", "app"),
+		newTestObject("apps/v1", "Deployment", "test", "app"),
+		newTestObject("rbac.authorization.k8s.io/v1", "ClusterRole", "", "app"),
+		newTestObject("v1", "ConfigMap", "other", "app"),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(keyed).To(HaveKey("Service/test/app"))
+	g.Expect(keyed).To(HaveKey("Deployment/test/app"))
+	g.Expect(keyed).To(HaveKey("ConfigMap/other/app"))
+	// A cluster-scoped object has no namespace segment.
+	g.Expect(keyed).To(HaveKey("ClusterRole/app"))
+}
+
+// Test_KeyObjectsSameKind checks that objects of the same kind served by
+// different API groups stay addressable, rather than one overwriting the other.
+func Test_KeyObjectsSameKind(t *testing.T) {
+	g := NewWithT(t)
+
+	keyed, err := keyObjects([]*unstructured.Unstructured{
+		newTestObject("v1", "Service", "test", "app"),
+		newTestObject("serving.knative.dev/v1", "Service", "test", "app"),
+		newTestObject("v1", "ConfigMap", "test", "app"),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(keyed).To(HaveLen(3))
+	g.Expect(keyed).To(HaveKey("Service.serving.knative.dev/test/app"))
+	// An object in the core group has no group to qualify the kind with.
+	g.Expect(keyed).To(HaveKey("Service/test/app"))
+	// A kind that is not contested keeps the identifier Timoni prints elsewhere.
+	g.Expect(keyed).To(HaveKey("ConfigMap/test/app"))
+}
+
+// Test_KeyObjectsSameKindOutsideCore checks that both objects carry their API
+// group when neither of them is served by the core group.
+func Test_KeyObjectsSameKindOutsideCore(t *testing.T) {
+	g := NewWithT(t)
+
+	keyed, err := keyObjects([]*unstructured.Unstructured{
+		newTestObject("cluster.x-k8s.io/v1beta1", "Cluster", "test", "app"),
+		newTestObject("postgresql.cnpg.io/v1", "Cluster", "test", "app"),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(keyed).To(HaveLen(2))
+	g.Expect(keyed).To(HaveKey("Cluster.cluster.x-k8s.io/test/app"))
+	g.Expect(keyed).To(HaveKey("Cluster.postgresql.cnpg.io/test/app"))
+}
+
+// Test_KeyObjectsSameNameDifferentNamespace checks that the namespace is part
+// of the identifier, so a module can render the same kind and name twice.
+func Test_KeyObjectsSameNameDifferentNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	keyed, err := keyObjects([]*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", "test", "app"),
+		newTestObject("v1", "ConfigMap", "other", "app"),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(keyed).To(HaveLen(2))
+	g.Expect(keyed).To(HaveKey("ConfigMap/test/app"))
+	g.Expect(keyed).To(HaveKey("ConfigMap/other/app"))
+}
+
+// Test_BuildInputsKey checks that the cases sharing a build are exactly the
+// ones built with the same inputs, since a case served another case's build
+// would be checked against objects it did not ask for.
+func Test_BuildInputsKey(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	base := buildInputs{
+		name:        "test",
+		namespace:   "test",
+		kubeVersion: "1.30.0",
+		values:      ctx.CompileString(`{replicas: 2}`),
+	}
+
+	same := base
+	same.values = ctx.CompileString(`{replicas: 2}`)
+	g.Expect(same.key()).To(Equal(base.key()))
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(*buildInputs)
+	}{
+		{"name", func(in *buildInputs) { in.name = "other" }},
+		{"namespace", func(in *buildInputs) { in.namespace = "other" }},
+		{"moduleVersion", func(in *buildInputs) { in.moduleVersion = "1.0.0" }},
+		{"kubeVersion", func(in *buildInputs) { in.kubeVersion = "1.31.0" }},
+		{"values", func(in *buildInputs) { in.values = ctx.CompileString(`{replicas: 3}`) }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			other := base
+			tt.mutate(&other)
+			g.Expect(other.key()).ToNot(Equal(base.key()))
+		})
+	}
+}
+
+// Test_BuildInputsKeyWithoutValues checks that a case declaring no values does
+// not share a build with one that declares them.
+func Test_BuildInputsKeyWithoutValues(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	defaults := buildInputs{name: "test", namespace: "test"}
+	explicit := defaults
+	explicit.values = ctx.CompileString(`{replicas: 2}`)
+
+	g.Expect(explicit.key()).ToNot(Equal(defaults.key()))
+}
+
+func Test_KeyObjectsIndistinguishable(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := keyObjects([]*unstructured.Unstructured{
+		newTestObject("v1", "ConfigMap", "test", "app"),
+		newTestObject("v1", "ConfigMap", "test", "app"),
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("more than one object identified by ConfigMap/test/app"))
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -145,6 +145,10 @@ func ColorizeWarning(subject string) string {
 	return color.YellowString(subject)
 }
 
+func ColorizeFailure(subject string) string {
+	return colorError.Sprint(subject)
+}
+
 func ColorizeUnstructured(object *unstructured.Unstructured) string {
 	return ColorizeSubject(ssautil.FmtUnstructured(object))
 }

--- a/internal/oci/build_image.go
+++ b/internal/oci/build_image.go
@@ -120,11 +120,13 @@ func BuildArtifactImage(contentPath string, ignorePaths []string, contentType st
 }
 
 // BuildModuleImage packages a module as ordered vendor and module layers.
+// Test files are excluded from both layers: they are an input to
+// 'timoni mod test' and are never part of the published module.
 func BuildModuleImage(contentPath string, ignorePaths []string, annotations map[string]string) (*ImageBuild, error) {
 	// Copy caller rules before excluding vendored schemas from the module layer.
-	moduleIgnore := append(append([]string{}, ignorePaths...), "cue.mod/")
+	moduleIgnore := append(append([]string{}, ignorePaths...), "cue.mod/", apiv1.TestFilePattern)
 	return buildImage(contentPath, []contentLayer{
-		{name: "vendor", ignorePaths: []string{"/*", "!/cue.mod"}, contentType: apiv1.TimoniModVendorContentType},
+		{name: "vendor", ignorePaths: []string{"/*", "!/cue.mod", apiv1.TestFilePattern}, contentType: apiv1.TimoniModVendorContentType},
 		{name: "module", ignorePaths: moduleIgnore, contentType: apiv1.TimoniModContentType},
 	}, annotations)
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
           - Cluster version constraints: cue/module/semver-constraints.md
           - Control the apply behavior: cue/module/apply-behavior.md
           - Custom health checks: cue/module/health-checks.md
+          - Test modules with CUE: cue/module/unit-tests.md
           - Run tests with Kubernetes Jobs: cue/module/test-jobs.md
           - Import resources from YAML: cue/module/import-resources.md
       - Module Distribution:
@@ -140,6 +141,7 @@ nav:
           - cmd/timoni_mod_pull.md
           - cmd/timoni_mod_list.md
           - cmd/timoni_mod_vet.md
+          - cmd/timoni_mod_test.md
           - cmd/timoni_mod_vendor.md
           - cmd/timoni_mod_vendor_k8s.md
           - cmd/timoni_mod_vendor_crd.md


### PR DESCRIPTION
⚠️  WIP

---

Module authors can write unit tests in CUE that check what a module renders for a
given set of values. The tests run offline with `timoni mod test`, without a
Kubernetes cluster.

## Test files

Test cases live in files ending in `_test.cue`, placed next to the templates they
cover, in the same CUE package:

```text
my-module/
├── templates/
│   ├── config.cue
│   ├── service.cue
│   └── service_test.cue
├── timoni.cue
└── values.cue
```

Like Go, CUE excludes `*_test.cue` files from regular package loads. They are
invisible to `timoni build`, `timoni apply` and `timoni mod vet`, they are read
only by `timoni mod test`, and they are never included in the published module
artifact.

## Test cases

Each case is a field under `cases`, keyed by the test name:

```cue
package templates

cases: "service defaults to ClusterIP on port 80": {
	objects: "Service/test/test": {
		apiVersion: "v1"
		spec: {
			type: "ClusterIP"
			ports: [{name: "http", port: 80, protocol: "TCP", targetPort: "http"}]
		}
	}
}
```

Timoni builds the module with the case's inputs, then unifies the case's
`objects` with the Kubernetes objects the module rendered. A case passes when
every expectation holds. Cases are independent: one case cannot influence the
outcome of another.

Only the fields named in a case are checked, so an expectation is a partial
object rather than a full manifest. Lists are an exception: their lengths must
match, so `ports: [{port: 80}]` asserts both that there is exactly one port and
that its number is 80.

Every field a case names must be one the module actually renders. An expectation
for an object or a field that does not exist fails the case:

```text
FAIL service defaults to ClusterIP on port 80
     expected field(s) "Service/test/test".spec.typ not rendered by the module
```

A case that names no expectations at all is still built, and checks that a given
set of values renders successfully.

### Addressing objects

Objects are keyed by `<kind>/<namespace>/<name>`, the same identifier Timoni
prints for a resource in the output of `timoni build`, `timoni apply` and
`timoni mod vet`. Cluster-scoped objects have no namespace segment:

```cue
objects: "Deployment/test/test": spec: replicas: 2
objects: "ClusterRole/test":     rules: [{verbs: ["get"], resources: ["pods"], apiGroups: [""]}]
```

When a module renders two objects of the same kind from different API groups,
such as a core `Service` and a Knative `Service`, the kind is qualified with the
API group. Objects in the core group have no group to add:

```cue
objects: "Service/test/test": spec: type: "ClusterIP"
objects: "Service.serving.knative.dev/test/test": spec: template: spec: containers: [{image: "app:1.0.0"}]
```

An expectation for an object the module does not render fails the case, and the
error lists the keys the module does render.

### Case fields

| Field           | Description                                                             |
|-----------------|-------------------------------------------------------------------------|
| `values`        | Values to build the module with, merged over the module's `values.cue`. |
| `objects`       | Expected Kubernetes objects, keyed by `<kind>/<namespace>/<name>`.      |
| `assert`        | Named predicates that must evaluate to `true`.                          |
| `name`          | Instance name to build with, defaults to `test`.                        |
| `namespace`     | Instance namespace to build with, defaults to `test`.                   |
| `moduleVersion` | Module version to build with.                                           |
| `kubeVersion`   | Kubernetes version to build with.                                       |

A case may declare no other field. An unknown field fails the case. Helpers and
the values under test belong in hidden fields, which are not part of a case's
field set.

### Testing with values

Set `values` to build the case with a configuration other than the module defaults:

```cue
cases: "service port is configurable": {
	values: service: port: 9898
	objects: "Service/test/test": spec: ports: [{port: 9898}]
}
```

### Testing across Kubernetes versions

Modules that select an API version based on the cluster version can pin
`kubeVersion` per case:

```cue
cases: "uses autoscaling/v2 on Kubernetes 1.23 and later": {
	values: autoscaling: enabled: true
	kubeVersion: "1.23.0"
	objects: "HorizontalPodAutoscaler/test/test": apiVersion: "autoscaling/v2"
}
```

## Assertions

Expectations that cannot be expressed as a partial object go under `assert`, where
each field is a description and its value must evaluate to `true`. A case using
`assert` must declare the objects it reads, both so that the reference resolves
and so that the keys are checked against what the module renders:

```cue
cases: "service selector targets the deployment pods": {
	objects: {
		"Service/test/test": kind:    "Service"
		"Deployment/test/test": kind: "Deployment"
	}
	assert: "selector matches the pod template labels":
		objects["Service/test/test"].spec.selector ==
		objects["Deployment/test/test"].spec.template.metadata.labels
}
```

Use assertions for cross-object invariants, for quantified checks over a list of
resources, and for the absence of a field:

```cue
cases: "service has no annotations by default": {
	objects: "Service/test/test": kind: "Service"
	assert: "annotations are absent": objects["Service/test/test"].metadata.annotations == _|_
}
```

A path that does not resolve is bottom, and bottom satisfies `== _|_`, so an
absence assertion holds whether the field is absent or its name is misspelled.
Pair it with a positive assertion on the same object when the distinction
matters.

## Testing the config schema

A module's `#Config` is its public contract, and the values it rejects are worth
testing. Because the config is reachable from the test file's package, these cases
need no rendering at all:

```cue
cases: "service port outside the valid range is rejected": {
	_config: #Config & {service: port: 70000}
	assert: "port 70000 is rejected": _config == _|_
}
```

The value under test must be assigned to a hidden field, so that the intentional
error does not affect the rest of the evaluation.

Note that a missing required field is incomplete rather than invalid, so it does
not satisfy `== _|_`. To check that a field is required, assert on the field the
schema leaves unresolved instead.

## Running tests

```shell
timoni mod test ./path/to/module
```

```text
PASS service annotations are propagated
PASS service defaults to ClusterIP on port 80
PASS service has no annotations by default
PASS service port is configurable
PASS service port outside the valid range is rejected
PASS service selector targets the deployment pods
OK 6 test cases passed
```

The command exits non-zero when a case fails. Every expectation that did not
hold is reported, with the path to the field and its position in the test file:

```text
FAIL service defaults to ClusterIP on port 80
     cases."service defaults to ClusterIP on port 80".objects."Service/test/test".spec.ports.0.port: conflicting values 80 and 443:
         ./templates/service_test.cue:6:33
     cases."service defaults to ClusterIP on port 80".objects."Service/test/test".spec.type: conflicting values "ClusterIP" and "LoadBalancer":
         ./templates/service_test.cue:5:9
```

To run a subset of the cases, filter them by name with a regular expression:

```shell
timoni mod test ./path/to/module --run '^service'
```

A module with no test cases at all passes. An expression that matches none of
the cases a module does have is an error.
