### PR TITLE
fix(engine): Validate the metadata of objects in apply sets

### DIFF
--- a/docs/cue/module/initialization.md
+++ b/docs/cue/module/initialization.md
@@ -311,6 +311,31 @@ timoni: {
 
 ```
 
+### Apply sets
+
+The `timoni: apply:` field holds one or more named lists of Kubernetes objects:
+
+```cue
+timoni: {
+	apply: app: [for obj in instance.objects {obj}]
+	apply: test: [for obj in instance.tests {obj}]
+}
+```
+
+The set names are chosen by the module author. When installing or upgrading
+an instance, Timoni applies the sets in the order they are defined. When
+waiting is enabled, Timoni waits for the objects in the current set to become
+ready before applying the next set.
+
+Every object in an apply set must have the `apiVersion`, `kind` and
+`metadata.name` fields set. The object's name, namespace, labels and
+annotations are validated at build time with the Kubernetes API server rules.
+When an object fails validation, Timoni reports an error containing the
+CUE path of the invalid object.
+
+Null values in apply sets are skipped, and Kubernetes `List` objects are
+expanded to their items.
+
 ### Kubernetes definitions
 
 The `deployment.cue` and `service.cue` files contain the

--- a/internal/engine/objectmeta.go
+++ b/internal/engine/objectmeta.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"fmt"
+	"maps"
+	"regexp"
+	"slices"
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/validate/content"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var regexHintRE = regexp.MustCompile(`regex used for validation is '([^']*)'`)
+
+// shortenRule collapses an apimachinery validation message to
+// "must match regex '<pattern>'" when the message carries the regex hint.
+func shortenRule(msg string) string {
+	m := regexHintRE.FindStringSubmatch(msg)
+	if len(m) < 2 {
+		return msg
+	}
+	return "must match regex '" + m[1] + "'"
+}
+
+// rbacKinds enumerates the kinds which the kube-apiserver validates with
+// path-segment rules instead of DNS-1123 subdomain.
+var rbacKinds = map[string]struct{}{
+	"Role":               {},
+	"ClusterRole":        {},
+	"RoleBinding":        {},
+	"ClusterRoleBinding": {},
+}
+
+// isRBACObject reports whether the object belongs to the Kubernetes RBAC
+// API group with a kind whose name allows path-segment characters.
+func isRBACObject(obj *unstructured.Unstructured) bool {
+	if _, ok := rbacKinds[obj.GetKind()]; !ok {
+		return false
+	}
+	return obj.GroupVersionKind().Group == rbacv1.GroupName
+}
+
+// validateObjectMeta checks that the object carries the apiVersion, kind and
+// metadata.name fields required for it to be applied on the cluster and
+// tracked in the instance inventory, then validates the metadata name,
+// namespace, labels and annotations with the kube-apiserver ObjectMeta rules.
+// It returns one error per violation.
+func validateObjectMeta(obj *unstructured.Unstructured) []error {
+	var missing []string
+	if obj.GetAPIVersion() == "" {
+		missing = append(missing, "apiVersion")
+	}
+	if obj.GetKind() == "" {
+		missing = append(missing, "kind")
+	}
+	if obj.GetName() == "" {
+		missing = append(missing, "metadata.name")
+	}
+	if len(missing) > 0 {
+		return []error{fmt.Errorf("missing required field(s) %s", strings.Join(missing, ", "))}
+	}
+
+	var errs []error
+
+	nameFn := apivalidation.NameIsDNSSubdomain
+	if isRBACObject(obj) {
+		nameFn = func(name string, _ bool) []string {
+			return content.IsPathSegmentName(name)
+		}
+	}
+	for _, msg := range nameFn(obj.GetName(), false) {
+		errs = append(errs, fmt.Errorf("metadata.name %q %s", obj.GetName(), shortenRule(msg)))
+	}
+
+	if ns := obj.GetNamespace(); ns != "" {
+		for _, msg := range apivalidation.ValidateNamespaceName(ns, false) {
+			errs = append(errs, fmt.Errorf("metadata.namespace %q %s", ns, shortenRule(msg)))
+		}
+	}
+
+	metadata, _ := obj.Object["metadata"].(map[string]any)
+	if labels, ok := metadata["labels"].(map[string]any); ok {
+		errs = append(errs, validateLabels(labels)...)
+	}
+	if annotations, ok := metadata["annotations"].(map[string]any); ok {
+		errs = append(errs, validateAnnotations(annotations)...)
+	}
+
+	return errs
+}
+
+// validateLabels validates the label keys and values with the
+// kube-apiserver rules, returning one error per violation.
+func validateLabels(labels map[string]any) []error {
+	var errs []error
+	for _, k := range slices.Sorted(maps.Keys(labels)) {
+		v, ok := labels[k].(string)
+		if !ok {
+			errs = append(errs, fmt.Errorf("metadata.labels[%q] must be a string", k))
+			continue
+		}
+		for _, msg := range content.IsLabelKey(k) {
+			errs = append(errs, fmt.Errorf("metadata.labels[%q] key %s", k, shortenRule(msg)))
+		}
+		for _, msg := range content.IsLabelValue(v) {
+			errs = append(errs, fmt.Errorf("metadata.labels[%q] value %s", k, shortenRule(msg)))
+		}
+	}
+	return errs
+}
+
+// validateAnnotations validates the annotation keys and the total
+// annotations size with the kube-apiserver rules, returning one error
+// per violation. Annotation keys are case-insensitive for the
+// qualified-name check, matching apivalidation.ValidateAnnotations.
+func validateAnnotations(annotations map[string]any) []error {
+	var errs []error
+	var totalSize int64
+	for _, k := range slices.Sorted(maps.Keys(annotations)) {
+		v, ok := annotations[k].(string)
+		if !ok {
+			errs = append(errs, fmt.Errorf("metadata.annotations[%q] must be a string", k))
+			continue
+		}
+		for _, msg := range content.IsLabelKey(strings.ToLower(k)) {
+			errs = append(errs, fmt.Errorf("metadata.annotations[%q] key %s", k, shortenRule(msg)))
+		}
+		totalSize += int64(len(k)) + int64(len(v))
+	}
+	if totalSize > int64(apivalidation.TotalAnnotationSizeLimitB) {
+		errs = append(errs, fmt.Errorf("metadata.annotations total size must be at most %d bytes",
+			apivalidation.TotalAnnotationSizeLimitB))
+	}
+	return errs
+}

--- a/internal/engine/objectmeta_test.go
+++ b/internal/engine/objectmeta_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeObject(apiVersion, kind, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{}}
+	if apiVersion != "" {
+		obj.SetAPIVersion(apiVersion)
+	}
+	if kind != "" {
+		obj.SetKind(kind)
+	}
+	if name != "" {
+		obj.SetName(name)
+	}
+	return obj
+}
+
+func TestValidateObjectMeta_Valid(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := makeObject("v1", "ConfigMap", "test")
+	obj.SetNamespace("default")
+	obj.SetLabels(map[string]string{"app.kubernetes.io/name": "test"})
+	obj.SetAnnotations(map[string]string{"timoni.sh/test": "enabled"})
+
+	g.Expect(validateObjectMeta(obj)).To(BeEmpty())
+}
+
+func TestValidateObjectMeta_MissingFields(t *testing.T) {
+	g := NewWithT(t)
+
+	errs := validateObjectMeta(makeObject("", "ConfigMap", ""))
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("missing required field(s) apiVersion, metadata.name"))
+
+	errs = validateObjectMeta(makeObject("v1", "", "test"))
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring("missing required field(s) kind"))
+}
+
+func TestValidateObjectMeta_InvalidName(t *testing.T) {
+	g := NewWithT(t)
+
+	errs := validateObjectMeta(makeObject("v1", "ConfigMap", "Test_App"))
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring(`metadata.name "Test_App" must match regex`))
+}
+
+func TestValidateObjectMeta_RBACName(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := makeObject("rbac.authorization.k8s.io/v1", "ClusterRole", "system:controller:test")
+	g.Expect(validateObjectMeta(obj)).To(BeEmpty())
+
+	obj = makeObject("v1", "ConfigMap", "system:controller:test")
+	g.Expect(validateObjectMeta(obj)).To(HaveLen(1))
+}
+
+func TestValidateObjectMeta_InvalidNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := makeObject("v1", "ConfigMap", "test")
+	obj.SetNamespace("Default")
+
+	errs := validateObjectMeta(obj)
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Error()).To(ContainSubstring(`metadata.namespace "Default"`))
+}
+
+func TestValidateObjectMeta_InvalidLabels(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := makeObject("v1", "ConfigMap", "test")
+	obj.Object["metadata"].(map[string]any)["labels"] = map[string]any{
+		"-invalid-key": "test",
+		"app":          "Invalid Value!",
+		"replicas":     int64(2),
+	}
+
+	errs := validateObjectMeta(obj)
+	g.Expect(errs).To(HaveLen(3))
+	g.Expect(errors.Join(errs...).Error()).To(SatisfyAll(
+		ContainSubstring(`metadata.labels["-invalid-key"] key must match regex`),
+		ContainSubstring(`metadata.labels["app"] value must match regex`),
+		ContainSubstring(`metadata.labels["replicas"] must be a string`),
+	))
+}
+
+func TestValidateObjectMeta_InvalidAnnotations(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := makeObject("v1", "ConfigMap", "test")
+	obj.Object["metadata"].(map[string]any)["annotations"] = map[string]any{
+		"-invalid-key": "test",
+		"large":        strings.Repeat("a", 256*1024),
+	}
+
+	errs := validateObjectMeta(obj)
+	g.Expect(errs).To(HaveLen(2))
+	g.Expect(errors.Join(errs...).Error()).To(SatisfyAll(
+		ContainSubstring(`metadata.annotations["-invalid-key"] key must match regex`),
+		ContainSubstring("metadata.annotations total size must be at most"),
+	))
+}

--- a/internal/engine/resourceset.go
+++ b/internal/engine/resourceset.go
@@ -18,13 +18,16 @@ package engine
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/encoding/yaml"
 	ssautil "github.com/fluxcd/pkg/ssa/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	apiyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // ResourceSet is a named list of Kubernetes resource objects.
@@ -39,8 +42,11 @@ type ResourceSet struct {
 }
 
 // GetResources converts the CUE value to a list of ResourceSets.
+// If objects in multiple resource lists are found invalid, the returned
+// error aggregates the failures of all lists, retrievable with errors.Unwrap.
 func GetResources(value cue.Value) ([]ResourceSet, error) {
 	var sets []ResourceSet
+	var errs []error
 
 	if err := value.Validate(cue.Concrete(true), cue.Final()); err != nil {
 		return nil, err
@@ -64,7 +70,8 @@ func GetResources(value cue.Value) ([]ResourceSet, error) {
 
 		objects, err := decodeObjects(items)
 		if err != nil {
-			return nil, fmt.Errorf("loading objects for resource list %q failed: %w", name, err)
+			errs = append(errs, fmt.Errorf("loading objects for resource list %q failed: %w", name, err))
+			continue
 		}
 
 		sets = append(sets, ResourceSet{
@@ -72,14 +79,20 @@ func GetResources(value cue.Value) ([]ResourceSet, error) {
 			Objects: objects,
 		})
 	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
 	return sets, nil
 }
 
 // decodeObjects converts the CUE values in the given iterator to Kubernetes
-// unstructured objects. Values which are not Kubernetes objects are silently
-// dropped from the result, and Kubernetes lists are expanded to their items.
+// unstructured objects. Null values and Kustomize config objects are skipped,
+// and Kubernetes lists are expanded to their items. Objects which fail the
+// validateObjectMeta checks yield an error naming their CUE path, one per
+// violation, aggregated with errors.Join across all items.
 func decodeObjects(items cue.Iterator) ([]*unstructured.Unstructured, error) {
 	objects := make([]*unstructured.Unstructured, 0)
+	var errs []error
 
 	for items.Next() {
 		item := items.Value()
@@ -87,42 +100,70 @@ func decodeObjects(items cue.Iterator) ([]*unstructured.Unstructured, error) {
 			continue
 		}
 
+		var (
+			objs []*unstructured.Unstructured
+			err  error
+		)
 		if needsYAMLDecoding(item) {
-			objs, err := decodeYAMLObjects(item)
-			if err != nil {
-				return nil, err
-			}
-			objects = append(objects, objs...)
-			continue
+			objs, err = decodeYAMLObjects(item)
+		} else {
+			objs, err = decodeJSONObjects(item)
 		}
-
-		data, err := item.MarshalJSON()
 		if err != nil {
-			return nil, err
-		}
-
-		obj := &unstructured.Unstructured{}
-		if err := obj.UnmarshalJSON(data); err != nil {
-			return nil, err
-		}
-
-		if obj.IsList() {
-			err = obj.EachListItem(func(item runtime.Object) error {
-				objects = append(objects, item.(*unstructured.Unstructured))
-				return nil
-			})
-			if err != nil {
-				return nil, err
-			}
+			errs = append(errs, fmt.Errorf("decoding object at path %s failed: %w", item.Path(), err))
 			continue
 		}
 
-		if ssautil.IsKubernetesObject(obj) && !ssautil.IsKustomization(obj) {
-			objects = append(objects, obj)
+		for _, obj := range objs {
+			if ssautil.IsKustomization(obj) {
+				continue
+			}
+
+			verrs := validateObjectMeta(obj)
+			for _, verr := range verrs {
+				errs = append(errs, fmt.Errorf("invalid object at path %s: %w", item.Path(), verr))
+			}
+			if len(verrs) == 0 {
+				objects = append(objects, obj)
+			}
 		}
 	}
 
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
 	return objects, nil
+}
+
+// listItems expands a Kubernetes list object to its items.
+func listItems(list *unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
+	var objects []*unstructured.Unstructured
+	err := list.EachListItem(func(item runtime.Object) error {
+		objects = append(objects, item.(*unstructured.Unstructured))
+		return nil
+	})
+	return objects, err
+}
+
+// decodeJSONObjects converts the CUE value to Kubernetes unstructured
+// objects through its JSON encoding, expanding Kubernetes lists to
+// their items.
+func decodeJSONObjects(value cue.Value) ([]*unstructured.Unstructured, error) {
+	data, err := value.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	obj := &unstructured.Unstructured{}
+	if err := obj.UnmarshalJSON(data); err != nil {
+		return nil, err
+	}
+
+	if obj.IsList() {
+		return listItems(obj)
+	}
+
+	return []*unstructured.Unstructured{obj}, nil
 }
 
 // needsYAMLDecoding reports whether the value contains fields of a kind
@@ -147,11 +188,35 @@ func needsYAMLDecoding(value cue.Value) bool {
 
 // decodeYAMLObjects converts the CUE value to Kubernetes unstructured
 // objects through a YAML round-trip, preserving the YAML decoding of
-// bytes and integral floats.
+// bytes and integral floats, and expanding Kubernetes lists to their items.
 func decodeYAMLObjects(value cue.Value) ([]*unstructured.Unstructured, error) {
 	data, err := yaml.Encode(value)
 	if err != nil {
 		return nil, err
 	}
-	return ssautil.ReadObjects(bytes.NewReader(data))
+
+	reader := apiyaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 2048)
+	objects := make([]*unstructured.Unstructured, 0)
+	for {
+		obj := &unstructured.Unstructured{}
+		err := reader.Decode(obj)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if obj.IsList() {
+			items, err := listItems(obj)
+			if err != nil {
+				return nil, err
+			}
+			objects = append(objects, items...)
+			continue
+		}
+
+		objects = append(objects, obj)
+	}
+	return objects, nil
 }

--- a/internal/engine/resourceset_test.go
+++ b/internal/engine/resourceset_test.go
@@ -124,3 +124,108 @@ func TestGetResources_MissingKind(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("Kind"))
 }
+
+func TestGetResources_MissingAPIVersion(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`app: [{
+		kind: "ConfigMap"
+		metadata: name: "test"
+	}]`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	_, err := GetResources(value)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(SatisfyAll(
+		ContainSubstring("invalid object at path app[0]"),
+		ContainSubstring("missing required field(s) apiVersion"),
+	))
+}
+
+func TestGetResources_MissingName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`app: [{
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+	}]`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	_, err := GetResources(value)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(SatisfyAll(
+		ContainSubstring("invalid object at path app[0]"),
+		ContainSubstring("missing required field(s) metadata.name"),
+	))
+}
+
+func TestGetResources_MissingNameBytesValue(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`app: [{
+		apiVersion: "v1"
+		kind:       "Secret"
+		stringData: key: '\x68\x69'
+	}]`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	_, err := GetResources(value)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("missing required field(s) metadata.name"))
+}
+
+func TestGetResources_InvalidMetadata(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`app: [{
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: {
+			name:      "Test_App"
+			namespace: "Default"
+			labels: app: "Invalid Value!"
+		}
+	}]`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	_, err := GetResources(value)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(SatisfyAll(
+		ContainSubstring(`metadata.name "Test_App"`),
+		ContainSubstring(`metadata.namespace "Default"`),
+		ContainSubstring(`metadata.labels["app"] value`),
+	))
+}
+
+func TestGetResources_AggregatesErrors(t *testing.T) {
+	g := NewWithT(t)
+	ctx := cuecontext.New()
+
+	value := ctx.CompileString(`
+	app: [{
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+	}]
+	addons: [{
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: name: "test"
+	}, {
+		kind: "ConfigMap"
+		metadata: name: "test"
+	}]`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+
+	_, err := GetResources(value)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(SatisfyAll(
+		ContainSubstring(`resource list "app"`),
+		ContainSubstring("invalid object at path app[0]"),
+		ContainSubstring(`resource list "addons"`),
+		ContainSubstring("invalid object at path addons[1]"),
+	))
+}


### PR DESCRIPTION
Fail the build with an error naming the CUE path of the offending object when an item in a `timoni: apply:` set is missing `apiVersion`, `kind` or` metadata.name`.

In addition, validate the object's `name`, `namespace`, `labels` and `annotations` using the same rules as Kubernetes API, aggregating all violations across the apply sets into a single error.

This PR also adds a section to the docs explaining the apply sets behavior. 

Fixes #514