### PR TITLE
feat(oci): Push pre-built module OCI archives

### DIFF
--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -38,7 +38,10 @@ var pushModCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(2),
 	Short: "Push a module to a container registry",
 	Long: `The push command packages the module as an OCI artifact and pushes it to the
-container registry using the version as the image tag.`,
+container registry using the version as the image tag.
+
+The push command can also push a module OCI archive or layout produced by
+'timoni mod build' without accessing the original module directory.`,
 	Example: `  # Push a module to Docker Hub using the credentials from '~/.docker/config.json'
   echo $DOCKER_PAT | docker login --username timoni --password-stdin
   timoni mod push ./path/to/module oci://docker.io/org/app-module -v 1.0.0
@@ -78,6 +81,9 @@ container registry using the version as the image tag.`,
   timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
 	--version=1.0.0 \
 	--sign=cosign
+
+  # Push a pre-built module OCI archive produced by 'timoni mod build'
+  timoni mod push ./module-1.0.0.oci.tar oci://docker.io/org/app-module -v 1.0.0
 `,
 	RunE: pushModCmdRun,
 }
@@ -141,54 +147,72 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 
 	ociURL := fmt.Sprintf("%s:%s", args[1], version)
 
-	if fs, err := os.Stat(pushModArgs.module); err != nil || !fs.IsDir() {
+	fs, err := os.Stat(pushModArgs.module)
+	if err != nil {
 		return fmt.Errorf("module not found at path %s", pushModArgs.module)
 	}
 
 	log := LoggerFrom(cmd.Context())
 
-	annotations, err := oci.ParseAnnotations(pushModArgs.annotations)
-	if err != nil {
-		return err
-	}
-
-	annotations[apiv1.VersionAnnotation] = version
-	oci.AppendGitMetadata(cmd.Context(), pushModArgs.module, annotations)
-
 	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
-
-	ps, err := engine.ReadIgnoreFile(pushModArgs.module)
-	if err != nil {
-		return fmt.Errorf("reading %s failed: %w", apiv1.IgnoreFile, err)
-	}
-	pushModArgs.ignorePaths = append(pushModArgs.ignorePaths, ps...)
-
-	// When symlink resolution is enabled, stage the module in a temp dir
-	// so that the artifact contains the resolved file set local builds
-	// see. Without it the archiver skips symlinks by itself, so the
-	// module is packaged straight from its source dir.
-	moduleDir := pushModArgs.module
-	if pushModArgs.resolveSymlinks {
-		tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
-		if err != nil {
-			return err
-		}
-		defer os.RemoveAll(tmpDir)
-
-		moduleDir = path.Join(tmpDir, "module")
-		if err := engine.CopyDir(pushModArgs.module, moduleDir, true); err != nil {
-			return err
-		}
-	}
 
 	spin := logger.StartSpinner("pushing module")
 	defer spin.Stop()
 
 	opts := oci.Options(ctx, pushModArgs.creds.String(), rootArgs.registryInsecure)
-	digestURL, err := oci.PushModule(ociURL, moduleDir, pushModArgs.ignorePaths, annotations, opts)
-	if err != nil {
-		return err
+
+	var digestURL string
+	if !fs.IsDir() || oci.IsOCILayout(pushModArgs.module) {
+		// Push a pre-built OCI archive or layout as-is.
+		if pushModArgs.resolveSymlinks {
+			return fmt.Errorf("--resolve-symlinks is not supported when pushing a pre-built archive or layout")
+		}
+		if len(pushModArgs.annotations) > 0 {
+			return fmt.Errorf("--annotation is not supported when pushing a pre-built archive or layout")
+		}
+
+		digestURL, err = oci.PushModuleArchive(ociURL, pushModArgs.module, version, opts)
+		if err != nil {
+			return err
+		}
+	} else {
+		annotations, err := oci.ParseAnnotations(pushModArgs.annotations)
+		if err != nil {
+			return err
+		}
+
+		annotations[apiv1.VersionAnnotation] = version
+		oci.AppendGitMetadata(cmd.Context(), pushModArgs.module, annotations)
+
+		ps, err := engine.ReadIgnoreFile(pushModArgs.module)
+		if err != nil {
+			return fmt.Errorf("reading %s failed: %w", apiv1.IgnoreFile, err)
+		}
+		pushModArgs.ignorePaths = append(pushModArgs.ignorePaths, ps...)
+
+		// When symlink resolution is enabled, stage the module in a temp dir
+		// so that the artifact contains the resolved file set local builds
+		// see. Without it the archiver skips symlinks by itself, so the
+		// module is packaged straight from its source dir.
+		moduleDir := pushModArgs.module
+		if pushModArgs.resolveSymlinks {
+			tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+			if err != nil {
+				return err
+			}
+			defer os.RemoveAll(tmpDir)
+
+			moduleDir = path.Join(tmpDir, "module")
+			if err := engine.CopyDir(pushModArgs.module, moduleDir, true); err != nil {
+				return err
+			}
+		}
+
+		digestURL, err = oci.PushModule(ociURL, moduleDir, pushModArgs.ignorePaths, annotations, opts)
+		if err != nil {
+			return err
+		}
 	}
 
 	if pushModArgs.latest {

--- a/cmd/timoni/mod_push.go
+++ b/cmd/timoni/mod_push.go
@@ -40,18 +40,18 @@ var pushModCmd = &cobra.Command{
 	Long: `The push command packages the module as an OCI artifact and pushes it to the
 container registry using the version as the image tag.
 
-The push command can also push a module OCI archive or layout produced by
-'timoni mod build' without accessing the original module directory.`,
+The push command can also push an OCI archive produced by 'timoni mod build',
+extracting the version from the archive manifest.`,
 	Example: `  # Push a module to Docker Hub using the credentials from '~/.docker/config.json'
   echo $DOCKER_PAT | docker login --username timoni --password-stdin
   timoni mod push ./path/to/module oci://docker.io/org/app-module -v 1.0.0
 
-  # Push a module to GitHub Container Registry using a GitHub token
-  timoni mod push ./path/to/module oci://ghcr.io/org/modules/app \
+  # Push a module to a private registry with explicit credentials
+  timoni mod push ./path/to/module oci://registry.example.com/org/app-module \
 	--version=1.0.0 \
-	--creds timoni:$GITHUB_TOKEN
+	--creds user:password
 
-  # Push a release candidate without marking it as the latest stable
+  # Push a pre-release version without marking it as latest
   timoni mod push ./path/to/module oci://docker.io/org/app-module \
 	--version=2.0.0-rc.1 \
 	--latest=false
@@ -83,7 +83,7 @@ The push command can also push a module OCI archive or layout produced by
 	--sign=cosign
 
   # Push a pre-built module OCI archive produced by 'timoni mod build'
-  timoni mod push ./module-1.0.0.oci.tar oci://docker.io/org/app-module -v 1.0.0
+  timoni mod push ./module-1.0.0.oci.tar oci://docker.io/org/app-module
 `,
 	RunE: pushModCmdRun,
 }
@@ -130,9 +130,6 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	pushModArgs.module = args[0]
 
 	version := pushModArgs.version.String()
-	if err := flags.ValidateModuleVersion(version); err != nil {
-		return err
-	}
 	if err := validateOutputFormat(pushModArgs.output, true); err != nil {
 		return err
 	}
@@ -145,12 +142,33 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	ociURL := fmt.Sprintf("%s:%s", args[1], version)
-
 	fs, err := os.Stat(pushModArgs.module)
 	if err != nil {
 		return fmt.Errorf("module not found at path %s", pushModArgs.module)
 	}
+
+	// A regular file is a pre-built OCI archive: the version comes from the
+	// archive manifest, while a module directory still requires --version.
+	if !fs.IsDir() {
+		if pushModArgs.resolveSymlinks {
+			return fmt.Errorf("--resolve-symlinks is not supported when pushing a pre-built archive")
+		}
+		if len(pushModArgs.annotations) > 0 {
+			return fmt.Errorf("--annotation is not supported when pushing a pre-built archive")
+		}
+		if version == "" {
+			version, err = oci.ModuleVersion(pushModArgs.module)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		if err := flags.ValidateModuleVersion(version); err != nil {
+			return err
+		}
+	}
+
+	ociURL := fmt.Sprintf("%s:%s", args[1], version)
 
 	log := LoggerFrom(cmd.Context())
 
@@ -163,15 +181,8 @@ func pushModCmdRun(cmd *cobra.Command, args []string) error {
 	opts := oci.Options(ctx, pushModArgs.creds.String(), rootArgs.registryInsecure)
 
 	var digestURL string
-	if !fs.IsDir() || oci.IsOCILayout(pushModArgs.module) {
-		// Push a pre-built OCI archive or layout as-is.
-		if pushModArgs.resolveSymlinks {
-			return fmt.Errorf("--resolve-symlinks is not supported when pushing a pre-built archive or layout")
-		}
-		if len(pushModArgs.annotations) > 0 {
-			return fmt.Errorf("--annotation is not supported when pushing a pre-built archive or layout")
-		}
-
+	if !fs.IsDir() {
+		// Push a pre-built OCI archive as-is.
 		digestURL, err = oci.PushModuleArchive(ociURL, pushModArgs.module, version, opts)
 		if err != nil {
 			return err

--- a/cmd/timoni/mod_push_test.go
+++ b/cmd/timoni/mod_push_test.go
@@ -197,12 +197,12 @@ func Test_PushMod_Archive(t *testing.T) {
 	g.Expect(archive).To(BeAnExistingFile())
 	g.Expect(buildOutput).To(ContainSubstring("digest: sha256:"))
 
-	// Push the pre-built archive to the registry.
+	// Push the pre-built archive without specifying a version: it is read
+	// from the archive manifest.
 	output, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
+		"mod push %s oci://%s",
 		archive,
 		modURL,
-		modVer,
 	))
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -220,12 +220,6 @@ func Test_PushMod_Archive(t *testing.T) {
 	g.Expect(manifest.Annotations[apiv1.CreatedAnnotation]).To(BeEquivalentTo("2024-01-02T03:04:05Z"))
 	g.Expect(manifest.Annotations[apiv1.VersionAnnotation]).To(BeEquivalentTo(modVer))
 	g.Expect(manifest.Annotations[apiv1.SourceAnnotation]).To(ContainSubstring("github.com"))
-
-	// The module layer shape must be preserved.
-	g.Expect(manifest.Config.MediaType).To(BeEquivalentTo(apiv1.ConfigMediaType))
-	g.Expect(len(manifest.Layers)).To(BeEquivalentTo(2))
-	g.Expect(manifest.Layers[0].Annotations[apiv1.ContentTypeAnnotation]).To(BeEquivalentTo(apiv1.TimoniModVendorContentType))
-	g.Expect(manifest.Layers[1].Annotations[apiv1.ContentTypeAnnotation]).To(BeEquivalentTo(apiv1.TimoniModContentType))
 }
 
 func Test_PushMod_ArchiveRejectsBadMediaType(t *testing.T) {
@@ -233,7 +227,7 @@ func Test_PushMod_ArchiveRejectsBadMediaType(t *testing.T) {
 	archive := filepath.Join(t.TempDir(), "foreign.tar")
 	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
 
-	// Write a non-Timoni image (default OCI config media type) as an archive.
+	// Write a non-Timoni image (Docker manifest media type) as an archive.
 	g.Expect(oci.WriteImage(empty.Image, archive, oci.FormatArchive, []string{"1.0.0"})).To(Succeed())
 
 	_, err := executeCommand(fmt.Sprintf(
@@ -241,37 +235,7 @@ func Test_PushMod_ArchiveRejectsBadMediaType(t *testing.T) {
 		archive,
 		modURL,
 	))
-	g.Expect(err).To(MatchError(ContainSubstring("unsupported artifact type")))
-}
-
-func Test_PushMod_LayoutDir(t *testing.T) {
-	g := NewWithT(t)
-	layoutDir := filepath.Join(t.TempDir(), "module")
-	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
-	modVer := "1.0.0"
-
-	buildOutput, err := executeCommand(fmt.Sprintf(
-		"mod build testdata/module -v %s -o %s --format oci-layout",
-		modVer,
-		layoutDir,
-	))
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(buildOutput).To(ContainSubstring("digest: sha256:"))
-
-	output, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v %s",
-		layoutDir,
-		modURL,
-		modVer,
-	))
-	g.Expect(err).ToNot(HaveOccurred())
-
-	image, err := crane.Pull(fmt.Sprintf("%s:%s", modURL, modVer))
-	g.Expect(err).ToNot(HaveOccurred())
-	digest, err := image.Digest()
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(output).To(ContainSubstring(digest.String()))
-	g.Expect(buildOutput).To(ContainSubstring(digest.String()))
+	g.Expect(err).To(MatchError(ContainSubstring("unsupported manifest media type")))
 }
 
 func Test_PushMod_ArchiveRejectsResolveSymlinks(t *testing.T) {
@@ -286,11 +250,11 @@ func Test_PushMod_ArchiveRejectsResolveSymlinks(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	_, err = executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v 1.0.0 --resolve-symlinks",
+		"mod push %s oci://%s --resolve-symlinks",
 		archive,
 		modURL,
 	))
-	g.Expect(err).To(MatchError(ContainSubstring("--resolve-symlinks is not supported when pushing a pre-built archive or layout")))
+	g.Expect(err).To(MatchError(ContainSubstring("--resolve-symlinks is not supported when pushing a pre-built archive")))
 }
 
 func Test_PushMod_ArchiveRejectsVersionMismatch(t *testing.T) {
@@ -316,7 +280,7 @@ func Test_PushMod_ArchiveMissingFile(t *testing.T) {
 	g := NewWithT(t)
 
 	_, err := executeCommand(fmt.Sprintf(
-		"mod push %s oci://%s -v 1.0.0",
+		"mod push %s oci://%s",
 		filepath.Join(t.TempDir(), "missing.tar"),
 		fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5)),
 	))

--- a/cmd/timoni/mod_push_test.go
+++ b/cmd/timoni/mod_push_test.go
@@ -24,11 +24,13 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	. "github.com/onsi/gomega"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/fscopy"
+	"github.com/stefanprodan/timoni/internal/oci"
 )
 
 func Test_PushMod(t *testing.T) {
@@ -173,4 +175,150 @@ func TestPushModRejectsInvalidOutputBeforeInput(t *testing.T) {
 
 	_, err := executeCommand("mod push /does/not/exist oci://registry.example.com/org/module -v 1.0.0 --output invalid")
 	g.Expect(err).To(MatchError("unknown --output=invalid, can be yaml or json"))
+}
+
+func Test_PushMod_Archive(t *testing.T) {
+	modPath := "testdata/module"
+
+	g := NewWithT(t)
+	archive := filepath.Join(t.TempDir(), "module.tar")
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
+	modVer := "1.0.0"
+
+	// Build the module to a local OCI archive first.
+	buildOutput, err := executeCommand(fmt.Sprintf(
+		"mod build %s -v %s -o %s -a %s=2024-01-02T03:04:05Z",
+		modPath,
+		modVer,
+		archive,
+		apiv1.CreatedAnnotation,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(archive).To(BeAnExistingFile())
+	g.Expect(buildOutput).To(ContainSubstring("digest: sha256:"))
+
+	// Push the pre-built archive to the registry.
+	output, err := executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v %s",
+		archive,
+		modURL,
+		modVer,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// The pushed digest must equal the build-time digest.
+	image, err := crane.Pull(fmt.Sprintf("%s:%s", modURL, modVer))
+	g.Expect(err).ToNot(HaveOccurred())
+	digest, err := image.Digest()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(ContainSubstring(digest.String()))
+	g.Expect(buildOutput).To(ContainSubstring(digest.String()))
+
+	// The baked annotations must be preserved on push.
+	manifest, err := image.Manifest()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(manifest.Annotations[apiv1.CreatedAnnotation]).To(BeEquivalentTo("2024-01-02T03:04:05Z"))
+	g.Expect(manifest.Annotations[apiv1.VersionAnnotation]).To(BeEquivalentTo(modVer))
+	g.Expect(manifest.Annotations[apiv1.SourceAnnotation]).To(ContainSubstring("github.com"))
+
+	// The module layer shape must be preserved.
+	g.Expect(manifest.Config.MediaType).To(BeEquivalentTo(apiv1.ConfigMediaType))
+	g.Expect(len(manifest.Layers)).To(BeEquivalentTo(2))
+	g.Expect(manifest.Layers[0].Annotations[apiv1.ContentTypeAnnotation]).To(BeEquivalentTo(apiv1.TimoniModVendorContentType))
+	g.Expect(manifest.Layers[1].Annotations[apiv1.ContentTypeAnnotation]).To(BeEquivalentTo(apiv1.TimoniModContentType))
+}
+
+func Test_PushMod_ArchiveRejectsBadMediaType(t *testing.T) {
+	g := NewWithT(t)
+	archive := filepath.Join(t.TempDir(), "foreign.tar")
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
+
+	// Write a non-Timoni image (default OCI config media type) as an archive.
+	g.Expect(oci.WriteImage(empty.Image, archive, oci.FormatArchive, []string{"1.0.0"})).To(Succeed())
+
+	_, err := executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v 1.0.0",
+		archive,
+		modURL,
+	))
+	g.Expect(err).To(MatchError(ContainSubstring("unsupported artifact type")))
+}
+
+func Test_PushMod_LayoutDir(t *testing.T) {
+	g := NewWithT(t)
+	layoutDir := filepath.Join(t.TempDir(), "module")
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
+	modVer := "1.0.0"
+
+	buildOutput, err := executeCommand(fmt.Sprintf(
+		"mod build testdata/module -v %s -o %s --format oci-layout",
+		modVer,
+		layoutDir,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(buildOutput).To(ContainSubstring("digest: sha256:"))
+
+	output, err := executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v %s",
+		layoutDir,
+		modURL,
+		modVer,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	image, err := crane.Pull(fmt.Sprintf("%s:%s", modURL, modVer))
+	g.Expect(err).ToNot(HaveOccurred())
+	digest, err := image.Digest()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(ContainSubstring(digest.String()))
+	g.Expect(buildOutput).To(ContainSubstring(digest.String()))
+}
+
+func Test_PushMod_ArchiveRejectsResolveSymlinks(t *testing.T) {
+	g := NewWithT(t)
+	archive := filepath.Join(t.TempDir(), "module.tar")
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
+
+	_, err := executeCommand(fmt.Sprintf(
+		"mod build testdata/module -v 1.0.0 -o %s",
+		archive,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v 1.0.0 --resolve-symlinks",
+		archive,
+		modURL,
+	))
+	g.Expect(err).To(MatchError(ContainSubstring("--resolve-symlinks is not supported when pushing a pre-built archive or layout")))
+}
+
+func Test_PushMod_ArchiveRejectsVersionMismatch(t *testing.T) {
+	g := NewWithT(t)
+	archive := filepath.Join(t.TempDir(), "module.tar")
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
+
+	_, err := executeCommand(fmt.Sprintf(
+		"mod build testdata/module -v 1.0.0 -o %s",
+		archive,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v 1.0.1",
+		archive,
+		modURL,
+	))
+	g.Expect(err).To(MatchError(ContainSubstring("version mismatch")))
+}
+
+func Test_PushMod_ArchiveMissingFile(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v 1.0.0",
+		filepath.Join(t.TempDir(), "missing.tar"),
+		fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5)),
+	))
+	g.Expect(err).To(MatchError(ContainSubstring("module not found at path")))
 }

--- a/docs/cue/module/publishing.md
+++ b/docs/cue/module/publishing.md
@@ -57,16 +57,17 @@ reference name. Use `--format=oci-layout` for directory output.
 Local outputs are unsigned; existing output paths are rejected.
 
 The archive produced by `mod build` can be pushed to a registry with
-`timoni mod push` without re-packaging the source module:
+`timoni mod push` without re-packaging the source module. The version is read
+from the archive manifest, so it must not be passed again:
 
 ```shell
 timoni mod build ./modules/my-app -v 1.0.0 -o ./my-app-1.0.0.oci.tar
-timoni mod push ./my-app-1.0.0.oci.tar oci://ghcr.io/org/modules/app -v 1.0.0
+timoni mod push ./my-app-1.0.0.oci.tar oci://ghcr.io/org/modules/app
 ```
 
-The version must match the version the archive was built with. Annotations and
-symlink resolution are fixed at build time, so `--annotation` and
-`--resolve-symlinks` are not supported when pushing a pre-built archive.
+Annotations and symlink resolution are fixed at build time, so
+`--annotation` and `--resolve-symlinks` are not supported when pushing a
+pre-built archive.
 
 ## Publishing module versions
 

--- a/docs/cue/module/publishing.md
+++ b/docs/cue/module/publishing.md
@@ -56,6 +56,18 @@ The version is required and becomes the manifest version annotation and local
 reference name. Use `--format=oci-layout` for directory output.
 Local outputs are unsigned; existing output paths are rejected.
 
+The archive produced by `mod build` can be pushed to a registry with
+`timoni mod push` without re-packaging the source module:
+
+```shell
+timoni mod build ./modules/my-app -v 1.0.0 -o ./my-app-1.0.0.oci.tar
+timoni mod push ./my-app-1.0.0.oci.tar oci://ghcr.io/org/modules/app -v 1.0.0
+```
+
+The version must match the version the archive was built with. Annotations and
+symlink resolution are fixed at build time, so `--annotation` and
+`--resolve-symlinks` are not supported when pushing a pre-built archive.
+
 ## Publishing module versions
 
 Timoni offers a command for publishing a module version

--- a/internal/oci/push_module.go
+++ b/internal/oci/push_module.go
@@ -20,12 +20,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/fluxcd/pkg/tar"
 	"github.com/google/go-containerregistry/pkg/crane"
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
@@ -55,15 +55,15 @@ func PushModule(ociURL, contentPath string, ignorePaths []string, annotations ma
 }
 
 // PushModuleArchive pushes a pre-built module image from a local OCI archive
-// or OCI layout to a registry, then returns the module's digest URL. The
-// version must match the version the image was built with.
+// to a registry, then returns the module's digest URL. The version must match
+// the version annotation baked into the archive.
 func PushModuleArchive(ociURL, archivePath, version string, opts []crane.Option) (result string, err error) {
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
 		return "", err
 	}
 
-	image, digest, cleanup, err := loadLocalImage(archivePath, version)
+	image, cleanup, err := imageFromLocal(archivePath)
 	if err != nil {
 		return "", err
 	}
@@ -71,101 +71,128 @@ func PushModuleArchive(ociURL, archivePath, version string, opts []crane.Option)
 		err = errors.Join(err, cleanup())
 	}()
 
+	manifest, err := image.Manifest()
+	if err != nil {
+		return "", fmt.Errorf("reading artifact manifest failed: %w", err)
+	}
+	if err := validateModuleManifest(manifest, version); err != nil {
+		return "", err
+	}
+
 	if err := crane.Push(image, ref.String(), opts...); err != nil {
 		return "", fmt.Errorf("pushing artifact failed: %w", err)
 	}
 
+	digest, err := image.Digest()
+	if err != nil {
+		return "", fmt.Errorf("calculating artifact digest failed: %w", err)
+	}
 	digestURL := ref.Context().Digest(digest.String()).String()
 	return fmt.Sprintf("%s%s", apiv1.ArtifactPrefix, digestURL), nil
 }
 
-// IsOCILayout reports whether path is an OCI image layout directory, that is
-// a directory written by `mod build --format=oci-layout` rather than a module
-// source directory. It is cheap to call and reads no blobs.
-func IsOCILayout(path string) bool {
-	for _, name := range []string{"oci-layout", "index.json"} {
-		info, err := os.Stat(filepath.Join(path, name))
-		if err != nil || info.IsDir() {
-			return false
-		}
-	}
-	return true
-}
-
-// loadLocalImage loads a Timoni module image from a local OCI archive or OCI
-// layout. The version matches the local reference stored in the layout index;
-// when no descriptor carries it, the first image is returned. The returned
-// image reads its blobs lazily from disk, so the caller must run the returned
-// cleanup function after the image is consumed.
-func loadLocalImage(source, version string) (gcrv1.Image, gcrv1.Hash, func() error, error) {
-	info, err := os.Stat(source)
+// ModuleVersion reads the module version annotation from a local OCI archive.
+func ModuleVersion(archivePath string) (string, error) {
+	image, cleanup, err := imageFromLocal(archivePath)
 	if err != nil {
-		return nil, gcrv1.Hash{}, nil, fmt.Errorf("module not found at path %s", source)
+		return "", err
 	}
-
-	image, cleanup, err := imageFromLocal(source, info.IsDir(), version)
-	if err != nil {
-		if cleanup != nil {
-			_ = cleanup()
-		}
-		return nil, gcrv1.Hash{}, nil, err
-	}
+	defer func() {
+		_ = cleanup()
+	}()
 
 	manifest, err := image.Manifest()
 	if err != nil {
-		_ = cleanup()
-		return nil, gcrv1.Hash{}, nil, fmt.Errorf("reading artifact manifest failed: %w", err)
+		return "", fmt.Errorf("reading artifact manifest failed: %w", err)
 	}
-	if manifest.Config.MediaType != apiv1.ConfigMediaType {
-		_ = cleanup()
-		return nil, gcrv1.Hash{}, nil, fmt.Errorf("unsupported artifact type '%s', must be '%s'",
-			manifest.Config.MediaType, apiv1.ConfigMediaType)
+	version, ok := manifest.Annotations[apiv1.VersionAnnotation]
+	if !ok {
+		return "", fmt.Errorf("module version annotation is missing")
 	}
-	if builtVersion, ok := manifest.Annotations[apiv1.VersionAnnotation]; ok && builtVersion != version {
-		_ = cleanup()
-		return nil, gcrv1.Hash{}, nil, fmt.Errorf("version mismatch: archive was built with version %s, cannot push as %s",
-			builtVersion, version)
-	}
-
-	digest, err := image.Digest()
-	if err != nil {
-		_ = cleanup()
-		return nil, gcrv1.Hash{}, nil, fmt.Errorf("calculating artifact digest failed: %w", err)
-	}
-	return image, digest, cleanup, nil
+	return version, nil
 }
 
-// imageFromLocal loads the first image of a local OCI layout directory or,
-// when source is a file, extracts the archive to a temporary directory that
-// stays alive until the returned cleanup function runs.
-func imageFromLocal(source string, isDir bool, version string) (gcrv1.Image, func() error, error) {
-	path := source
-	cleanup := func() error { return nil }
-	if !isDir {
-		tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
-		if err != nil {
-			return nil, nil, err
-		}
-		cleanup = func() error { return os.RemoveAll(tmpDir) }
-
-		archive, err := os.Open(source)
-		if err != nil {
-			return nil, cleanup, fmt.Errorf("opening OCI archive failed: %w", err)
-		}
-		defer archive.Close()
-
-		// Archives are plain tar streams of an OCI image layout.
-		if err := tar.Untar(archive, tmpDir,
-			tar.WithSkipGzip(),
-			tar.WithSkipSymlinks(),
-			tar.WithMaxUntarSize(tar.UnlimitedUntarSize),
-		); err != nil {
-			return nil, cleanup, fmt.Errorf("extracting OCI archive failed: %w", err)
-		}
-		path = tmpDir
+// validateModuleManifest verifies that the manifest describes a Timoni module
+// artifact: an OCI manifest with the Timoni config media type, the expected
+// version annotation, and exactly two ordered vendor and module layers.
+func validateModuleManifest(manifest *gcrv1.Manifest, version string) error {
+	if manifest.MediaType != types.OCIManifestSchema1 {
+		return fmt.Errorf("unsupported manifest media type %q", manifest.MediaType)
 	}
 
-	layoutPath, err := layout.FromPath(path)
+	if manifest.Config.MediaType != apiv1.ConfigMediaType {
+		return fmt.Errorf("unsupported config media type %q", manifest.Config.MediaType)
+	}
+
+	if got, ok := manifest.Annotations[apiv1.VersionAnnotation]; !ok {
+		return fmt.Errorf("module version annotation is missing")
+	} else if got != version {
+		return fmt.Errorf(
+			"version mismatch: archive was built with version %s, cannot push as %s",
+			got, version,
+		)
+	}
+
+	if len(manifest.Layers) != 2 {
+		return fmt.Errorf("invalid module artifact: expected 2 layers, got %d", len(manifest.Layers))
+	}
+
+	expected := []string{
+		apiv1.TimoniModVendorContentType,
+		apiv1.TimoniModContentType,
+	}
+
+	for i, layer := range manifest.Layers {
+		if layer.MediaType != apiv1.ContentMediaType {
+			return fmt.Errorf("invalid module layer %d media type %q", i, layer.MediaType)
+		}
+
+		if got := layer.Annotations[apiv1.ContentTypeAnnotation]; got != expected[i] {
+			return fmt.Errorf(
+				"invalid module layer %d content type %q, expected %q",
+				i, got, expected[i],
+			)
+		}
+	}
+
+	return nil
+}
+
+// imageFromLocal loads the first image of an OCI archive, extracting the
+// plain tar stream to a temporary directory that stays alive until the
+// returned cleanup function runs.
+func imageFromLocal(source string) (gcrv1.Image, func() error, error) {
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil, nil, fmt.Errorf("module not found at path %s", source)
+	}
+	if info.IsDir() {
+		return nil, nil, fmt.Errorf("module not found at path %s", source)
+	}
+
+	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := func() error { return os.RemoveAll(tmpDir) }
+
+	archive, err := os.Open(source)
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("opening OCI archive failed: %w", err)
+	}
+	defer func() {
+		_ = archive.Close()
+	}()
+
+	// Archives are plain tar streams of an OCI image layout.
+	if err := tar.Untar(archive, tmpDir,
+		tar.WithSkipGzip(),
+		tar.WithSkipSymlinks(),
+	); err != nil {
+		return nil, cleanup, fmt.Errorf("extracting OCI archive failed: %w", err)
+	}
+
+	layoutPath, err := layout.FromPath(tmpDir)
 	if err != nil {
 		return nil, cleanup, fmt.Errorf("opening OCI layout failed: %w", err)
 	}
@@ -179,13 +206,6 @@ func imageFromLocal(source string, isDir bool, version string) (gcrv1.Image, fun
 	}
 	if len(manifest.Manifests) == 0 {
 		return nil, cleanup, fmt.Errorf("no image found in OCI layout")
-	}
-
-	for _, desc := range manifest.Manifests {
-		if desc.Annotations["org.opencontainers.image.ref.name"] == version {
-			image, err := index.Image(desc.Digest)
-			return image, cleanup, err
-		}
 	}
 
 	image, err := index.Image(manifest.Manifests[0].Digest)

--- a/internal/oci/push_module.go
+++ b/internal/oci/push_module.go
@@ -17,9 +17,15 @@ limitations under the License.
 package oci
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/fluxcd/pkg/tar"
 	"github.com/google/go-containerregistry/pkg/crane"
+	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
@@ -46,4 +52,142 @@ func PushModule(ociURL, contentPath string, ignorePaths []string, annotations ma
 
 	digestURL := ref.Context().Digest(build.Digest.String()).String()
 	return fmt.Sprintf("%s%s", apiv1.ArtifactPrefix, digestURL), nil
+}
+
+// PushModuleArchive pushes a pre-built module image from a local OCI archive
+// or OCI layout to a registry, then returns the module's digest URL. The
+// version must match the version the image was built with.
+func PushModuleArchive(ociURL, archivePath, version string, opts []crane.Option) (result string, err error) {
+	ref, err := parseArtifactRef(ociURL)
+	if err != nil {
+		return "", err
+	}
+
+	image, digest, cleanup, err := loadLocalImage(archivePath, version)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err = errors.Join(err, cleanup())
+	}()
+
+	if err := crane.Push(image, ref.String(), opts...); err != nil {
+		return "", fmt.Errorf("pushing artifact failed: %w", err)
+	}
+
+	digestURL := ref.Context().Digest(digest.String()).String()
+	return fmt.Sprintf("%s%s", apiv1.ArtifactPrefix, digestURL), nil
+}
+
+// IsOCILayout reports whether path is an OCI image layout directory, that is
+// a directory written by `mod build --format=oci-layout` rather than a module
+// source directory. It is cheap to call and reads no blobs.
+func IsOCILayout(path string) bool {
+	for _, name := range []string{"oci-layout", "index.json"} {
+		info, err := os.Stat(filepath.Join(path, name))
+		if err != nil || info.IsDir() {
+			return false
+		}
+	}
+	return true
+}
+
+// loadLocalImage loads a Timoni module image from a local OCI archive or OCI
+// layout. The version matches the local reference stored in the layout index;
+// when no descriptor carries it, the first image is returned. The returned
+// image reads its blobs lazily from disk, so the caller must run the returned
+// cleanup function after the image is consumed.
+func loadLocalImage(source, version string) (gcrv1.Image, gcrv1.Hash, func() error, error) {
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil, gcrv1.Hash{}, nil, fmt.Errorf("module not found at path %s", source)
+	}
+
+	image, cleanup, err := imageFromLocal(source, info.IsDir(), version)
+	if err != nil {
+		if cleanup != nil {
+			_ = cleanup()
+		}
+		return nil, gcrv1.Hash{}, nil, err
+	}
+
+	manifest, err := image.Manifest()
+	if err != nil {
+		_ = cleanup()
+		return nil, gcrv1.Hash{}, nil, fmt.Errorf("reading artifact manifest failed: %w", err)
+	}
+	if manifest.Config.MediaType != apiv1.ConfigMediaType {
+		_ = cleanup()
+		return nil, gcrv1.Hash{}, nil, fmt.Errorf("unsupported artifact type '%s', must be '%s'",
+			manifest.Config.MediaType, apiv1.ConfigMediaType)
+	}
+	if builtVersion, ok := manifest.Annotations[apiv1.VersionAnnotation]; ok && builtVersion != version {
+		_ = cleanup()
+		return nil, gcrv1.Hash{}, nil, fmt.Errorf("version mismatch: archive was built with version %s, cannot push as %s",
+			builtVersion, version)
+	}
+
+	digest, err := image.Digest()
+	if err != nil {
+		_ = cleanup()
+		return nil, gcrv1.Hash{}, nil, fmt.Errorf("calculating artifact digest failed: %w", err)
+	}
+	return image, digest, cleanup, nil
+}
+
+// imageFromLocal loads the first image of a local OCI layout directory or,
+// when source is a file, extracts the archive to a temporary directory that
+// stays alive until the returned cleanup function runs.
+func imageFromLocal(source string, isDir bool, version string) (gcrv1.Image, func() error, error) {
+	path := source
+	cleanup := func() error { return nil }
+	if !isDir {
+		tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+		if err != nil {
+			return nil, nil, err
+		}
+		cleanup = func() error { return os.RemoveAll(tmpDir) }
+
+		archive, err := os.Open(source)
+		if err != nil {
+			return nil, cleanup, fmt.Errorf("opening OCI archive failed: %w", err)
+		}
+		defer archive.Close()
+
+		// Archives are plain tar streams of an OCI image layout.
+		if err := tar.Untar(archive, tmpDir,
+			tar.WithSkipGzip(),
+			tar.WithSkipSymlinks(),
+			tar.WithMaxUntarSize(tar.UnlimitedUntarSize),
+		); err != nil {
+			return nil, cleanup, fmt.Errorf("extracting OCI archive failed: %w", err)
+		}
+		path = tmpDir
+	}
+
+	layoutPath, err := layout.FromPath(path)
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("opening OCI layout failed: %w", err)
+	}
+	index, err := layoutPath.ImageIndex()
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("reading OCI layout failed: %w", err)
+	}
+	manifest, err := index.IndexManifest()
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("reading OCI layout failed: %w", err)
+	}
+	if len(manifest.Manifests) == 0 {
+		return nil, cleanup, fmt.Errorf("no image found in OCI layout")
+	}
+
+	for _, desc := range manifest.Manifests {
+		if desc.Annotations["org.opencontainers.image.ref.name"] == version {
+			image, err := index.Image(desc.Digest)
+			return image, cleanup, err
+		}
+	}
+
+	image, err := index.Image(manifest.Manifests[0].Digest)
+	return image, cleanup, err
 }

--- a/internal/oci/push_module_test.go
+++ b/internal/oci/push_module_test.go
@@ -21,13 +21,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	. "github.com/onsi/gomega"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
-func TestLoadLocalImage(t *testing.T) {
+func TestImageFromLocal(t *testing.T) {
 	g := NewWithT(t)
 
 	build, err := BuildModuleImage("testdata/module", []string{"timoni.ignore"}, map[string]string{
@@ -37,104 +39,200 @@ func TestLoadLocalImage(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	defer build.Close()
 
-	t.Run("layout directory", func(t *testing.T) {
-		g := NewWithT(t)
-		dst := filepath.Join(t.TempDir(), "module")
-		g.Expect(WriteImage(build.Image, dst, FormatLayout, []string{"1.0.0"})).To(Succeed())
-
-		image, digest, cleanup, err := loadLocalImage(dst, "1.0.0")
-		g.Expect(err).ToNot(HaveOccurred())
-		defer cleanup()
-		g.Expect(digest).To(Equal(build.Digest))
-		g.Expect(image).ToNot(BeNil())
-	})
-
 	t.Run("archive file", func(t *testing.T) {
 		g := NewWithT(t)
 		dst := filepath.Join(t.TempDir(), "module.tar")
 		g.Expect(WriteImage(build.Image, dst, FormatArchive, []string{"1.0.0"})).To(Succeed())
 
-		image, digest, cleanup, err := loadLocalImage(dst, "1.0.0")
+		image, cleanup, err := imageFromLocal(dst)
 		g.Expect(err).ToNot(HaveOccurred())
 		defer cleanup()
+
+		digest, err := image.Digest()
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(digest).To(Equal(build.Digest))
-		g.Expect(image).ToNot(BeNil())
 	})
 
-	t.Run("falls back to first descriptor", func(t *testing.T) {
+	t.Run("rejects directory", func(t *testing.T) {
 		g := NewWithT(t)
 		dst := filepath.Join(t.TempDir(), "module")
-		// The layout descriptor reference differs from the requested version,
-		// so the loader must fall back to the first image.
-		g.Expect(WriteImage(build.Image, dst, FormatLayout, []string{"9.9.9"})).To(Succeed())
+		g.Expect(WriteImage(build.Image, dst, FormatLayout, []string{"1.0.0"})).To(Succeed())
 
-		_, digest, cleanup, err := loadLocalImage(dst, "1.0.0")
-		g.Expect(err).ToNot(HaveOccurred())
-		defer cleanup()
-		g.Expect(digest).To(Equal(build.Digest))
+		_, _, err := imageFromLocal(dst)
+		g.Expect(err).To(MatchError(ContainSubstring("module not found at path")))
 	})
 
 	t.Run("missing source", func(t *testing.T) {
 		g := NewWithT(t)
-		_, _, _, err := loadLocalImage(filepath.Join(t.TempDir(), "missing.tar"), "1.0.0")
+		_, _, err := imageFromLocal(filepath.Join(t.TempDir(), "missing.tar"))
 		g.Expect(err).To(MatchError(ContainSubstring("module not found at path")))
 	})
 
-	t.Run("rejects foreign media type", func(t *testing.T) {
-		g := NewWithT(t)
-		dst := filepath.Join(t.TempDir(), "foreign.tar")
-		g.Expect(WriteImage(empty.Image, dst, FormatArchive, []string{"1.0.0"})).To(Succeed())
-
-		_, _, _, err := loadLocalImage(dst, "1.0.0")
-		g.Expect(err).To(MatchError(ContainSubstring("unsupported artifact type")))
-	})
-
-	t.Run("rejects version mismatch", func(t *testing.T) {
-		g := NewWithT(t)
-		dst := filepath.Join(t.TempDir(), "module.tar")
-		g.Expect(WriteImage(build.Image, dst, FormatArchive, []string{"1.0.0"})).To(Succeed())
-
-		_, _, _, err := loadLocalImage(dst, "2.0.0")
-		g.Expect(err).To(MatchError(ContainSubstring("version mismatch")))
-	})
-
-	t.Run("rejects corrupt archive", func(t *testing.T) {
+	t.Run("corrupt archive", func(t *testing.T) {
 		g := NewWithT(t)
 		dst := filepath.Join(t.TempDir(), "corrupt.tar")
 		g.Expect(os.WriteFile(dst, []byte("not a tar archive"), 0o644)).To(Succeed())
 
-		_, _, _, err := loadLocalImage(dst, "1.0.0")
+		_, _, err := imageFromLocal(dst)
 		g.Expect(err).To(MatchError(ContainSubstring("extracting OCI archive failed")))
 	})
 }
 
-func TestIsOCILayout(t *testing.T) {
+func TestModuleVersion(t *testing.T) {
 	g := NewWithT(t)
 
-	t.Run("recognizes layout directory", func(t *testing.T) {
-		build, err := BuildModuleImage("testdata/module", nil, map[string]string{
+	build, err := BuildModuleImage("testdata/module", []string{"timoni.ignore"}, map[string]string{
+		apiv1.CreatedAnnotation: "2024-01-02T03:04:05Z",
+		apiv1.VersionAnnotation: "1.0.0",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	defer build.Close()
+
+	t.Run("reads version annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "module.tar")
+		g.Expect(WriteImage(build.Image, dst, FormatArchive, []string{"1.0.0"})).To(Succeed())
+
+		version, err := ModuleVersion(dst)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(version).To(Equal("1.0.0"))
+	})
+
+	t.Run("rejects missing annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		// Build an image without the version annotation.
+		noVersion, err := BuildModuleImage("testdata/module", []string{"timoni.ignore"}, map[string]string{
+			apiv1.CreatedAnnotation: "2024-01-02T03:04:05Z",
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		defer noVersion.Close()
+
+		dst := filepath.Join(t.TempDir(), "module.tar")
+		g.Expect(WriteImage(noVersion.Image, dst, FormatArchive, []string{"1.0.0"})).To(Succeed())
+
+		_, err = ModuleVersion(dst)
+		g.Expect(err).To(MatchError(ContainSubstring("module version annotation is missing")))
+	})
+}
+
+func TestValidateModuleManifest(t *testing.T) {
+	g := NewWithT(t)
+
+	build, err := BuildModuleImage("testdata/module", []string{"timoni.ignore"}, map[string]string{
+		apiv1.CreatedAnnotation: "2024-01-02T03:04:05Z",
+		apiv1.VersionAnnotation: "1.0.0",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	defer build.Close()
+
+	manifest, err := build.Image.Manifest()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	t.Run("valid module manifest", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(validateModuleManifest(manifest, "1.0.0")).To(Succeed())
+	})
+
+	t.Run("rejects non-OCI manifest media type", func(t *testing.T) {
+		g := NewWithT(t)
+		foreign := &gcrv1.Manifest{MediaType: types.DockerManifestSchema2}
+		err := validateModuleManifest(foreign, "1.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("unsupported manifest media type")))
+	})
+
+	t.Run("rejects foreign config media type", func(t *testing.T) {
+		g := NewWithT(t)
+		foreign := &gcrv1.Manifest{MediaType: types.OCIManifestSchema1}
+		err := validateModuleManifest(foreign, "1.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("unsupported config media type")))
+	})
+
+	t.Run("rejects missing version annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		noVersion := &gcrv1.Manifest{
+			MediaType:   types.OCIManifestSchema1,
+			Config:      gcrv1.Descriptor{MediaType: apiv1.ConfigMediaType},
+			Annotations: map[string]string{},
+		}
+		err := validateModuleManifest(noVersion, "1.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("module version annotation is missing")))
+	})
+
+	t.Run("rejects version mismatch", func(t *testing.T) {
+		g := NewWithT(t)
+		err := validateModuleManifest(manifest, "2.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("version mismatch")))
+	})
+
+	t.Run("rejects wrong layer count", func(t *testing.T) {
+		g := NewWithT(t)
+		oneLayer := &gcrv1.Manifest{
+			MediaType: types.OCIManifestSchema1,
+			Config:    gcrv1.Descriptor{MediaType: apiv1.ConfigMediaType},
+			Annotations: map[string]string{
+				apiv1.VersionAnnotation: "1.0.0",
+			},
+			Layers: []gcrv1.Descriptor{{MediaType: apiv1.ContentMediaType}},
+		}
+		err := validateModuleManifest(oneLayer, "1.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("expected 2 layers")))
+	})
+
+	t.Run("rejects wrong layer content type", func(t *testing.T) {
+		g := NewWithT(t)
+		wrongLayers := &gcrv1.Manifest{
+			MediaType: types.OCIManifestSchema1,
+			Config:    gcrv1.Descriptor{MediaType: apiv1.ConfigMediaType},
+			Annotations: map[string]string{
+				apiv1.VersionAnnotation: "1.0.0",
+			},
+			Layers: []gcrv1.Descriptor{
+				{
+					MediaType: apiv1.ContentMediaType,
+					Annotations: map[string]string{
+						apiv1.ContentTypeAnnotation: "generic",
+					},
+				},
+				{
+					MediaType: apiv1.ContentMediaType,
+					Annotations: map[string]string{
+						apiv1.ContentTypeAnnotation: apiv1.TimoniModContentType,
+					},
+				},
+			},
+		}
+		err := validateModuleManifest(wrongLayers, "1.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("invalid module layer 0 content type")))
+	})
+
+	t.Run("rejects generic artifact", func(t *testing.T) {
+		g := NewWithT(t)
+		generic, err := BuildArtifactImage("testdata/module", []string{"timoni.ignore"}, "generic", map[string]string{
 			apiv1.VersionAnnotation: "1.0.0",
 		})
 		g.Expect(err).ToNot(HaveOccurred())
-		defer build.Close()
+		defer generic.Close()
 
-		dst := filepath.Join(t.TempDir(), "module")
-		g.Expect(WriteImage(build.Image, dst, FormatLayout, []string{"1.0.0"})).To(Succeed())
-		g.Expect(IsOCILayout(dst)).To(BeTrue())
+		manifest, err := generic.Image.Manifest()
+		g.Expect(err).ToNot(HaveOccurred())
+		err = validateModuleManifest(manifest, "1.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("expected 2 layers")))
 	})
+}
 
-	t.Run("rejects module source directory", func(t *testing.T) {
-		g := NewWithT(t)
-		g.Expect(IsOCILayout("testdata/module")).To(BeFalse())
-	})
+func TestLoadFromLocalRejectsForeignImage(t *testing.T) {
+	g := NewWithT(t)
 
-	t.Run("rejects missing path", func(t *testing.T) {
-		g := NewWithT(t)
-		g.Expect(IsOCILayout(filepath.Join(t.TempDir(), "missing"))).To(BeFalse())
-	})
+	// empty.Image has the Docker manifest media type and must be rejected
+	// before any registry interaction.
+	dst := filepath.Join(t.TempDir(), "foreign.tar")
+	g.Expect(WriteImage(empty.Image, dst, FormatArchive, []string{"1.0.0"})).To(Succeed())
 
-	t.Run("rejects archive file", func(t *testing.T) {
-		g := NewWithT(t)
-		g.Expect(IsOCILayout(filepath.Join(t.TempDir(), "module.tar"))).To(BeFalse())
-	})
+	image, cleanup, err := imageFromLocal(dst)
+	g.Expect(err).ToNot(HaveOccurred())
+	defer cleanup()
+
+	manifest, err := image.Manifest()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(validateModuleManifest(manifest, "1.0.0")).To(MatchError(ContainSubstring("unsupported manifest media type")))
 }

--- a/internal/oci/push_module_test.go
+++ b/internal/oci/push_module_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2023 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+func TestLoadLocalImage(t *testing.T) {
+	g := NewWithT(t)
+
+	build, err := BuildModuleImage("testdata/module", []string{"timoni.ignore"}, map[string]string{
+		apiv1.CreatedAnnotation: "2024-01-02T03:04:05Z",
+		apiv1.VersionAnnotation: "1.0.0",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	defer build.Close()
+
+	t.Run("layout directory", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "module")
+		g.Expect(WriteImage(build.Image, dst, FormatLayout, []string{"1.0.0"})).To(Succeed())
+
+		image, digest, cleanup, err := loadLocalImage(dst, "1.0.0")
+		g.Expect(err).ToNot(HaveOccurred())
+		defer cleanup()
+		g.Expect(digest).To(Equal(build.Digest))
+		g.Expect(image).ToNot(BeNil())
+	})
+
+	t.Run("archive file", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "module.tar")
+		g.Expect(WriteImage(build.Image, dst, FormatArchive, []string{"1.0.0"})).To(Succeed())
+
+		image, digest, cleanup, err := loadLocalImage(dst, "1.0.0")
+		g.Expect(err).ToNot(HaveOccurred())
+		defer cleanup()
+		g.Expect(digest).To(Equal(build.Digest))
+		g.Expect(image).ToNot(BeNil())
+	})
+
+	t.Run("falls back to first descriptor", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "module")
+		// The layout descriptor reference differs from the requested version,
+		// so the loader must fall back to the first image.
+		g.Expect(WriteImage(build.Image, dst, FormatLayout, []string{"9.9.9"})).To(Succeed())
+
+		_, digest, cleanup, err := loadLocalImage(dst, "1.0.0")
+		g.Expect(err).ToNot(HaveOccurred())
+		defer cleanup()
+		g.Expect(digest).To(Equal(build.Digest))
+	})
+
+	t.Run("missing source", func(t *testing.T) {
+		g := NewWithT(t)
+		_, _, _, err := loadLocalImage(filepath.Join(t.TempDir(), "missing.tar"), "1.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("module not found at path")))
+	})
+
+	t.Run("rejects foreign media type", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "foreign.tar")
+		g.Expect(WriteImage(empty.Image, dst, FormatArchive, []string{"1.0.0"})).To(Succeed())
+
+		_, _, _, err := loadLocalImage(dst, "1.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("unsupported artifact type")))
+	})
+
+	t.Run("rejects version mismatch", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "module.tar")
+		g.Expect(WriteImage(build.Image, dst, FormatArchive, []string{"1.0.0"})).To(Succeed())
+
+		_, _, _, err := loadLocalImage(dst, "2.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("version mismatch")))
+	})
+
+	t.Run("rejects corrupt archive", func(t *testing.T) {
+		g := NewWithT(t)
+		dst := filepath.Join(t.TempDir(), "corrupt.tar")
+		g.Expect(os.WriteFile(dst, []byte("not a tar archive"), 0o644)).To(Succeed())
+
+		_, _, _, err := loadLocalImage(dst, "1.0.0")
+		g.Expect(err).To(MatchError(ContainSubstring("extracting OCI archive failed")))
+	})
+}
+
+func TestIsOCILayout(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("recognizes layout directory", func(t *testing.T) {
+		build, err := BuildModuleImage("testdata/module", nil, map[string]string{
+			apiv1.VersionAnnotation: "1.0.0",
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		defer build.Close()
+
+		dst := filepath.Join(t.TempDir(), "module")
+		g.Expect(WriteImage(build.Image, dst, FormatLayout, []string{"1.0.0"})).To(Succeed())
+		g.Expect(IsOCILayout(dst)).To(BeTrue())
+	})
+
+	t.Run("rejects module source directory", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(IsOCILayout("testdata/module")).To(BeFalse())
+	})
+
+	t.Run("rejects missing path", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(IsOCILayout(filepath.Join(t.TempDir(), "missing"))).To(BeFalse())
+	})
+
+	t.Run("rejects archive file", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(IsOCILayout(filepath.Join(t.TempDir(), "module.tar"))).To(BeFalse())
+	})
+}


### PR DESCRIPTION
## What

Allow `timoni mod push` to push the OCI archive or layout produced by `timoni mod build` directly, without re-packaging the source module directory. The pushed digest matches the digest printed by `mod build`.

Closes #611.

## Why

`mod build` produces a self-contained OCI `.tar` for offline builds, but `timoni mod push` required the original module directory. Users who built the artifact elsewhere (sandbox, another machine) could not push what they built without extra tools like crane or skopeo.

## Reproduction

```shell
timoni mod build ./modules/my-app -v 1.0.0 -o ./my-app-1.0.0.oci.tar
timoni mod push ./my-app-1.0.0.oci.tar oci://ghcr.io/org/modules/app -v 1.0.0
# main: timoni mod push rejects the .tar and requires the module source directory.
# here: the pre-built archive is pushed as-is.
```

## Verification

```shell
go test ./cmd/timoni/ ./internal/oci/ -count=1
```

Developed with carefully directed, manually reviewed AI assistance.