### PR TITLE
feat(cli): Add workdir flag for resolving CUE imports in bundles

### DIFF
--- a/cmd/timoni/bundle.go
+++ b/cmd/timoni/bundle.go
@@ -25,6 +25,7 @@ type bundleFlags struct {
 	runtimeFiles        []string
 	runtimeCluster      string
 	runtimeClusterGroup string
+	workdir             string
 }
 
 var bundleArgs bundleFlags
@@ -43,5 +44,7 @@ func init() {
 		"Filter runtime cluster by name.")
 	bundleCmd.PersistentFlags().StringVar(&bundleArgs.runtimeClusterGroup, "runtime-group", "*",
 		"Filter runtime clusters by group.")
+	bundleCmd.PersistentFlags().StringVar(&bundleArgs.workdir, "workdir", "",
+		"The local path to the CUE module root (the directory containing cue.mod), used to resolve imports in the bundle and runtime definitions. Defaults to the current directory.")
 	rootCmd.AddCommand(bundleCmd)
 }

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -124,8 +124,14 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 	defer cancel()
 
+	workdir, err := resolveWorkdir(bundleArgs.workdir)
+	if err != nil {
+		return err
+	}
+
 	cuectx := cuecontext.New()
 	bm := engine.NewBundleBuilder(cuectx, files)
+	bm.SetWorkdir(workdir)
 
 	runtimeValues := make(map[string]string)
 
@@ -133,7 +139,7 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 		maps.Copy(runtimeValues, engine.GetEnv())
 	}
 
-	rt, err := buildRuntime(bundleArgs.runtimeFiles)
+	rt, err := buildRuntime(bundleArgs.runtimeFiles, bundleArgs.workdir)
 	if err != nil {
 		return err
 	}

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -108,8 +108,14 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
+	workdir, err := resolveWorkdir(bundleArgs.workdir)
+	if err != nil {
+		return err
+	}
+
 	ctx := cuecontext.New()
 	bm := engine.NewBundleBuilder(ctx, files)
+	bm.SetWorkdir(workdir)
 
 	workspace := apiv1.RuntimeDefaultName
 	runtimeValues := make(map[string]string)
@@ -122,7 +128,7 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		kctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
 		defer cancel()
 
-		rt, err := buildRuntime(bundleArgs.runtimeFiles)
+		rt, err := buildRuntime(bundleArgs.runtimeFiles, bundleArgs.workdir)
 		if err != nil {
 			return err
 		}

--- a/cmd/timoni/bundle_delete.go
+++ b/cmd/timoni/bundle_delete.go
@@ -95,7 +95,7 @@ func runBundleDelCmd(cmd *cobra.Command, args []string) error {
 		bundleDelArgs.name = args[0]
 	}
 
-	rt, err := buildRuntime(bundleArgs.runtimeFiles)
+	rt, err := buildRuntime(bundleArgs.runtimeFiles, bundleArgs.workdir)
 	if err != nil {
 		return err
 	}

--- a/cmd/timoni/bundle_status.go
+++ b/cmd/timoni/bundle_status.go
@@ -77,7 +77,7 @@ func runBundleStatusCmd(cmd *cobra.Command, args []string) error {
 		bundleStatusArgs.name = args[0]
 	}
 
-	rt, err := buildRuntime(bundleArgs.runtimeFiles)
+	rt, err := buildRuntime(bundleArgs.runtimeFiles, bundleArgs.workdir)
 	if err != nil {
 		return err
 	}

--- a/cmd/timoni/bundle_vet.go
+++ b/cmd/timoni/bundle_vet.go
@@ -97,8 +97,14 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 		defer os.Remove(stdinFile)
 	}
 
+	workdir, err := resolveWorkdir(bundleArgs.workdir)
+	if err != nil {
+		return err
+	}
+
 	cuectx := cuecontext.New()
 	bm := engine.NewBundleBuilder(cuectx, files)
+	bm.SetWorkdir(workdir)
 
 	runtimeValues := make(map[string]string)
 
@@ -106,7 +112,7 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 		maps.Copy(runtimeValues, engine.GetEnv())
 	}
 
-	rt, err := buildRuntime(bundleArgs.runtimeFiles)
+	rt, err := buildRuntime(bundleArgs.runtimeFiles, bundleArgs.workdir)
 	if err != nil {
 		return err
 	}

--- a/cmd/timoni/bundle_vet_test.go
+++ b/cmd/timoni/bundle_vet_test.go
@@ -406,3 +406,98 @@ runtime: {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(output).To(BeEquivalentTo(bundleComputed))
 }
+
+func Test_BundleVet_Workdir(t *testing.T) {
+	g := NewWithT(t)
+
+	moduleCue := `
+module: "test.example/bundles"
+language: version: "v0.14.0"
+`
+	imagesJSON := `{"podinfo": {"digest": "sha256:abc123"}}`
+
+	instanceCue := `
+@extern(embed)
+
+package instance
+
+_images: _ @embed(file="images.json")
+
+Podinfo: {
+	module: url:     "oci://ghcr.io/stefanprodan/modules/podinfo"
+	module: version: "6.7.0"
+	namespace: "podinfo"
+	values: image: digest: _images.podinfo.digest
+}
+`
+	bundleCue := `
+import "test.example/bundles/instance"
+
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "podinfo"
+	instances: podinfo: instance.Podinfo
+}
+`
+	bundleComputed := `bundle: {
+	apiVersion: "v1alpha1"
+	name:       "podinfo"
+	instances: {
+		podinfo: {
+			module: {
+				url:     "oci://ghcr.io/stefanprodan/modules/podinfo"
+				version: "6.7.0"
+			}
+			namespace: "podinfo"
+			values: {
+				image: {
+					digest: "sha256:abc123"
+				}
+			}
+		}
+	}
+}
+`
+	wd := t.TempDir()
+	g.Expect(os.MkdirAll(filepath.Join(wd, "cue.mod"), 0755)).ToNot(HaveOccurred())
+	g.Expect(os.MkdirAll(filepath.Join(wd, "instance"), 0755)).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(wd, "cue.mod", "module.cue"), []byte(moduleCue), 0644)).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(wd, "instance", "instance.cue"), []byte(instanceCue), 0644)).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(wd, "instance", "images.json"), []byte(imagesJSON), 0644)).ToNot(HaveOccurred())
+
+	bundlePath := filepath.Join(wd, "bundle.cue")
+	g.Expect(os.WriteFile(bundlePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
+
+	t.Run("resolves imports and embeds from workdir", func(t *testing.T) {
+		g := NewWithT(t)
+
+		output, err := executeCommand(fmt.Sprintf(
+			"bundle vet -f %s --workdir %s -p main --print-value",
+			bundlePath, wd,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(BeEquivalentTo(bundleComputed))
+	})
+
+	t.Run("fails without workdir", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := executeCommand(fmt.Sprintf(
+			"bundle vet -f %s -p main --print-value",
+			bundlePath,
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("imports are unavailable"))
+	})
+
+	t.Run("fails for workdir not found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := executeCommand(fmt.Sprintf(
+			"bundle vet -f %s --workdir %s -p main --print-value",
+			bundlePath, filepath.Join(wd, "not-found"),
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid workdir"))
+	})
+}

--- a/cmd/timoni/runtime_build.go
+++ b/cmd/timoni/runtime_build.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"cuelang.org/go/cue/cuecontext"
@@ -46,6 +47,7 @@ type runtimeBuildFlags struct {
 	files                []string
 	clusterSelector      string
 	clusterGroupSelector string
+	workdir              string
 }
 
 var runtimeBuildArgs runtimeBuildFlags
@@ -57,6 +59,8 @@ func init() {
 		"Select cluster by name.")
 	runtimeBuildCmd.Flags().StringVar(&runtimeBuildArgs.clusterGroupSelector, "cluster-group", "*",
 		"Select clusters by group name.")
+	runtimeBuildCmd.Flags().StringVar(&runtimeBuildArgs.workdir, "workdir", "",
+		"The local path to the CUE module root (the directory containing cue.mod), used to resolve imports in the runtime definitions. Defaults to the current directory.")
 	runtimeCmd.AddCommand(runtimeBuildCmd)
 }
 
@@ -80,7 +84,7 @@ func runRuntimeBuildCmd(cmd *cobra.Command, args []string) error {
 		defer os.Remove(stdinFile)
 	}
 
-	rt, err := buildRuntime(files)
+	rt, err := buildRuntime(files, runtimeBuildArgs.workdir)
 	if err != nil {
 		return err
 	}
@@ -128,14 +132,23 @@ func runRuntimeBuildCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func buildRuntime(files []string) (*apiv1.Runtime, error) {
+// buildRuntime compiles the runtime definitions into a Runtime object.
+// The workdir is the CUE module root used to resolve imports; when empty,
+// the CUE loader falls back to the process working directory.
+func buildRuntime(files []string, workdir string) (*apiv1.Runtime, error) {
 	defaultRuntime := apiv1.DefaultRuntime(*kubeconfigArgs.Context)
 	if len(files) == 0 {
 		return defaultRuntime, nil
 	}
 
+	dir, err := resolveWorkdir(workdir)
+	if err != nil {
+		return nil, err
+	}
+
 	ctx := cuecontext.New()
 	rb := engine.NewRuntimeBuilder(ctx, files)
+	rb.SetWorkdir(dir)
 
 	workspace := apiv1.RuntimeDefaultName
 	if err := rb.InitWorkspace(workspace); err != nil {
@@ -156,4 +169,28 @@ func buildRuntime(files []string) (*apiv1.Runtime, error) {
 		rt.Clusters = defaultRuntime.Clusters
 	}
 	return rt, nil
+}
+
+// resolveWorkdir validates that the given workdir exists and is a
+// directory, and returns its absolute path. An empty workdir resolves
+// to empty, letting the CUE loader use the process working directory.
+func resolveWorkdir(workdir string) (string, error) {
+	if workdir == "" {
+		return "", nil
+	}
+
+	dir, err := filepath.Abs(workdir)
+	if err != nil {
+		return "", fmt.Errorf("invalid workdir %s: %w", workdir, err)
+	}
+
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("invalid workdir: %w", err)
+	}
+	if !fi.IsDir() {
+		return "", fmt.Errorf("invalid workdir %s: not a directory", dir)
+	}
+
+	return dir, nil
 }

--- a/cmd/timoni/runtime_build_test.go
+++ b/cmd/timoni/runtime_build_test.go
@@ -225,3 +225,73 @@ runtime: {
 		g.Expect(i).To(BeEquivalentTo(1))
 	})
 }
+
+func Test_RuntimeBuild_Workdir(t *testing.T) {
+	g := NewWithT(t)
+
+	moduleCue := `
+module: "test.example/runtimes"
+language: version: "v0.14.0"
+`
+	fleetCue := `
+package fleet
+
+clusters: {
+	"staging": {
+		group:       "staging"
+		kubeContext: "envtest"
+	}
+}
+`
+	runtimeData := `
+import "test.example/runtimes/fleet"
+
+runtime: {
+	apiVersion: "v1alpha1"
+	name:       "fleet"
+	clusters: fleet.clusters
+	values: [
+		{
+			query: "k8s:v1:Namespace:kube-system"
+			for: {
+				"CLUSTER_UID": "obj.metadata.uid"
+			}
+		},
+	]
+}
+`
+	wd := t.TempDir()
+	g.Expect(os.MkdirAll(filepath.Join(wd, "cue.mod"), 0755)).ToNot(HaveOccurred())
+	g.Expect(os.MkdirAll(filepath.Join(wd, "fleet"), 0755)).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(wd, "cue.mod", "module.cue"), []byte(moduleCue), 0644)).ToNot(HaveOccurred())
+	g.Expect(os.WriteFile(filepath.Join(wd, "fleet", "clusters.cue"), []byte(fleetCue), 0644)).ToNot(HaveOccurred())
+
+	runtimePath := filepath.Join(wd, "runtime.cue")
+	g.Expect(os.WriteFile(runtimePath, []byte(runtimeData), 0644)).ToNot(HaveOccurred())
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-system",
+		},
+	}
+
+	err := envTestClient.Get(context.Background(), client.ObjectKeyFromObject(ns), ns)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	t.Run("resolves imports from workdir", func(t *testing.T) {
+		g := NewWithT(t)
+
+		output, err := executeCommand(fmt.Sprintf("runtime build -f %s --workdir %s", runtimePath, wd))
+		g.Expect(err).ToNot(HaveOccurred())
+		t.Log("\n", output)
+		g.Expect(output).To(MatchRegexp("staging.*CLUSTER_UID.*%s", string(ns.UID)))
+	})
+
+	t.Run("fails without workdir", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := executeCommand(fmt.Sprintf("runtime build -f %s", runtimePath))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("imports are unavailable"))
+	})
+}

--- a/internal/engine/bundle_builder.go
+++ b/internal/engine/bundle_builder.go
@@ -38,6 +38,7 @@ type BundleBuilder struct {
 	ctx               *cue.Context
 	files             []string
 	root              string
+	workdir           string
 	workspacesFiles   map[string][]string
 	workspacesSources map[string]map[string][]byte
 	mapSourceToOrigin map[string]string
@@ -66,6 +67,13 @@ func NewBundleBuilder(ctx *cue.Context, files []string) *BundleBuilder {
 // as the base for rendering error positions relative.
 func (b *BundleBuilder) WorkspaceDir(workspace string) string {
 	return filepath.Join(b.root, workspace)
+}
+
+// SetWorkdir sets the directory from which the CUE loader discovers the
+// cue.mod module root, enabling imports in the bundle definitions. When
+// unset, the loader uses the process working directory.
+func (b *BundleBuilder) SetWorkdir(dir string) {
+	b.workdir = dir
 }
 
 // InitWorkspace loads the bundle definitions into the in-memory workspace
@@ -142,6 +150,7 @@ func (b *BundleBuilder) Build(workspace string) (cue.Value, error) {
 		Package:   "_",
 		DataFiles: true,
 		Overlay:   overlay,
+		Dir:       b.workdir,
 	}
 
 	ix := load.Instances(b.workspacesFiles[workspace], cfg)

--- a/internal/engine/runtime_builder.go
+++ b/internal/engine/runtime_builder.go
@@ -39,6 +39,7 @@ type RuntimeBuilder struct {
 	ctx               *cue.Context
 	files             []string
 	root              string
+	workdir           string
 	workspacesFiles   map[string][]string
 	workspacesSources map[string]map[string][]byte
 }
@@ -63,6 +64,13 @@ func NewRuntimeBuilder(ctx *cue.Context, files []string) *RuntimeBuilder {
 // as the base for rendering error positions relative.
 func (b *RuntimeBuilder) WorkspaceDir(workspace string) string {
 	return filepath.Join(b.root, workspace)
+}
+
+// SetWorkdir sets the directory from which the CUE loader discovers the
+// cue.mod module root, enabling imports in the runtime definitions. When
+// unset, the loader uses the process working directory.
+func (b *RuntimeBuilder) SetWorkdir(dir string) {
+	b.workdir = dir
 }
 
 // InitWorkspace extracts the runtime definitions into the in-memory
@@ -137,6 +145,7 @@ func (b *RuntimeBuilder) Build(workspace string) (cue.Value, error) {
 		Package:   "_",
 		DataFiles: true,
 		Overlay:   overlay,
+		Dir:       b.workdir,
 	}
 
 	ix := load.Instances(b.workspacesFiles[workspace], cfg)


### PR DESCRIPTION
Add a `--workdir` flag to the bundle commands and to runtime build that sets the CUE module root from which the loader resolves imports in bundle and runtime definitions, instead of the process working directory. This allows composing complex bundles as CUE modules, with instances split across packages and config files embedded with the native CUE `@embed()` attribute, and building them from any directory.

closes: #324
xref: #89
