### PR TITLE
feat(cli): Add JSON and YAML output to list and push commands

### DIFF
--- a/cmd/timoni/artifact_list.go
+++ b/cmd/timoni/artifact_list.go
@@ -18,10 +18,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/flags"
 	"github.com/stefanprodan/timoni/internal/logger"
 	"github.com/stefanprodan/timoni/internal/oci"
@@ -42,6 +45,10 @@ var listArtifactCmd = &cobra.Command{
   # Print the tags and digests of an artifact stored in a private repository
   echo $DOCKER_TOKEN | timoni registry login docker.io -u timoni --password-stdin
   timoni artifact list oci://docker.io/org/app
+
+  # Check if a tag is published using the JSON output
+  timoni artifact list oci://ghcr.io/org/bundles/app -o json | \
+	jq -e --arg t "latest" 'any(.[]; .tag == $t)'
 `,
 	RunE: listArtifactCmdRun,
 }
@@ -49,6 +56,7 @@ var listArtifactCmd = &cobra.Command{
 type listArtifactFlags struct {
 	creds      flags.Credentials
 	withDigest bool
+	output     string
 }
 
 var listArtifactArgs listArtifactFlags
@@ -57,6 +65,8 @@ func init() {
 	listArtifactCmd.Flags().Var(&listArtifactArgs.creds, listArtifactArgs.creds.Type(), listArtifactArgs.creds.Description())
 	listArtifactCmd.Flags().BoolVar(&listArtifactArgs.withDigest, "with-digest", true,
 		"Resolve the digest of each version.")
+	listArtifactCmd.Flags().StringVarP(&listArtifactArgs.output, "output", "o", "",
+		"The format in which the tags should be printed, can be 'yaml' or 'json'.")
 	artifactCmd.AddCommand(listArtifactCmd)
 }
 
@@ -65,6 +75,10 @@ func listArtifactCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("repository URL is required")
 	}
 	ociURL := args[0]
+
+	if err := validateOutputFormat(listArtifactArgs.output, true); err != nil {
+		return err
+	}
 
 	spin := logger.StartSpinner("fetching tags")
 	defer spin.Stop()
@@ -79,16 +93,37 @@ func listArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	spin.Stop()
-	var rows [][]string
-	for _, v := range list {
-		row := []string{
-			v.Tag,
-			v.Digest,
+
+	if listArtifactArgs.output == "" {
+		var rows [][]string
+		for _, v := range list {
+			row := []string{
+				v.Tag,
+				v.Digest,
+			}
+			rows = append(rows, row)
 		}
-		rows = append(rows, row)
+
+		printTable(rootCmd.OutOrStdout(), []string{"tag", "digest"}, rows)
+
+		return nil
 	}
 
-	printTable(rootCmd.OutOrStdout(), []string{"tag", "digest"}, rows)
+	if list == nil {
+		list = []apiv1.ArtifactReference{}
+	}
 
-	return nil
+	var marshalled []byte
+	if listArtifactArgs.output == "json" {
+		marshalled, err = json.MarshalIndent(list, "", "  ")
+		marshalled = append(marshalled, "\n"...)
+	} else {
+		marshalled, err = yaml.Marshal(list)
+	}
+	if err != nil {
+		return err
+	}
+
+	_, err = cmd.OutOrStdout().Write(marshalled)
+	return err
 }

--- a/cmd/timoni/artifact_list_test.go
+++ b/cmd/timoni/artifact_list_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 Stefan Prodan
+Copyright 2026 Stefan Prodan
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,83 +27,81 @@ import (
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
-func Test_ListMod(t *testing.T) {
+func Test_ListArtifact(t *testing.T) {
 	g := NewWithT(t)
-	modPath := "testdata/module"
-	modURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-mod", 5))
-	modVers := []string{"1.0.0", "2.0.0", "1.1.0-rc.1"}
+	aPath := "testdata/module-values"
+	aURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-artifact", 5))
+	aTags := []string{"1.0.0", "latest"}
 
-	for _, v := range modVers {
-		_, err := executeCommand(fmt.Sprintf(
-			"mod push %s oci://%s -v %s --latest --resolve-symlinks",
-			modPath,
-			modURL,
-			v,
-		))
-		g.Expect(err).ToNot(HaveOccurred())
-	}
+	_, err := executeCommand(fmt.Sprintf(
+		"artifact push oci://%s -f %s -t %s -t %s",
+		aURL,
+		aPath,
+		aTags[0],
+		aTags[1],
+	))
+	g.Expect(err).ToNot(HaveOccurred())
 
 	t.Run("prints table", func(t *testing.T) {
 		g := NewWithT(t)
 		output, err := executeCommand(fmt.Sprintf(
-			"mod ls oci://%s",
-			modURL,
+			"artifact ls oci://%s",
+			aURL,
 		))
 		g.Expect(err).ToNot(HaveOccurred())
 
-		g.Expect(output).To(ContainSubstring("VERSION"))
-		g.Expect(output).To(ContainSubstring(apiv1.LatestVersion))
-		for _, v := range modVers {
-			g.Expect(output).To(ContainSubstring(v))
+		g.Expect(output).To(ContainSubstring("TAG"))
+		for _, tag := range aTags {
+			g.Expect(output).To(ContainSubstring(tag))
 		}
 	})
 
 	t.Run("prints JSON", func(t *testing.T) {
 		g := NewWithT(t)
 		output, err := executeCommand(fmt.Sprintf(
-			"mod ls oci://%s -o json",
-			modURL,
+			"artifact ls oci://%s -o json",
+			aURL,
 		))
 		g.Expect(err).ToNot(HaveOccurred())
 
-		var list []apiv1.ModuleReference
+		var list []apiv1.ArtifactReference
 		g.Expect(json.Unmarshal([]byte(output), &list)).To(Succeed())
 
-		versions := map[string]bool{}
+		tags := map[string]bool{}
 		for _, ref := range list {
-			g.Expect(ref.Repository).To(ContainSubstring(modURL))
+			g.Expect(ref.Repository).To(ContainSubstring(aURL))
 			g.Expect(ref.Digest).ToNot(BeEmpty())
-			versions[ref.Version] = true
+			tags[ref.Tag] = true
 		}
-		for _, v := range modVers {
-			g.Expect(versions).To(HaveKey(v))
+		for _, tag := range aTags {
+			g.Expect(tags).To(HaveKey(tag))
 		}
 	})
 
 	t.Run("prints YAML", func(t *testing.T) {
 		g := NewWithT(t)
 		output, err := executeCommand(fmt.Sprintf(
-			"mod ls oci://%s -o yaml",
-			modURL,
+			"artifact ls oci://%s -o yaml",
+			aURL,
 		))
 		g.Expect(err).ToNot(HaveOccurred())
 
-		var list []apiv1.ModuleReference
+		var list []apiv1.ArtifactReference
 		g.Expect(yaml.Unmarshal([]byte(output), &list)).To(Succeed())
 
-		versions := map[string]bool{}
+		tags := map[string]bool{}
 		for _, ref := range list {
 			g.Expect(ref.Digest).ToNot(BeEmpty())
-			versions[ref.Version] = true
+			tags[ref.Tag] = true
 		}
-		for _, v := range modVers {
-			g.Expect(versions).To(HaveKey(v))
+		for _, tag := range aTags {
+			g.Expect(tags).To(HaveKey(tag))
 		}
 	})
 
 	t.Run("fails for invalid output format", func(t *testing.T) {
 		g := NewWithT(t)
-		_, err := executeCommand("mod ls oci://registry.example.com/org/module -o junk")
+		_, err := executeCommand("artifact ls oci://registry.example.com/org/app -o junk")
 		g.Expect(err).To(MatchError("unknown --output=junk, can be yaml or json"))
 	})
 }

--- a/cmd/timoni/artifact_push.go
+++ b/cmd/timoni/artifact_push.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/engine"
@@ -74,6 +76,7 @@ type pushArtifactFlags struct {
 	tags            []string
 	annotations     []string
 	contentType     string
+	output          string
 	resolveSymlinks bool
 	sign            string
 	cosignKey       string
@@ -91,6 +94,8 @@ func init() {
 		"Annotation in the format '<key>=<value>'.")
 	pushArtifactCmd.Flags().StringVar(&pushArtifactArgs.contentType, "content-type", "generic",
 		"The content type of this artifact.")
+	pushArtifactCmd.Flags().StringVarP(&pushArtifactArgs.output, "output", "o", "",
+		"The format in which the artifact digest should be printed, can be 'yaml' or 'json'.")
 	pushArtifactCmd.Flags().BoolVar(&pushArtifactArgs.resolveSymlinks, "resolve-symlinks", false,
 		"Resolve symbolic links and package their targets as regular files and directories.")
 	pushArtifactCmd.Flags().StringVar(&pushArtifactArgs.sign, "sign", "",
@@ -115,6 +120,9 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 		if err := oci.ValidateTag(tag); err != nil {
 			return err
 		}
+	}
+	if err := validateOutputFormat(pushArtifactArgs.output, true); err != nil {
+		return err
 	}
 	if err := validateProviderCompanionFlags(cmd, pushArtifactArgs.sign, "sign", "cosign-key"); err != nil {
 		return err
@@ -213,8 +221,37 @@ func pushArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	log.Info(fmt.Sprintf("artifact: %s", logger.ColorizeSubject(ociURL)))
-	log.Info(fmt.Sprintf("digest: %s", logger.ColorizeSubject(digest.DigestStr())))
+
+	info := struct {
+		URL        string `json:"url"`
+		Repository string `json:"repository"`
+		Tag        string `json:"tag"`
+		Digest     string `json:"digest"`
+	}{
+		URL:        digestURL,
+		Repository: digest.Repository.Name(),
+		Tag:        pushArtifactArgs.tags[0],
+		Digest:     digest.DigestStr(),
+	}
+
+	switch pushArtifactArgs.output {
+	case "json":
+		marshalled, err := json.MarshalIndent(&info, "", "  ")
+		if err != nil {
+			return fmt.Errorf("artifact info JSON conversion failed: %w", err)
+		}
+		marshalled = append(marshalled, "\n"...)
+		cmd.OutOrStdout().Write(marshalled)
+	case "yaml":
+		marshalled, err := yaml.Marshal(&info)
+		if err != nil {
+			return fmt.Errorf("artifact info YAML conversion failed: %w", err)
+		}
+		cmd.OutOrStdout().Write(marshalled)
+	default:
+		log.Info(fmt.Sprintf("artifact: %s", logger.ColorizeSubject(ociURL)))
+		log.Info(fmt.Sprintf("digest: %s", logger.ColorizeSubject(digest.DigestStr())))
+	}
 
 	return nil
 }

--- a/cmd/timoni/artifact_push_test.go
+++ b/cmd/timoni/artifact_push_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -145,4 +146,44 @@ func TestPushArtifactRejectsMissingCosignBeforeInput(t *testing.T) {
 
 	_, err := executeCommand("artifact push oci://registry.example.com/org/artifact -f /does/not/exist -t 1.0.0 --sign cosign")
 	g.Expect(err).To(MatchError(ContainSubstring("executing cosign failed")))
+}
+
+func TestPushArtifactRejectsInvalidOutputBeforeInput(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := executeCommand("artifact push oci://registry.example.com/org/artifact -f /does/not/exist -t 1.0.0 --output invalid")
+	g.Expect(err).To(MatchError("unknown --output=invalid, can be yaml or json"))
+}
+
+func Test_PushArtifact_OutputJSON(t *testing.T) {
+	g := NewWithT(t)
+	aPath := "testdata/module-values"
+	aURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-artifact", 5))
+	aTag := "1.0.0"
+
+	output, err := executeCommand(fmt.Sprintf(
+		"artifact push oci://%s -f %s -t %s --content-type=generic -o json",
+		aURL,
+		aPath,
+		aTag,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var info struct {
+		URL        string `json:"url"`
+		Repository string `json:"repository"`
+		Tag        string `json:"tag"`
+		Digest     string `json:"digest"`
+	}
+	g.Expect(json.Unmarshal([]byte(output), &info)).To(Succeed())
+
+	image, err := crane.Pull(fmt.Sprintf("%s:%s", aURL, aTag))
+	g.Expect(err).ToNot(HaveOccurred())
+	digest, err := image.Digest()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(info.Repository).To(Equal(aURL))
+	g.Expect(info.Tag).To(Equal(aTag))
+	g.Expect(info.Digest).To(Equal(digest.String()))
+	g.Expect(info.URL).To(Equal(fmt.Sprintf("oci://%s@%s", aURL, digest.String())))
 }

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -160,6 +160,8 @@ func resetCmdArgs() {
 		name: "default",
 	}
 	listArgs = listFlags{}
+	listModArgs = listModFlags{withDigest: true}
+	listArtifactArgs = listArtifactFlags{withDigest: true}
 	pullModArgs = pullModFlags{}
 	pushModArgs = pushModFlags{}
 	buildModArgs = buildModFlags{format: "oci-archive"}
@@ -170,7 +172,10 @@ func resetCmdArgs() {
 	bundleBuildArgs = bundleBuildFlags{}
 	vendorCrdArgs = vendorCrdFlags{}
 	vendorK8sArgs = vendorK8sFlags{}
-	pushArtifactArgs = pushArtifactFlags{}
+	pushArtifactArgs = pushArtifactFlags{
+		path:        ".",
+		contentType: "generic",
+	}
 	buildArtifactArgs = buildArtifactFlags{
 		path:        ".",
 		format:      "oci-archive",

--- a/cmd/timoni/mod_list.go
+++ b/cmd/timoni/mod_list.go
@@ -18,10 +18,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/flags"
 	"github.com/stefanprodan/timoni/internal/logger"
 	"github.com/stefanprodan/timoni/internal/oci"
@@ -42,6 +45,10 @@ var listModCmd = &cobra.Command{
   # Print the versions of a module from GitHub Container Registry
   timoni mod list oci://ghcr.io/org/manifests/app \
 	--creds timoni:$GITHUB_TOKEN
+
+  # Check if a version is published using the JSON output
+  timoni mod list oci://ghcr.io/org/modules/app -o json | \
+	jq -e --arg v "1.0.0" 'any(.[]; .version == $v)'
 `,
 	RunE: listModCmdRun,
 }
@@ -49,6 +56,7 @@ var listModCmd = &cobra.Command{
 type listModFlags struct {
 	creds      flags.Credentials
 	withDigest bool
+	output     string
 }
 
 var listModArgs listModFlags
@@ -57,6 +65,8 @@ func init() {
 	listModCmd.Flags().Var(&listModArgs.creds, listModArgs.creds.Type(), listModArgs.creds.Description())
 	listModCmd.Flags().BoolVar(&listModArgs.withDigest, "with-digest", true,
 		"Resolve the digest of each version.")
+	listModCmd.Flags().StringVarP(&listModArgs.output, "output", "o", "",
+		"The format in which the versions should be printed, can be 'yaml' or 'json'.")
 	modCmd.AddCommand(listModCmd)
 }
 
@@ -65,6 +75,10 @@ func listModCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("module URL is required")
 	}
 	ociURL := args[0]
+
+	if err := validateOutputFormat(listModArgs.output, true); err != nil {
+		return err
+	}
 
 	spin := logger.StartSpinner("fetching versions")
 	defer spin.Stop()
@@ -79,16 +93,37 @@ func listModCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	spin.Stop()
-	var rows [][]string
-	for _, v := range list {
-		row := []string{
-			v.Version,
-			v.Digest,
+
+	if listModArgs.output == "" {
+		var rows [][]string
+		for _, v := range list {
+			row := []string{
+				v.Version,
+				v.Digest,
+			}
+			rows = append(rows, row)
 		}
-		rows = append(rows, row)
+
+		printTable(rootCmd.OutOrStdout(), []string{"version", "digest"}, rows)
+
+		return nil
 	}
 
-	printTable(rootCmd.OutOrStdout(), []string{"version", "digest"}, rows)
+	if list == nil {
+		list = []apiv1.ModuleReference{}
+	}
 
-	return nil
+	var marshalled []byte
+	if listModArgs.output == "json" {
+		marshalled, err = json.MarshalIndent(list, "", "  ")
+		marshalled = append(marshalled, "\n"...)
+	} else {
+		marshalled, err = yaml.Marshal(list)
+	}
+	if err != nil {
+		return err
+	}
+
+	_, err = cmd.OutOrStdout().Write(marshalled)
+	return err
 }


### PR DESCRIPTION
Add the `--output/-o` flag accepting 'yaml' or 'json' to `timoni mod list`, `timoni artifact list` and `timoni artifact push`. 