### PR TITLE
feat(runtime): Take ownership of existing resources

### DIFF
--- a/cmd/timoni/apply_crd_test.go
+++ b/cmd/timoni/apply_crd_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// getWidgetFor returns a getter for the Widget custom resource
+// rendered by the module-crd testdata module for the given API group.
+func getWidgetFor(ctx context.Context, group, name, namespace string) func() error {
+	return func() error {
+		widget := &unstructured.Unstructured{}
+		widget.SetAPIVersion(group + "/v1")
+		widget.SetKind("Widget")
+		widget.SetName(name)
+		widget.SetNamespace(namespace)
+		return envTestClient.Get(ctx, client.ObjectKeyFromObject(widget), widget)
+	}
+}
+
+func TestApplyWithCRDs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	modPath := "testdata/module-crd"
+	name := rnd("my-widget", 5)
+	namespace := rnd("my-namespace", 5)
+
+	// A unique API group per run guarantees the kind is unknown to
+	// any discovery data cached before the apply starts.
+	group := fmt.Sprintf("%s.testing.timoni.sh", rnd("apply", 5))
+
+	valuesPath := filepath.Join(t.TempDir(), "values.cue")
+	g.Expect(os.WriteFile(valuesPath,
+		fmt.Appendf(nil, "values: group: %q\n", group), 0644)).To(Succeed())
+
+	// The first install must apply the CRD and resolve the Widget
+	// kind registered by it in the same run.
+	output, err := executeCommand(fmt.Sprintf(
+		"apply -n %s %s %s -p main -f %s --wait --timeout=60s",
+		namespace,
+		name,
+		modPath,
+		valuesPath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+	t.Log("\n", output)
+
+	g.Expect(getWidgetFor(ctx, group, name, namespace)()).To(Succeed())
+
+	// The uninstall must remove the custom resource and its CRD.
+	_, err = executeCommand(fmt.Sprintf(
+		"delete -n %s %s --wait",
+		namespace,
+		name,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	crd := &unstructured.Unstructured{}
+	crd.SetAPIVersion("apiextensions.k8s.io/v1")
+	crd.SetKind("CustomResourceDefinition")
+	crd.SetName("widgets." + group)
+	g.Eventually(func() bool {
+		err := envTestClient.Get(ctx, client.ObjectKeyFromObject(crd), crd)
+		return apierrors.IsNotFound(err)
+	}, 10*time.Second).Should(BeTrue())
+}
+
+func Test_BundleApplyWithCRDs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	bundleName := rnd("my-bundle", 5)
+	modPath := "testdata/module-crd"
+	namespace := rnd("my-namespace", 5)
+	modName := rnd("my-mod", 5)
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
+	modVer := "1.0.0"
+	group := fmt.Sprintf("%s.testing.timoni.sh", rnd("bundle", 5))
+
+	// Push the module to registry
+	_, err := executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v %s",
+		modPath,
+		modURL,
+		modVer,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	bundleData := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "%[1]s"
+	instances: {
+		widgets: {
+			module: {
+				url:     "oci://%[2]s"
+				version: "%[3]s"
+			}
+			namespace: "%[4]s"
+			values: group: "%[5]s"
+		}
+	}
+}
+`, bundleName, modURL, modVer, namespace, group)
+
+	bundlePath := filepath.Join(t.TempDir(), "bundle.cue")
+	g.Expect(os.WriteFile(bundlePath, []byte(bundleData), 0644)).To(Succeed())
+
+	// The first install must apply the CRD and resolve the Widget
+	// kind registered by it in the same run.
+	output, err := executeCommand(fmt.Sprintf(
+		"bundle apply -f %s -p main --wait --timeout=60s",
+		bundlePath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+	t.Log("\n", output)
+
+	g.Expect(getWidgetFor(ctx, group, "widgets", namespace)()).To(Succeed())
+
+	// The uninstall must remove the custom resource and its CRD.
+	_, err = executeCommand(fmt.Sprintf(
+		"bundle delete %s --wait",
+		bundleName,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Eventually(func() bool {
+		return apierrors.IsNotFound(getWidgetFor(ctx, group, "widgets", namespace)())
+	}, 10*time.Second).Should(BeTrue())
+}

--- a/cmd/timoni/apply_takeover_test.go
+++ b/cmd/timoni/apply_takeover_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stefanprodan/timoni/internal/runtime"
+)
+
+// TestApplyTakeoverServicePorts covers the takeover of objects whose
+// Helm-managed fields conflict with the module's desired state on
+// server-side apply list merging, such as Service ports differing
+// only by port number.
+func TestApplyTakeoverServicePorts(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	modPath := "testdata/module-svc"
+	name := rnd("my-instance", 5)
+	namespace := rnd("my-namespace", 5)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}
+	g.Expect(envTestClient.Create(ctx, ns)).To(Succeed())
+
+	// Simulate a Helm v4 release owning the module's Service with
+	// ports that differ from the module's desired state.
+	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"meta.helm.sh/release-name":      "my-release",
+				"meta.helm.sh/release-namespace": namespace,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{"app": name},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       9898,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt32(9898),
+				},
+				{
+					Name:       "grpc",
+					Port:       9999,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt32(9999),
+				},
+			},
+		},
+	}
+	u, err := runtime.ToUnstructured(svc)
+	g.Expect(err).ToNot(HaveOccurred())
+	unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(u.Object, "status")
+	g.Expect(envTestClient.Apply(ctx, client.ApplyConfigurationFromUnstructured(u),
+		client.FieldOwner("helm"), client.ForceOwnership)).To(Succeed())
+
+	output, err := executeCommand(fmt.Sprintf(
+		"apply -n %s %s %s -p main --wait",
+		namespace,
+		name,
+		modPath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+	t.Log("\n", output)
+
+	result := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	g.Expect(envTestClient.Get(ctx, client.ObjectKeyFromObject(result), result)).To(Succeed())
+
+	// The Helm release ports are replaced with the module's ones.
+	g.Expect(result.Spec.Ports).To(HaveLen(1))
+	g.Expect(result.Spec.Ports[0].Name).To(Equal("http"))
+	g.Expect(result.Spec.Ports[0].Port).To(Equal(int32(80)))
+
+	// The Helm release metadata is removed from the object.
+	g.Expect(result.GetAnnotations()).ToNot(HaveKey("meta.helm.sh/release-name"))
+	g.Expect(result.GetAnnotations()).ToNot(HaveKey("meta.helm.sh/release-namespace"))
+
+	// The field ownership is transferred from Helm to Timoni.
+	g.Expect(result.GetManagedFields()).ToNot(BeEmpty())
+	for _, entry := range result.GetManagedFields() {
+		g.Expect(entry.Manager).ToNot(Equal("helm"))
+	}
+}
+
+func TestApplyTakeoverFromHelm(t *testing.T) {
+	tests := []struct {
+		name   string
+		create func(ctx context.Context, cm *corev1.ConfigMap) error
+	}{
+		{
+			// Helm v3 tracks objects under the 'helm'
+			// field manager with the Update operation.
+			name: "client-side apply",
+			create: func(ctx context.Context, cm *corev1.ConfigMap) error {
+				return envTestClient.Create(ctx, cm, client.FieldOwner("helm"))
+			},
+		},
+		{
+			// Helm v4 tracks objects under the 'helm'
+			// field manager with the Apply operation.
+			name: "server-side apply",
+			create: func(ctx context.Context, cm *corev1.ConfigMap) error {
+				u, err := runtime.ToUnstructured(cm)
+				if err != nil {
+					return err
+				}
+				unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+				return envTestClient.Apply(ctx, client.ApplyConfigurationFromUnstructured(u),
+					client.FieldOwner("helm"), client.ForceOwnership)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+			modPath := "testdata/module"
+			name := rnd("my-instance", 5)
+			namespace := rnd("my-namespace", 5)
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: namespace},
+			}
+			g.Expect(envTestClient.Create(ctx, ns)).To(Succeed())
+
+			// Simulate a Helm release owning one of the module's objects:
+			// the ConfigMap carries the Helm release metadata, its fields
+			// are registered under the 'helm' manager, and the 'extra' key
+			// is not part of the module's desired state.
+			cm := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-client", name),
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"meta.helm.sh/release-name":      "my-release",
+						"meta.helm.sh/release-namespace": namespace,
+					},
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "Helm",
+					},
+				},
+				Data: map[string]string{
+					"server": "tcp://helm.internal:9090",
+					"extra":  "set by helm",
+				},
+			}
+			g.Expect(tt.create(ctx, cm)).To(Succeed())
+
+			output, err := executeCommand(fmt.Sprintf(
+				"apply -n %s %s %s -p main --wait",
+				namespace,
+				name,
+				modPath,
+			))
+			g.Expect(err).ToNot(HaveOccurred())
+			t.Log("\n", output)
+
+			result := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-client", name),
+					Namespace: namespace,
+				},
+			}
+			g.Expect(envTestClient.Get(ctx, client.ObjectKeyFromObject(result), result)).To(Succeed())
+
+			// The module values take precedence over the Helm release ones.
+			g.Expect(result.Data).To(HaveKeyWithValue("server", "tcp://example.internal:9090"))
+
+			// The Helm release metadata is removed from the object.
+			g.Expect(result.GetAnnotations()).ToNot(HaveKey("meta.helm.sh/release-name"))
+			g.Expect(result.GetAnnotations()).ToNot(HaveKey("meta.helm.sh/release-namespace"))
+
+			// The field ownership is transferred from Helm to Timoni.
+			g.Expect(result.GetManagedFields()).ToNot(BeEmpty())
+			for _, entry := range result.GetManagedFields() {
+				g.Expect(entry.Manager).ToNot(Equal("helm"))
+			}
+		})
+	}
+}

--- a/cmd/timoni/testdata/module-crd/cue.mod/module.cue
+++ b/cmd/timoni/testdata/module-crd/cue.mod/module.cue
@@ -1,0 +1,2 @@
+module: "timoni.sh/test-crd"
+language: version: "v0.17.1"

--- a/cmd/timoni/testdata/module-crd/timoni.cue
+++ b/cmd/timoni/testdata/module-crd/timoni.cue
@@ -1,0 +1,67 @@
+package main
+
+// Define the schema for the user-supplied values.
+values: {
+	group: *"testing.timoni.sh" | string
+}
+
+// Define how Timoni should build, validate and
+// apply the Kubernetes resources.
+timoni: {
+	apiVersion: "v1alpha1"
+
+	instance: {
+		config: {
+			metadata: {
+				name:      string @tag(name)
+				namespace: string @tag(namespace)
+			}
+			group: values.group
+		}
+
+		objects: {
+			// The CRD and a custom resource of its kind belong to the
+			// same apply set: the staged apply must register the CRD
+			// before resolving the Widget kind.
+			crd: {
+				apiVersion: "apiextensions.k8s.io/v1"
+				kind:       "CustomResourceDefinition"
+				metadata: name: "widgets.\(config.group)"
+				spec: {
+					group: config.group
+					names: {
+						kind:     "Widget"
+						listKind: "WidgetList"
+						plural:   "widgets"
+						singular: "widget"
+					}
+					scope: "Namespaced"
+					versions: [{
+						name:    "v1"
+						served:  true
+						storage: true
+						schema: openAPIV3Schema: {
+							type: "object"
+							properties: spec: {
+								type: "object"
+								properties: message: type: "string"
+							}
+						}
+					}]
+				}
+			}
+
+			widget: {
+				apiVersion: "\(config.group)/v1"
+				kind:       "Widget"
+				metadata: {
+					name:      config.metadata.name
+					namespace: config.metadata.namespace
+				}
+				spec: message: "hello"
+			}
+		}
+	}
+
+	apply: app: [for obj in instance.objects {obj}]
+}

--- a/cmd/timoni/testdata/module-crd/values.cue
+++ b/cmd/timoni/testdata/module-crd/values.cue
@@ -1,0 +1,7 @@
+// Note that this file must have no imports and all values must be concrete.
+
+package main
+
+values: {
+	group: "testing.timoni.sh"
+}

--- a/cmd/timoni/testdata/module-svc/cue.mod/module.cue
+++ b/cmd/timoni/testdata/module-svc/cue.mod/module.cue
@@ -1,0 +1,2 @@
+module: "timoni.sh/test-svc"
+language: version: "v0.17.1"

--- a/cmd/timoni/testdata/module-svc/timoni.cue
+++ b/cmd/timoni/testdata/module-svc/timoni.cue
@@ -20,6 +20,42 @@ timoni: {
 		}
 
 		objects: {
+			// The Role is applied in a separate stage before the Service.
+			role: {
+				apiVersion: "rbac.authorization.k8s.io/v1"
+				kind:       "Role"
+				metadata: {
+					name:      config.metadata.name
+					namespace: config.metadata.namespace
+				}
+				rules: [{
+					apiGroups: [""]
+					resources: ["configmaps"]
+					verbs: ["get", "list"]
+				}]
+			}
+
+			// The RoleBinding is applied in the main stage, after the
+			// Role it references has registered.
+			binding: {
+				apiVersion: "rbac.authorization.k8s.io/v1"
+				kind:       "RoleBinding"
+				metadata: {
+					name:      config.metadata.name
+					namespace: config.metadata.namespace
+				}
+				roleRef: {
+					apiGroup: "rbac.authorization.k8s.io"
+					kind:     "Role"
+					name:     config.metadata.name
+				}
+				subjects: [{
+					kind:      "ServiceAccount"
+					name:      "default"
+					namespace: config.metadata.namespace
+				}]
+			}
+
 			svc: {
 				apiVersion: "v1"
 				kind:       "Service"

--- a/cmd/timoni/testdata/module-svc/timoni.cue
+++ b/cmd/timoni/testdata/module-svc/timoni.cue
@@ -1,0 +1,45 @@
+package main
+
+// Define the schema for the user-supplied values.
+values: {
+	port: *80 | int
+}
+
+// Define how Timoni should build, validate and
+// apply the Kubernetes resources.
+timoni: {
+	apiVersion: "v1alpha1"
+
+	instance: {
+		config: {
+			metadata: {
+				name:      string @tag(name)
+				namespace: string @tag(namespace)
+			}
+			port: values.port
+		}
+
+		objects: {
+			svc: {
+				apiVersion: "v1"
+				kind:       "Service"
+				metadata: {
+					name:      config.metadata.name
+					namespace: config.metadata.namespace
+				}
+				spec: {
+					type: "ClusterIP"
+					selector: app: config.metadata.name
+					ports: [{
+						name:       "http"
+						port:       config.port
+						protocol:   "TCP"
+						targetPort: config.port
+					}]
+				}
+			}
+		}
+	}
+
+	apply: app: [for obj in instance.objects {obj}]
+}

--- a/cmd/timoni/testdata/module-svc/values.cue
+++ b/cmd/timoni/testdata/module-svc/values.cue
@@ -1,0 +1,7 @@
+// Note that this file must have no imports and all values must be concrete.
+
+package main
+
+values: {
+	port: 80
+}

--- a/docs/cue/module/apply-behavior.md
+++ b/docs/cue/module/apply-behavior.md
@@ -156,3 +156,22 @@ timoni: healthChecks: {
 The above definition tells Timoni to look for the `Ready=True` condition in
 all kinds under the `cert-manager.io` group (`ClusterIssuer`, `Issuer`, `Certificate`) and
 to look for `Synced=True` for the trust-manager kinds (`ClusterBundle`, `Bundle`).
+
+## Taking Ownership of Existing Resources
+
+When a module's resources already exist on the cluster, Timoni takes ownership
+of them during the server-side apply. Objects created with `kubectl apply` or
+`helm install` (both Helm v3 and Helm v4 releases) become managed by Timoni:
+the field ownership is transferred from the `kubectl` and `helm` field managers
+to `timoni` before the objects are applied, and the fields set with these tools
+are replaced with the module's desired state.
+
+When taking ownership, Timoni removes the following metadata from the objects:
+
+- the `kubectl.kubernetes.io/last-applied-configuration` annotation
+- the `meta.helm.sh/release-name` annotation
+- the `meta.helm.sh/release-namespace` annotation
+
+This allows migrating an app from Helm to Timoni by installing the module
+instance over the existing Helm release, then deleting the Helm release
+secrets without uninstalling the app.

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -228,7 +228,14 @@ func (r *Reconciler) ApplyAllSets(ctx context.Context, log logr.Logger, withChan
 	return nil
 }
 
+// ApplyAllStaged transfers the ownership of the set's existing objects
+// from kubectl and Helm to Timoni, then server-side applies the objects
+// in stages, waiting for the CRDs and Namespaces to register before
+// applying the rest of the set.
 func (r *Reconciler) ApplyAllStaged(ctx context.Context, set engine.ResourceSet) (*ssa.ChangeSet, error) {
+	if err := runtime.TakeOwnership(ctx, r.resourceManager.Client(), set.Objects); err != nil {
+		return nil, err
+	}
 	return r.resourceManager.ApplyAllStaged(ctx, set.Objects, r.applyOptions)
 }
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -230,8 +230,8 @@ func (r *Reconciler) ApplyAllSets(ctx context.Context, log logr.Logger, withChan
 
 // ApplyAllStaged transfers the ownership of the set's existing objects
 // from kubectl and Helm to Timoni, then server-side applies the objects
-// in stages, waiting for the CRDs and Namespaces to register before
-// applying the rest of the set.
+// in stages, waiting for the CRDs, Namespaces, cluster-wide RBAC and
+// RBAC Roles to register before applying the rest of the set.
 func (r *Reconciler) ApplyAllStaged(ctx context.Context, set engine.ResourceSet) (*ssa.ChangeSet, error) {
 	if err := runtime.TakeOwnership(ctx, r.resourceManager.Client(), set.Objects); err != nil {
 		return nil, err

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -17,6 +17,8 @@ limitations under the License.
 package runtime
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -25,12 +27,16 @@ import (
 	"github.com/fluxcd/cli-utils/pkg/kstatus/polling/clusterreader"
 	pollingEngine "github.com/fluxcd/cli-utils/pkg/kstatus/polling/engine"
 	"github.com/fluxcd/pkg/ssa"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -121,6 +127,8 @@ func SelectObjectsFromSet(set *ssa.ChangeSet, action ssa.Action) []*unstructured
 }
 
 // ApplyOptions returns the default options for server-side apply operations.
+// The cleanup options transfer the ownership of objects managed with kubectl
+// or Helm to Timoni, and remove their tracking metadata.
 func ApplyOptions(force bool, wait time.Duration) ssa.ApplyOptions {
 	return ssa.ApplyOptions{
 		Force: force,
@@ -130,7 +138,101 @@ func ApplyOptions(force bool, wait time.Duration) ssa.ApplyOptions {
 		IfNotPresentSelector: map[string]string{
 			apiv1.IfNotPresentAction: apiv1.EnabledValue,
 		},
+		Cleanup: ssa.ApplyCleanupOptions{
+			// Remove the kubectl and Helm tracking metadata.
+			Annotations: []string{
+				corev1.LastAppliedConfigAnnotation,
+				"meta.helm.sh/release-name",
+				"meta.helm.sh/release-namespace",
+			},
+			// Take ownership of existing objects and
+			// undo changes made with kubectl or Helm.
+			FieldManagers: takeOwnershipFrom(),
+		},
 		WaitTimeout: wait,
+	}
+}
+
+// TakeOwnership transfers the ownership of the given objects' fields from
+// kubectl and Helm to Timoni's field manager before server-side applying
+// them, so that the apply replaces the fields set with these tools instead
+// of merging with them. Objects not found on the cluster, without matching
+// field managers, or annotated with the if-not-present action are skipped.
+func TakeOwnership(ctx context.Context, kubeClient client.Client, objects []*unstructured.Unstructured) error {
+	skipSelector := map[string]string{
+		apiv1.IfNotPresentAction: apiv1.EnabledValue,
+	}
+
+	for _, object := range objects {
+		if ssautil.AnyInMetadata(object, skipSelector) {
+			continue
+		}
+
+		existing := &unstructured.Unstructured{}
+		existing.SetGroupVersionKind(object.GroupVersionKind())
+		if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(object), existing); err != nil {
+			if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+				continue
+			}
+			return fmt.Errorf("%s failed to read object: %w", ssautil.FmtUnstructured(object), err)
+		}
+
+		if ssautil.AnyInMetadata(existing, skipSelector) {
+			continue
+		}
+
+		patch, err := ssa.PatchReplaceFieldsManagers(existing, takeOwnershipFrom(), ownerRef.Field)
+		if err != nil {
+			return fmt.Errorf("%s failed to compute ownership patch: %w", ssautil.FmtUnstructured(existing), err)
+		}
+		if len(patch) == 0 {
+			continue
+		}
+
+		rawPatch, err := json.Marshal(patch)
+		if err != nil {
+			return err
+		}
+		if err := kubeClient.Patch(ctx, existing, client.RawPatch(types.JSONPatchType, rawPatch),
+			client.FieldOwner(ownerRef.Field)); err != nil {
+			return fmt.Errorf("%s failed to take ownership: %w", ssautil.FmtUnstructured(existing), err)
+		}
+	}
+
+	return nil
+}
+
+// takeOwnershipFrom returns the list of field managers whose ownership
+// over objects is transferred to Timoni during server-side apply.
+func takeOwnershipFrom() []ssa.FieldManager {
+	return []ssa.FieldManager{
+		{
+			// to take over objects managed with Helm v3 client-side apply
+			Name:          "helm",
+			OperationType: metav1.ManagedFieldsOperationUpdate,
+			ExactMatch:    true,
+		},
+		{
+			// to take over objects managed with Helm v4 server-side apply
+			Name:          "helm",
+			OperationType: metav1.ManagedFieldsOperationApply,
+			ExactMatch:    true,
+		},
+		{
+			// to take over changes made with 'kubectl apply'
+			Name:          "kubectl",
+			OperationType: metav1.ManagedFieldsOperationUpdate,
+		},
+		{
+			// to take over changes made with 'kubectl apply --server-side'
+			Name:          "before-first-apply",
+			OperationType: metav1.ManagedFieldsOperationUpdate,
+		},
+		{
+			// to take over changes made with 'kubectl apply --server-side --force-conflicts'
+			Name:          "kubectl",
+			OperationType: metav1.ManagedFieldsOperationApply,
+		},
 	}
 }
 

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -149,6 +149,13 @@ func ApplyOptions(force bool, wait time.Duration) ssa.ApplyOptions {
 			// undo changes made with kubectl or Helm.
 			FieldManagers: takeOwnershipFrom(),
 		},
+		// Apply the RBAC Roles in a separate stage before the other
+		// namespaced objects, so that the RoleBindings referencing them
+		// pass the RBAC escalation checks when applied by a user which
+		// is not a cluster-admin.
+		CustomStageKinds: map[schema.GroupKind]struct{}{
+			{Group: "rbac.authorization.k8s.io", Kind: "Role"}: {},
+		},
 		WaitTimeout: wait,
 	}
 }

--- a/internal/runtime/resources.go
+++ b/internal/runtime/resources.go
@@ -32,7 +32,9 @@ import (
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
@@ -44,6 +46,8 @@ var ownerRef = ssa.Owner{
 }
 
 // NewResourceManager creates a ResourceManager for the given cluster.
+// The manager's client and status poller share a dynamic RESTMapper that
+// discovers kinds registered by CRDs applied during the current run.
 // The optional factories add custom kstatus readers to the status poller,
 // next to the built-in Kubernetes Job one.
 func NewResourceManager(rcg genericclioptions.RESTClientGetter, readers ...StatusReaderFactory) (*ssa.ResourceManager, error) {
@@ -56,12 +60,22 @@ func NewResourceManager(rcg genericclioptions.RESTClientGetter, readers ...Statu
 	cfg.QPS = 100.0
 	cfg.Burst = 300
 
-	restMapper, err := rcg.ToRESTMapper()
+	httpClient, err := rest.HTTPClientFor(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	kubeClient, err := client.New(cfg, client.Options{Mapper: restMapper, Scheme: defaultScheme()})
+	// The dynamic RESTMapper reloads the API discovery data on unknown kinds.
+	restMapper, err := apiutil.NewDynamicRESTMapper(cfg, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeClient, err := client.New(cfg, client.Options{
+		HTTPClient: httpClient,
+		Mapper:     restMapper,
+		Scheme:     defaultScheme(),
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When a module's resources already exist on the cluster, Timoni takes ownership of them during the server-side apply. Objects created with `kubectl apply` or `helm install` (both Helm v3 and Helm v4 releases) become managed by Timoni.

When taking ownership, Timoni removes the following metadata from the objects:

- the `kubectl.kubernetes.io/last-applied-configuration` annotation
- the `meta.helm.sh/release-name` annotation
- the `meta.helm.sh/release-namespace` annotation

This allows migrating an app from Helm to Timoni by installing the module instance over the existing Helm release, then deleting the Helm release secrets without uninstalling the app.

PS. This was end-to-end tested with podinfo [Helm chart](https://github.com/stefanprodan/podinfo/tree/master/charts/podinfo) and [Timoni module](https://github.com/stefanprodan/podinfo/tree/master/timoni/podinfo).