### PR TITLE
fix(cli): Propagate bundle render output errors

### DIFF
--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -227,7 +228,14 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	cmd.OutOrStdout().Write([]byte(sb.String()))
+	data := []byte(sb.String())
+	n, err := cmd.OutOrStdout().Write(data)
+	if err != nil {
+		return err
+	}
+	if n < len(data) {
+		return io.ErrShortWrite
+	}
 
 	return nil
 }

--- a/cmd/timoni/bundle_build_test.go
+++ b/cmd/timoni/bundle_build_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +13,7 @@ import (
 
 	ssautil "github.com/fluxcd/pkg/ssa/utils"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/stefanprodan/timoni/internal/engine"
@@ -599,5 +604,93 @@ bundle: {
 	t.Run("produces identical output regardless of concurrency", func(t *testing.T) {
 		g := NewWithT(t)
 		g.Expect(build(1)).To(Equal(concurrent))
+	})
+}
+
+// failWriter is an io.Writer that rejects every write with a fixed error.
+type failWriter struct {
+	err error
+}
+
+func (w failWriter) Write(p []byte) (int, error) {
+	return 0, w.err
+}
+
+// shortWriter is an io.Writer that accepts no bytes but never returns an
+// error, so the command must report io.ErrShortWrite itself.
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) {
+	return 0, nil
+}
+
+func Test_BundleBuild_OutputWriter(t *testing.T) {
+	g := NewWithT(t)
+
+	modPath := "testdata/module"
+	namespace := rnd("my-namespace", 5)
+
+	bundleCue := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "my-bundle"
+	instances: {
+		backend: {
+			module: {
+				url: "file://%[1]s"
+			}
+			namespace: "%[2]s"
+			values: client: enabled: true
+		}
+	}
+}
+`, modPath, namespace)
+
+	wd := t.TempDir()
+	cuePath := filepath.Join(wd, "bundle.cue")
+	g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).ToNot(HaveOccurred())
+	g.Expect(engine.CopyDir(modPath, filepath.Join(wd, modPath), true)).ToNot(HaveOccurred())
+
+	run := func(out io.Writer) error {
+		defer resetCmdArgs()
+		bundleBuildArgs.files = []string{cuePath}
+		cmd := &cobra.Command{Use: "build"}
+		cmd.SetContext(context.Background())
+		cmd.SetOut(out)
+		cmd.SetErr(io.Discard)
+		return runBundleBuildCmd(cmd, nil)
+	}
+
+	t.Run("returns the writer error", func(t *testing.T) {
+		g := NewWithT(t)
+		sentinel := errors.New("output sink closed")
+		err := run(failWriter{err: sentinel})
+		g.Expect(err).To(MatchError(sentinel))
+	})
+
+	t.Run("returns io.ErrShortWrite on a short write", func(t *testing.T) {
+		g := NewWithT(t)
+		err := run(shortWriter{})
+		g.Expect(err).To(MatchError(io.ErrShortWrite))
+	})
+
+	t.Run("leaves the writer empty when rendering fails", func(t *testing.T) {
+		g := NewWithT(t)
+
+		badPath := filepath.Join(wd, "bad.cue")
+		badCue := strings.Replace(bundleCue, "values: client: enabled: true", "values: domain: 123", 1)
+		g.Expect(os.WriteFile(badPath, []byte(badCue), 0644)).ToNot(HaveOccurred())
+
+		defer resetCmdArgs()
+		bundleBuildArgs.files = []string{badPath}
+		var out bytes.Buffer
+		cmd := &cobra.Command{Use: "build"}
+		cmd.SetContext(context.Background())
+		cmd.SetOut(&out)
+		cmd.SetErr(io.Discard)
+
+		err := runBundleBuildCmd(cmd, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(out.Len()).To(BeZero())
 	})
 }

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -606,6 +606,12 @@ the module version set to `0.0.0-devel`.
 By default, `timoni bundle build` prints the resulting Kubernetes resources of all
 instances to stdout. To write the manifests as files on disk, use the `--output-dir` flag.
 
+Stdout mode is render-only: every instance is built and marshalled in memory first,
+and the complete result is written to stdout in one pass only after all instances
+succeed. If the build of any instance fails, no output is written. The exit status
+also reflects the final stdout write, so a failed or incomplete write cannot be
+reported as success.
+
 The instances are built concurrently, with the number of concurrent builds set by the
 `--concurrency` flag. It defaults to the number of CPU cores capped at 8; raising it
 can speed up large bundles at the cost of a higher peak memory usage.


### PR DESCRIPTION
## What

Make a successful `timoni bundle build` exit guarantee that the complete in-memory render was accepted by stdout. Propagate the final writer error, and report `io.ErrShortWrite` when the writer accepts fewer bytes without returning an error. The command, flags, rendered bytes, ordering, concurrency, and existing `--output-dir` behavior stay unchanged; the `--output-dir` path already returned file write errors and is untouched.

## Why

Bundle rendering already has an excellent automation shape: Timoni builds every instance in memory, preserves bundle order, and performs one final stdout write only after the whole render succeeds. The final `Write` result is currently discarded, so a full, closed, or otherwise failing output sink can receive incomplete data while Timoni reports success. This fix turns the exit status into a dependable completeness signal for artifact pipelines and other render-only consumers, without adding a destination directory, staging tree, or apply step.

## Reproduction

The command before and after this change is identical.

```shell
# Linux: a failing output sink (writes fail with ENOSPC).
timoni bundle build -f bundle.cue >/dev/full
echo $?

# main: discards the write error, leaves the stdout stream empty, still exits 0.
# this PR: returns the write error, logs it to stderr, exits 1.
```

## What the reviewer must decide

1. Whether failing the command on a short write with a nil error (not only on a returned writer error) is the right completeness contract for a render-only stdout command.
2. Whether keeping the sibling single-instance `timoni build` on its existing behavior (it already propagates the write error but does not check short writes) is acceptable, or whether the two render commands should share the same check.

## Verification

```shell
go test ./cmd/timoni/ -run 'Test_BundleBuild' -count=1
```

The focused suite covers a sentinel writer failure, a nil-error short write, an ordinary render failure with zero output, existing stdout bytes and ordering, and unchanged directory output.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>