### PR TITLE
feat(cli): Add tag filtering to artifact list command

### DIFF
--- a/cmd/timoni/artifact_list.go
+++ b/cmd/timoni/artifact_list.go
@@ -42,6 +42,12 @@ var listArtifactCmd = &cobra.Command{
   # Print the tags without digests
   timoni artifact list oci://ghcr.io/org/bundles/app --with-digest=false
 
+  # Print the tags matching a regular expression
+  timoni artifact list oci://docker.io/org/app --filter-regex '^1\.'
+
+  # Print the tags matching a semver range
+  timoni artifact list oci://docker.io/org/app --filter-semver '>=1.0.0 <2.0.0'
+
   # Print the tags and digests of an artifact stored in a private repository
   echo $DOCKER_TOKEN | timoni registry login docker.io -u timoni --password-stdin
   timoni artifact list oci://docker.io/org/app
@@ -54,9 +60,11 @@ var listArtifactCmd = &cobra.Command{
 }
 
 type listArtifactFlags struct {
-	creds      flags.Credentials
-	withDigest bool
-	output     string
+	creds        flags.Credentials
+	withDigest   bool
+	output       string
+	filterRegex  string
+	filterSemver string
 }
 
 var listArtifactArgs listArtifactFlags
@@ -67,6 +75,10 @@ func init() {
 		"Resolve the digest of each version.")
 	listArtifactCmd.Flags().StringVarP(&listArtifactArgs.output, "output", "o", "",
 		"The format in which the tags should be printed, can be 'yaml' or 'json'.")
+	listArtifactCmd.Flags().StringVar(&listArtifactArgs.filterRegex, "filter-regex", "",
+		"Filter tags returned from the OCI repository using regular expressions.")
+	listArtifactCmd.Flags().StringVar(&listArtifactArgs.filterSemver, "filter-semver", "",
+		"Filter tags returned from the OCI repository using semantic version ranges.")
 	artifactCmd.AddCommand(listArtifactCmd)
 }
 
@@ -87,7 +99,11 @@ func listArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	opts := oci.Options(ctx, listArtifactArgs.creds.String(), rootArgs.registryInsecure)
-	list, err := oci.ListArtifactTags(ociURL, listArtifactArgs.withDigest, opts)
+	list, err := oci.ListArtifactTags(ociURL, oci.ListArtifactOptions{
+		WithDigest:   listArtifactArgs.withDigest,
+		FilterRegex:  listArtifactArgs.filterRegex,
+		FilterSemver: listArtifactArgs.filterSemver,
+	}, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/timoni/artifact_list_test.go
+++ b/cmd/timoni/artifact_list_test.go
@@ -31,16 +31,32 @@ func Test_ListArtifact(t *testing.T) {
 	g := NewWithT(t)
 	aPath := "testdata/module-values"
 	aURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-artifact", 5))
-	aTags := []string{"1.0.0", "latest"}
+	aTags := []string{"1.0.0", "1.1.0", "2.0.0", "dev", "latest"}
 
-	_, err := executeCommand(fmt.Sprintf(
-		"artifact push oci://%s -f %s -t %s -t %s",
-		aURL,
-		aPath,
-		aTags[0],
-		aTags[1],
-	))
+	pushCmd := fmt.Sprintf("artifact push oci://%s -f %s", aURL, aPath)
+	for _, tag := range aTags {
+		pushCmd += fmt.Sprintf(" -t %s", tag)
+	}
+
+	_, err := executeCommand(pushCmd)
 	g.Expect(err).ToNot(HaveOccurred())
+
+	listTags := func(t *testing.T, args string) []string {
+		t.Helper()
+		g := NewWithT(t)
+
+		output, err := executeCommand(fmt.Sprintf("artifact ls oci://%s -o json %s", aURL, args))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var list []apiv1.ArtifactReference
+		g.Expect(json.Unmarshal([]byte(output), &list)).To(Succeed())
+
+		var tags []string
+		for _, ref := range list {
+			tags = append(tags, ref.Tag)
+		}
+		return tags
+	}
 
 	t.Run("prints table", func(t *testing.T) {
 		g := NewWithT(t)
@@ -97,6 +113,41 @@ func Test_ListArtifact(t *testing.T) {
 		for _, tag := range aTags {
 			g.Expect(tags).To(HaveKey(tag))
 		}
+	})
+
+	t.Run("filters tags by regex", func(t *testing.T) {
+		g := NewWithT(t)
+		tags := listTags(t, `--filter-regex '^1\.'`)
+
+		g.Expect(tags).To(ConsistOf("1.0.0", "1.1.0"))
+	})
+
+	t.Run("filters tags by semver", func(t *testing.T) {
+		g := NewWithT(t)
+		tags := listTags(t, `--filter-semver '>=1.1.0'`)
+
+		g.Expect(tags).To(ConsistOf("1.1.0", "2.0.0"))
+	})
+
+	t.Run("filters tags by regex and semver", func(t *testing.T) {
+		g := NewWithT(t)
+		tags := listTags(t, `--filter-regex '^1\.' --filter-semver '>=1.1.0'`)
+
+		g.Expect(tags).To(ConsistOf("1.1.0"))
+	})
+
+	t.Run("fails for invalid regex filter", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf("artifact ls oci://%s --filter-regex '['", aURL))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid regex filter"))
+	})
+
+	t.Run("fails for invalid semver filter", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf("artifact ls oci://%s --filter-semver 'junk'", aURL))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid semver filter"))
 	})
 
 	t.Run("fails for invalid output format", func(t *testing.T) {

--- a/docs/bundle-distribution.md
+++ b/docs/bundle-distribution.md
@@ -115,6 +115,18 @@ List all the artifact's tags and digest with [timoni artifact list](cmd/timoni_a
 timoni artifact list oci://docker.io/my-org/my-app-bundle
 ```
 
+The tags can be filtered with a regular expression using `--filter-regex`,
+and with a semantic version range using `--filter-semver`:
+
+```shell
+timoni artifact list oci://docker.io/my-org/my-app-bundle \
+  --filter-regex '^1\.' \
+  --filter-semver '>=1.1.0'
+```
+
+Tags that are not valid semantic versions, such as `latest`, are excluded
+when `--filter-semver` is set.
+
 Verify the signature and download a specific artifact tag with [timoni artifact pull](cmd/timoni_artifact_pull.md):
 
 ```shell

--- a/internal/oci/artifact_test.go
+++ b/internal/oci/artifact_test.go
@@ -51,7 +51,7 @@ func TestArtifactOperations(t *testing.T) {
 	err = TagArtifact(digestURL, apiv1.LatestVersion, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	list, err := ListArtifactTags(imgURL, true, opts)
+	list, err := ListArtifactTags(imgURL, ListArtifactOptions{WithDigest: true}, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(list)).To(BeEquivalentTo(2))
 	g.Expect(list[0].Tag).To(BeEquivalentTo(apiv1.LatestVersion))

--- a/internal/oci/list_artifact.go
+++ b/internal/oci/list_artifact.go
@@ -18,20 +18,38 @@ package oci
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
+// ListArtifactOptions holds the options for listing the tags
+// of an artifact repository.
+type ListArtifactOptions struct {
+	// WithDigest enables the resolving of the digest for each tag.
+	WithDigest bool
+
+	// FilterRegex is a regular expression used to filter the tags,
+	// all tags are returned if empty.
+	FilterRegex string
+
+	// FilterSemver is a semantic version range used to filter the tags,
+	// all tags are returned if empty.
+	FilterSemver string
+}
+
 // ListArtifactTags performs the following operations:
 // - fetches the digest of the latest tag (if it exists)
 // - lists all the tags from the artifact repository
+// - filters the tags based on the regex and semver expressions (if configured to do so)
 // - fetches the digest of each tag (if configured to do so)
 // - returns an array of ArtifactReference objects
-func ListArtifactTags(ociURL string, withDigest bool, opts []crane.Option) ([]apiv1.ArtifactReference, error) {
+func ListArtifactTags(ociURL string, listOpts ListArtifactOptions, opts []crane.Option) ([]apiv1.ArtifactReference, error) {
 	var list []apiv1.ArtifactReference
 
 	ref, err := parseArtifactRef(ociURL)
@@ -39,17 +57,25 @@ func ListArtifactTags(ociURL string, withDigest bool, opts []crane.Option) ([]ap
 		return nil, err
 	}
 
+	filter, err := newTagFilter(listOpts.FilterRegex, listOpts.FilterSemver)
+	if err != nil {
+		return nil, err
+	}
+
+	withDigest := listOpts.WithDigest
 	repoURL := ref.Context().Name()
 
-	if digest, err := crane.Digest(fmt.Sprintf("%s:%s", repoURL, name.DefaultTag), opts...); err == nil {
-		if !withDigest {
-			digest = ""
+	if filter.matches(name.DefaultTag) {
+		if digest, err := crane.Digest(fmt.Sprintf("%s:%s", repoURL, name.DefaultTag), opts...); err == nil {
+			if !withDigest {
+				digest = ""
+			}
+			list = append(list, apiv1.ArtifactReference{
+				Repository: ociURL,
+				Tag:        name.DefaultTag,
+				Digest:     digest,
+			})
 		}
-		list = append(list, apiv1.ArtifactReference{
-			Repository: ociURL,
-			Tag:        name.DefaultTag,
-			Digest:     digest,
-		})
 	}
 
 	tags, err := crane.ListTags(repoURL, opts...)
@@ -60,7 +86,7 @@ func ListArtifactTags(ociURL string, withDigest bool, opts []crane.Option) ([]ap
 	sort.Slice(tags, func(i, j int) bool { return tags[i] > tags[j] })
 
 	for _, tag := range tags {
-		if tag == name.DefaultTag {
+		if tag == name.DefaultTag || !filter.matches(tag) {
 			continue
 		}
 		digest := ""
@@ -79,4 +105,55 @@ func ListArtifactTags(ociURL string, withDigest bool, opts []crane.Option) ([]ap
 	}
 
 	return list, nil
+}
+
+// tagFilter filters OCI tags by regular expression and semantic version range.
+type tagFilter struct {
+	regex      *regexp.Regexp
+	constraint *semver.Constraints
+}
+
+// newTagFilter returns a tagFilter for the given regular expression and
+// semantic version range, both expressions are optional.
+func newTagFilter(filterRegex, filterSemver string) (*tagFilter, error) {
+	f := &tagFilter{}
+
+	if filterRegex != "" {
+		regex, err := regexp.Compile(filterRegex)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex filter '%s': %w", filterRegex, err)
+		}
+		f.regex = regex
+	}
+
+	if filterSemver != "" {
+		constraint, err := semver.NewConstraint(filterSemver)
+		if err != nil {
+			return nil, fmt.Errorf("invalid semver filter '%s': %w", filterSemver, err)
+		}
+		f.constraint = constraint
+	}
+
+	return f, nil
+}
+
+// matches returns true if the tag satisfies both the regular expression and
+// the semantic version range. Tags that are not valid semantic versions are
+// filtered out when a semver range is set.
+func (f *tagFilter) matches(tag string) bool {
+	if f.regex != nil && !f.regex.MatchString(tag) {
+		return false
+	}
+
+	if f.constraint != nil {
+		version, err := semver.NewVersion(tag)
+		if err != nil {
+			return false
+		}
+		if !f.constraint.Check(version) {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
Add `--filter-regex `and `--filter-semver` flags to filter the tags returned by `timoni artifact list`.

xref: https://github.com/stefanprodan/timoni/issues/615