### PR TITLE
feat(cli): Add `artifact digest` command

### DIFF
--- a/cmd/timoni/args_test.go
+++ b/cmd/timoni/args_test.go
@@ -30,6 +30,7 @@ func TestCommandsRejectExtraArgs(t *testing.T) {
 		args []string
 	}{
 		{name: "apply", cmd: applyCmd, args: []string{"instance", "module", "extra"}},
+		{name: "artifact digest", cmd: digestArtifactCmd, args: []string{"url", "extra"}},
 		{name: "artifact list", cmd: listArtifactCmd, args: []string{"url", "extra"}},
 		{name: "artifact pull", cmd: pullArtifactCmd, args: []string{"url", "extra"}},
 		{name: "artifact push", cmd: pushArtifactCmd, args: []string{"url", "extra"}},

--- a/cmd/timoni/artifact_digest.go
+++ b/cmd/timoni/artifact_digest.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"github.com/stefanprodan/timoni/internal/flags"
+	"github.com/stefanprodan/timoni/internal/logger"
+	"github.com/stefanprodan/timoni/internal/oci"
+)
+
+var digestArtifactCmd = &cobra.Command{
+	Use:   "digest ARTIFACT_URL",
+	Args:  cobra.MaximumNArgs(1),
+	Short: "Resolve the digest of an artifact",
+	Long: `The digest command resolves the digest of an artifact tag.
+When the URL contains no tag, the 'latest' tag is used.`,
+	Example: `  # Print the digest of the latest tag
+  timoni artifact digest oci://docker.io/org/app
+
+  # Print the digest of a specific tag
+  timoni artifact digest oci://docker.io/org/app:1.0.0
+
+  # Print the digest of an artifact stored in a private repository
+  echo $DOCKER_TOKEN | timoni registry login docker.io -u timoni --password-stdin
+  timoni artifact digest oci://docker.io/org/app
+
+  # Extract the digest using the JSON output
+  timoni artifact digest oci://ghcr.io/org/bundles/app -o json | jq -r '.digest'
+`,
+	RunE: digestArtifactCmdRun,
+}
+
+type digestArtifactFlags struct {
+	creds  flags.Credentials
+	output string
+}
+
+var digestArtifactArgs digestArtifactFlags
+
+func init() {
+	digestArtifactCmd.Flags().Var(&digestArtifactArgs.creds, digestArtifactArgs.creds.Type(), digestArtifactArgs.creds.Description())
+	digestArtifactCmd.Flags().StringVarP(&digestArtifactArgs.output, "output", "o", "",
+		"The format in which the digest should be printed, can be 'yaml' or 'json'.")
+
+	artifactCmd.AddCommand(digestArtifactCmd)
+}
+
+// digestArtifactCmdRun resolves the digest of an OCI artifact tag
+// and prints the artifact reference in the specified format.
+func digestArtifactCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("artifact URL is required")
+	}
+	ociURL := args[0]
+
+	if err := validateOutputFormat(digestArtifactArgs.output, true); err != nil {
+		return err
+	}
+
+	spin := logger.StartSpinner("resolving digest")
+	defer spin.Stop()
+
+	log := LoggerFrom(cmd.Context())
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
+	defer cancel()
+
+	opts := oci.Options(ctx, digestArtifactArgs.creds.String(), rootArgs.registryInsecure)
+	ref, err := oci.GetArtifactDigest(ociURL, opts)
+	if err != nil {
+		return err
+	}
+
+	spin.Stop()
+
+	switch digestArtifactArgs.output {
+	case "json":
+		marshalled, err := json.MarshalIndent(&ref, "", "  ")
+		if err != nil {
+			return fmt.Errorf("artifact digest JSON conversion failed: %w", err)
+		}
+		marshalled = append(marshalled, "\n"...)
+		_, err = cmd.OutOrStdout().Write(marshalled)
+		return err
+	case "yaml":
+		marshalled, err := yaml.Marshal(&ref)
+		if err != nil {
+			return fmt.Errorf("artifact digest YAML conversion failed: %w", err)
+		}
+		_, err = cmd.OutOrStdout().Write(marshalled)
+		return err
+	default:
+		url := ref.Repository
+		if ref.Tag != "" {
+			url = fmt.Sprintf("%s:%s", ref.Repository, ref.Tag)
+		}
+		log.Info(fmt.Sprintf("artifact: %s", logger.ColorizeSubject(url)))
+		log.Info(fmt.Sprintf("digest: %s", logger.ColorizeSubject(ref.Digest)))
+	}
+
+	return nil
+}

--- a/cmd/timoni/artifact_digest_test.go
+++ b/cmd/timoni/artifact_digest_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+func Test_DigestArtifact(t *testing.T) {
+	g := NewWithT(t)
+	aPath := "testdata/module-values"
+	aURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("my-artifact", 5))
+
+	_, err := executeCommand(fmt.Sprintf("artifact push oci://%s -f %s -t 1.0.0 -t latest", aURL, aPath))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	latestDigest, err := crane.Digest(fmt.Sprintf("%s:latest", aURL))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	t.Run("defaults to the latest tag", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf("artifact digest oci://%s", aURL))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(output).To(ContainSubstring(fmt.Sprintf("artifact: oci://%s:latest", aURL)))
+		g.Expect(output).To(ContainSubstring(fmt.Sprintf("digest: %s", latestDigest)))
+	})
+
+	t.Run("resolves the specified tag", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf("artifact digest oci://%s:1.0.0", aURL))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(output).To(ContainSubstring(fmt.Sprintf("artifact: oci://%s:1.0.0", aURL)))
+		g.Expect(output).To(ContainSubstring(fmt.Sprintf("digest: %s", latestDigest)))
+	})
+
+	t.Run("prints JSON", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf("artifact digest oci://%s:1.0.0 -o json", aURL))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var ref apiv1.ArtifactReference
+		g.Expect(json.Unmarshal([]byte(output), &ref)).To(Succeed())
+		g.Expect(ref.Repository).To(Equal(fmt.Sprintf("oci://%s", aURL)))
+		g.Expect(ref.Tag).To(Equal("1.0.0"))
+		g.Expect(ref.Digest).To(Equal(latestDigest))
+	})
+
+	t.Run("prints YAML", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf("artifact digest oci://%s -o yaml", aURL))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var ref apiv1.ArtifactReference
+		g.Expect(yaml.Unmarshal([]byte(output), &ref)).To(Succeed())
+		g.Expect(ref.Repository).To(Equal(fmt.Sprintf("oci://%s", aURL)))
+		g.Expect(ref.Tag).To(Equal("latest"))
+		g.Expect(ref.Digest).To(Equal(latestDigest))
+	})
+
+	t.Run("fails for missing tag", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf("artifact digest oci://%s:2.0.0", aURL))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("resolving digest"))
+	})
+
+	t.Run("fails for invalid URL", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf("artifact digest %s", aURL))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("URL must be in format"))
+	})
+
+	t.Run("fails for invalid output format", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf("artifact digest oci://%s -o junk", aURL))
+		g.Expect(err).To(MatchError("unknown --output=junk, can be yaml or json"))
+	})
+}

--- a/cmd/timoni/command_usage_test.go
+++ b/cmd/timoni/command_usage_test.go
@@ -29,6 +29,7 @@ func TestRequiredOperandsAreNotOptionalInUsage(t *testing.T) {
 		want string
 	}{
 		{applyCmd, "apply INSTANCE_NAME MODULE_URL"},
+		{digestArtifactCmd, "digest ARTIFACT_URL"},
 		{listArtifactCmd, "list ARTIFACT_URL"},
 		{pullArtifactCmd, "pull ARTIFACT_URL"},
 		{pushArtifactCmd, "push REPOSITORY_URL"},

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -182,6 +182,7 @@ func resetCmdArgs() {
 		contentType: "generic",
 	}
 	pullArtifactArgs = pullArtifactFlags{}
+	digestArtifactArgs = digestArtifactFlags{}
 	runtimeBuildArgs = runtimeBuildFlags{}
 	versionArgs = versionFlags{output: "yaml"}
 }

--- a/docs/bundle-distribution.md
+++ b/docs/bundle-distribution.md
@@ -127,6 +127,12 @@ timoni artifact list oci://docker.io/my-org/my-app-bundle \
 Tags that are not valid semantic versions, such as `latest`, are excluded
 when `--filter-semver` is set.
 
+Resolve the digest of a single tag with [timoni artifact digest](cmd/timoni_artifact_digest.md):
+
+```shell
+timoni artifact digest oci://docker.io/my-org/my-app-bundle:1.0.0
+```
+
 Verify the signature and download a specific artifact tag with [timoni artifact pull](cmd/timoni_artifact_pull.md):
 
 ```shell

--- a/internal/oci/digest_artifact.go
+++ b/internal/oci/digest_artifact.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+// GetArtifactDigest resolves the digest of the OpenContainers artifact
+// found at the given URL. When the URL contains no tag, the 'latest'
+// tag is used. The returned reference contains the canonical repository
+// name, the resolved tag and the digest in the format '<sha-type>:<hex>'.
+func GetArtifactDigest(ociURL string, opts []crane.Option) (apiv1.ArtifactReference, error) {
+	ref, err := parseArtifactRef(ociURL)
+	if err != nil {
+		return apiv1.ArtifactReference{}, err
+	}
+
+	digest, err := crane.Digest(ref.Name(), opts...)
+	if err != nil {
+		return apiv1.ArtifactReference{}, fmt.Errorf("resolving digest of '%s' failed: %w", ociURL, err)
+	}
+
+	var tag string
+	if t, ok := ref.(name.Tag); ok {
+		tag = t.TagStr()
+	}
+
+	return apiv1.ArtifactReference{
+		Repository: apiv1.ArtifactPrefix + ref.Context().Name(),
+		Tag:        tag,
+		Digest:     digest,
+	}, nil
+}

--- a/internal/oci/digest_artifact_test.go
+++ b/internal/oci/digest_artifact_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetArtifactDigestRejectsInvalidURL(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := GetArtifactDigest("docker.io/org/app", nil)
+	g.Expect(err).To(MatchError(ContainSubstring("URL must be in format")))
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,7 @@ nav:
       - Artifact:
           - cmd/timoni_artifact.md
           - cmd/timoni_artifact_build.md
+          - cmd/timoni_artifact_digest.md
           - cmd/timoni_artifact_list.md
           - cmd/timoni_artifact_push.md
           - cmd/timoni_artifact_pull.md


### PR DESCRIPTION
Add `timoni artifact digest ARTIFACT_URL` which resolves the digest of an artifact tag, defaulting to the `latest` tag when the URL contains no tag. Without `--output`, the command logs the artifact URL and its digest, with `--output json|yaml` it prints the repository, tag and digest.