### PR TITLE
feat(cli): Add `--mask-secrets` to build commands

### DIFF
--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -40,6 +40,7 @@ import (
 	"github.com/stefanprodan/timoni/internal/engine"
 	"github.com/stefanprodan/timoni/internal/engine/fetcher"
 	"github.com/stefanprodan/timoni/internal/flags"
+	"github.com/stefanprodan/timoni/internal/mask"
 )
 
 var buildCmd = &cobra.Command{
@@ -76,6 +77,7 @@ type buildFlags struct {
 	digest      flags.Digest
 	valuesFiles []string
 	output      string
+	maskSecrets bool
 	creds       flags.Credentials
 }
 
@@ -89,6 +91,8 @@ func init() {
 		"The local path to values files (cue, yaml or json format).")
 	buildCmd.Flags().StringVarP(&buildArgs.output, "output", "o", "yaml",
 		"The format in which the Kubernetes objects should be printed, can be 'yaml' or 'json'.")
+	buildCmd.Flags().BoolVar(&buildArgs.maskSecrets, "mask-secrets", false,
+		"Hide the values of Kubernetes Secrets in the printed objects.")
 	buildCmd.Flags().Var(&buildArgs.creds, buildArgs.creds.Type(), buildArgs.creds.Description())
 
 	rootCmd.AddCommand(buildCmd)
@@ -196,6 +200,12 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 	var objects []*unstructured.Unstructured
 	for _, set := range applySets {
 		objects = append(objects, set.Objects...)
+	}
+
+	if buildArgs.maskSecrets {
+		for i, obj := range objects {
+			objects[i] = mask.SecretData(obj)
+		}
 	}
 
 	switch buildArgs.output {

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -38,6 +38,7 @@ import (
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/engine"
 	"github.com/stefanprodan/timoni/internal/flags"
+	"github.com/stefanprodan/timoni/internal/mask"
 	"github.com/stefanprodan/timoni/internal/runtime"
 )
 
@@ -67,6 +68,7 @@ type bundleBuildFlags struct {
 	creds       flags.Credentials
 	outputDir   string
 	concurrency int
+	maskSecrets bool
 }
 
 var bundleBuildArgs bundleBuildFlags
@@ -80,6 +82,8 @@ func init() {
 		"The path to a directory where the manifests are written as a tree, one directory per instance and one file per resource.")
 	bundleBuildCmd.Flags().IntVar(&bundleBuildArgs.concurrency, "concurrency", 0,
 		"The number of instances to build concurrently, defaults to the number of CPU cores capped at 8.")
+	bundleBuildCmd.Flags().BoolVar(&bundleBuildArgs.maskSecrets, "mask-secrets", false,
+		"Hide the values of Kubernetes Secrets in the printed objects, ignored with --output-dir.")
 	bundleCmd.AddCommand(bundleBuildCmd)
 }
 
@@ -202,6 +206,12 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 			objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name])
 			if err != nil {
 				return err
+			}
+
+			if bundleBuildArgs.maskSecrets {
+				for i, obj := range objects {
+					objects[i] = mask.SecretData(obj)
+				}
 			}
 
 			m, err := marshalObjectsToYAML(objects)

--- a/cmd/timoni/mask_secrets_test.go
+++ b/cmd/timoni/mask_secrets_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/mask"
+)
+
+// TestApply_DiffMasksSecrets guards the masking of Secret data in the
+// server-side diff, performed by the fluxcd/pkg/ssa ResourceManager.
+func TestApply_DiffMasksSecrets(t *testing.T) {
+	g := NewWithT(t)
+	modPath := "testdata/module-secret"
+	name := rnd("my-instance", 5)
+	namespace := rnd("my-namespace", 5)
+
+	oldPassword := "s3cr3t"
+	newPassword := "ch4ng3d"
+	oldEncoded := base64.StdEncoding.EncodeToString([]byte(oldPassword))
+	newEncoded := base64.StdEncoding.EncodeToString([]byte(newPassword))
+
+	valuesPath := filepath.Join(t.TempDir(), "values.cue")
+	g.Expect(os.WriteFile(valuesPath, fmt.Appendf(nil, `values: password: %q`, newPassword), 0644)).To(Succeed())
+
+	_, err := executeCommand(fmt.Sprintf(
+		"apply -n %s %s %s -p main --wait",
+		namespace,
+		name,
+		modPath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output, err := executeCommand(fmt.Sprintf(
+		"apply -n %s %s %s -p main --diff -f %s",
+		namespace,
+		name,
+		modPath,
+		valuesPath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+	t.Log("\n", output)
+
+	g.Expect(output).To(ContainSubstring("Secret/%s/%s configured", namespace, name))
+	g.Expect(output).To(ContainSubstring("*** (before)"))
+	g.Expect(output).To(ContainSubstring("*** (after)"))
+	g.Expect(output).ToNot(ContainSubstring(oldEncoded))
+	g.Expect(output).ToNot(ContainSubstring(newEncoded))
+	g.Expect(output).ToNot(ContainSubstring(oldPassword))
+	g.Expect(output).ToNot(ContainSubstring(newPassword))
+}
+
+func TestBuild_MaskSecrets(t *testing.T) {
+	modPath := "testdata/module-secret"
+
+	t.Run("prints secret data by default", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(buildCmd.Flags().Lookup("mask-secrets").DefValue).To(Equal("false"))
+
+		output, err := executeCommand(fmt.Sprintf(
+			"build test %s -p main",
+			modPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("password: s3cr3t"))
+		g.Expect(output).To(ContainSubstring("secretName: test"))
+	})
+
+	t.Run("masks secret data in yaml and json output", func(t *testing.T) {
+		g := NewWithT(t)
+		for _, format := range []string{"yaml", "json"} {
+			output, err := executeCommand(fmt.Sprintf(
+				"build test %s -p main --mask-secrets -o %s",
+				modPath,
+				format,
+			))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(output).ToNot(ContainSubstring("s3cr3t"), format)
+			g.Expect(output).ToNot(ContainSubstring("t0k3n"), format)
+			g.Expect(output).To(ContainSubstring(mask.Value), format)
+			// ConfigMap data is not masked.
+			g.Expect(output).To(ContainSubstring("secretName"), format)
+			g.Expect(output).To(ContainSubstring("test"), format)
+		}
+	})
+}
+
+func TestBundleBuild_MaskSecrets(t *testing.T) {
+	g := NewWithT(t)
+	modPath := "testdata/module-secret"
+	namespace := rnd("my-namespace", 5)
+
+	bundleCue := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "secret-app"
+	instances: {
+		app: {
+			module: url: "file://%[1]s"
+			namespace: "%[2]s"
+			values: password: "bundl3-p4ss"
+		}
+	}
+}
+`, modPath, namespace)
+
+	wd := t.TempDir()
+	cuePath := filepath.Join(wd, "bundle.cue")
+	g.Expect(os.WriteFile(cuePath, []byte(bundleCue), 0644)).To(Succeed())
+	g.Expect(engine.CopyDir(modPath, filepath.Join(wd, modPath), true)).To(Succeed())
+
+	t.Run("prints secret data by default", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(bundleBuildCmd.Flags().Lookup("mask-secrets").DefValue).To(Equal("false"))
+
+		output, err := executeCommand(fmt.Sprintf("bundle build -f %s -p main", cuePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("password: bundl3-p4ss"))
+	})
+
+	t.Run("masks secret data on stdout", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf("bundle build -f %s -p main --mask-secrets", cuePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).ToNot(ContainSubstring("bundl3-p4ss"))
+		g.Expect(output).ToNot(ContainSubstring("t0k3n"))
+		g.Expect(output).To(ContainSubstring(mask.Value))
+		g.Expect(output).To(ContainSubstring("secretName: app"))
+	})
+
+	t.Run("writes secret data to the output dir", func(t *testing.T) {
+		g := NewWithT(t)
+		outDir := filepath.Join(t.TempDir(), "manifests")
+		_, err := executeCommand(fmt.Sprintf("bundle build -f %s -p main --mask-secrets --output-dir %s", cuePath, outDir))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		data, err := os.ReadFile(filepath.Join(outDir, "app", "v1_secret_app.yaml"))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(string(data)).To(ContainSubstring("bundl3-p4ss"))
+		g.Expect(string(data)).ToNot(ContainSubstring(mask.Value))
+	})
+}

--- a/cmd/timoni/testdata/module-secret/cue.mod/module.cue
+++ b/cmd/timoni/testdata/module-secret/cue.mod/module.cue
@@ -1,0 +1,2 @@
+module: "timoni.sh/test-secret"
+language: version: "v0.17.1"

--- a/cmd/timoni/testdata/module-secret/timoni.cue
+++ b/cmd/timoni/testdata/module-secret/timoni.cue
@@ -1,0 +1,53 @@
+package main
+
+// Define the schema for the user-supplied values.
+values: {
+	password: *"s3cr3t" | string
+	token:    *"t0k3n" | string
+}
+
+// Define how Timoni should build, validate and
+// apply the Kubernetes resources.
+timoni: {
+	apiVersion: "v1alpha1"
+
+	instance: {
+		config: {
+			metadata: {
+				name:      string @tag(name)
+				namespace: string @tag(namespace)
+			}
+			password: values.password
+			token:    values.token
+		}
+
+		objects: {
+			// The ConfigMap references the Secret and must never be masked.
+			cm: {
+				apiVersion: "v1"
+				kind:       "ConfigMap"
+				metadata: {
+					name:      config.metadata.name
+					namespace: config.metadata.namespace
+				}
+				data: secretName: config.metadata.name
+			}
+
+			secret: {
+				apiVersion: "v1"
+				kind:       "Secret"
+				metadata: {
+					name:      config.metadata.name
+					namespace: config.metadata.namespace
+				}
+				type: "Opaque"
+				stringData: {
+					password: config.password
+					token:    config.token
+				}
+			}
+		}
+	}
+
+	apply: app: [for obj in instance.objects {obj}]
+}

--- a/cmd/timoni/testdata/module-secret/values.cue
+++ b/cmd/timoni/testdata/module-secret/values.cue
@@ -1,0 +1,8 @@
+// Note that this file must have no imports and all values must be concrete.
+
+package main
+
+values: {
+	password: "s3cr3t"
+	token:    "t0k3n"
+}

--- a/docs/bundle.mdx
+++ b/docs/bundle.mdx
@@ -396,6 +396,9 @@ Example:
 timoni bundle apply --dry-run --diff -f bundle.cue
 ```
 
+The values of the Kubernetes Secrets `data` entries are masked in the diff
+output: changed entries are printed as `*** (before)` and `*** (after)`.
+
 ### Force Upgrade
 
 If an upgrade contains changes to immutable fields, such as changing the image
@@ -449,6 +452,14 @@ Example:
 
 ```shell
 timoni bundle build -f bundle.cue
+```
+
+To print the manifests without exposing credentials, for example when sharing
+the output or reviewing it in a CI log, use the `--mask-secrets` flag which
+replaces the values of Kubernetes Secrets with `***`:
+
+```shell
+timoni bundle build -f bundle.cue --mask-secrets
 ```
 
 To write the generated manifests to disk as a directory tree instead of printing them
@@ -617,6 +628,7 @@ the module version set to `0.0.0-devel`.
 
 By default, `timoni bundle build` prints the resulting Kubernetes resources of all
 instances to stdout. To write the manifests as files on disk, use the `--output-dir` flag.
+The files always contain the Secret values, the `--mask-secrets` flag applies to stdout only.
 
 Stdout mode is render-only: every instance is built and marshalled in memory first,
 and the complete result is written to stdout in one pass only after all instances

--- a/docs/cue/module/initialization.mdx
+++ b/docs/cue/module/initialization.mdx
@@ -104,6 +104,8 @@ Timoni will create it.
 When making changes to the module, you can use the `timoni apply --diff`
 flag to see the differences between the in-cluster resources
 and the newly generated ones.
+The values of the Kubernetes Secrets data entries are masked in the diff. To mask them in the
+`timoni build` output as well, use the `--mask-secrets` flag.
 </Tip>
 
 To delete the module instance:

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -171,6 +171,7 @@ Apply the config to the podinfo module to perform an upgrade:
 
 Before running an upgrade, you can review the changes that will
 be made on the cluster with `timoni apply --dry-run --diff`.
+The values of the Kubernetes Secrets data entries are masked in the diff output.
 
 ## Uninstall a module instance
 

--- a/internal/mask/mask.go
+++ b/internal/mask/mask.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mask hides the values of Kubernetes Secrets in the objects
+// that Timoni prints, so that rendered manifests can be shared without
+// exposing credentials.
+package mask
+
+import (
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Value replaces the values of the Secret data and stringData entries.
+const Value = "***"
+
+// lastAppliedAnnotation holds a copy of the object set by kubectl apply.
+const lastAppliedAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
+
+// secretFields are the Secret fields whose values are masked.
+var secretFields = []string{"data", "stringData"}
+
+// SecretData returns a copy of the object with every entry under the
+// Secret data and stringData fields replaced by the mask, along with the
+// kubectl last-applied-configuration annotation. A data or stringData
+// field that is not a map is replaced by the mask as a whole. Objects
+// that are not Secrets are returned unchanged.
+func SecretData(obj *unstructured.Unstructured) *unstructured.Unstructured {
+	if obj == nil || !ssautil.IsSecret(obj) {
+		return obj
+	}
+
+	masked := obj.DeepCopy()
+	for _, field := range secretFields {
+		raw, found := masked.Object[field]
+		if !found {
+			continue
+		}
+		entries, isMap := raw.(map[string]any)
+		if !isMap {
+			masked.Object[field] = Value
+			continue
+		}
+		for key := range entries {
+			entries[key] = Value
+		}
+	}
+	if annotations := masked.GetAnnotations(); annotations != nil {
+		if _, found := annotations[lastAppliedAnnotation]; found {
+			annotations[lastAppliedAnnotation] = Value
+			masked.SetAnnotations(annotations)
+		}
+	}
+	return masked
+}

--- a/internal/mask/mask_test.go
+++ b/internal/mask/mask_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mask
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func secret(data map[string]any, stringData map[string]any) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]any{
+			"name":      "test",
+			"namespace": "default",
+		},
+	}}
+	if data != nil {
+		obj.Object["data"] = data
+	}
+	if stringData != nil {
+		obj.Object["stringData"] = stringData
+	}
+	return obj
+}
+
+func TestSecretData(t *testing.T) {
+	t.Run("masks data and stringData", func(t *testing.T) {
+		g := NewWithT(t)
+		obj := secret(
+			map[string]any{"password": "cGFzcw=="},
+			map[string]any{"token": "plain"},
+		)
+
+		masked := SecretData(obj)
+
+		g.Expect(masked.Object["data"]).To(Equal(map[string]any{"password": Value}))
+		g.Expect(masked.Object["stringData"]).To(Equal(map[string]any{"token": Value}))
+		g.Expect(masked.GetName()).To(Equal("test"))
+	})
+
+	t.Run("does not mutate the input", func(t *testing.T) {
+		g := NewWithT(t)
+		obj := secret(map[string]any{"password": "cGFzcw=="}, nil)
+
+		SecretData(obj)
+
+		g.Expect(obj.Object["data"]).To(Equal(map[string]any{"password": "cGFzcw=="}))
+	})
+
+	t.Run("leaves other kinds unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "test"},
+			"data":       map[string]any{"key": "value"},
+		}}
+
+		g.Expect(SecretData(obj)).To(BeIdenticalTo(obj))
+		g.Expect(obj.Object["data"]).To(Equal(map[string]any{"key": "value"}))
+	})
+
+	t.Run("masks malformed data fields as a whole", func(t *testing.T) {
+		g := NewWithT(t)
+		obj := secret(nil, nil)
+		obj.Object["data"] = "not-a-map"
+		obj.Object["stringData"] = []any{"a", "b"}
+
+		masked := SecretData(obj)
+
+		g.Expect(masked.Object["data"]).To(Equal(Value))
+		g.Expect(masked.Object["stringData"]).To(Equal(Value))
+	})
+
+	t.Run("masks the last-applied annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		obj := secret(map[string]any{"password": "cGFzcw=="}, nil)
+		obj.SetAnnotations(map[string]string{
+			"kubectl.kubernetes.io/last-applied-configuration": `{"data":{"password":"cGFzcw=="}}`,
+			"app.kubernetes.io/managed-by":                     "timoni",
+		})
+
+		masked := SecretData(obj)
+
+		g.Expect(masked.GetAnnotations()).To(HaveKeyWithValue("kubectl.kubernetes.io/last-applied-configuration", Value))
+		g.Expect(masked.GetAnnotations()).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "timoni"))
+		g.Expect(obj.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]).To(ContainSubstring("cGFzcw=="))
+	})
+
+	t.Run("handles nil and empty secrets", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(SecretData(nil)).To(BeNil())
+		g.Expect(SecretData(secret(nil, nil)).Object).ToNot(HaveKey("data"))
+	})
+}


### PR DESCRIPTION
Add the `--mask-secrets` flag to `timoni build` and `timoni bundle build` that replaces the values of Kubernetes Secrets in the printed manifests with `***`. 

In the `apply --diff` output, the changed Secret values are shown as `*** (before)` and `*** (after)`.

This flag is intended for AI Agents and CI jobs to keep secrets out of the AI context and logs.