### PR TITLE
feat(oci): Resolve digests concurrently and add `--limit` to mod/artifact list

### DIFF
--- a/cmd/timoni/artifact_list.go
+++ b/cmd/timoni/artifact_list.go
@@ -35,12 +35,17 @@ var listArtifactCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"ls"},
 	Short:   "List the tags of an artifact",
-	Long:    `The list command prints a table with the artifact tags and their digests.`,
-	Example: `  # Print the tags and digests of an artifact
-  timoni artifact ls oci://docker.io/org/app 
+	Long: `The list command prints a table with the artifact tags and their digests.
+By default, the last 100 tags in descending lexical order are listed,
+use '--limit 0' to list all tags.`,
+	Example: `  # Print the last 100 tags and their digests
+  timoni artifact ls oci://docker.io/org/app
 
-  # Print the tags without digests
-  timoni artifact list oci://ghcr.io/org/bundles/app --with-digest=false
+  # Print the last 10 tags
+  timoni artifact list oci://docker.io/org/app --limit 10
+
+  # Print all the tags without digests
+  timoni artifact list oci://ghcr.io/org/bundles/app --limit 0 --with-digest=false
 
   # Print the tags matching a regular expression
   timoni artifact list oci://docker.io/org/app --filter-regex '^1\.'
@@ -53,7 +58,7 @@ var listArtifactCmd = &cobra.Command{
   timoni artifact list oci://docker.io/org/app
 
   # Check if a tag is published using the JSON output
-  timoni artifact list oci://ghcr.io/org/bundles/app -o json | \
+  timoni artifact list oci://ghcr.io/org/bundles/app --limit 0 -o json | \
 	jq -e --arg t "latest" 'any(.[]; .tag == $t)'
 `,
 	RunE: listArtifactCmdRun,
@@ -62,6 +67,7 @@ var listArtifactCmd = &cobra.Command{
 type listArtifactFlags struct {
 	creds        flags.Credentials
 	withDigest   bool
+	limit        int
 	output       string
 	filterRegex  string
 	filterSemver string
@@ -72,7 +78,9 @@ var listArtifactArgs listArtifactFlags
 func init() {
 	listArtifactCmd.Flags().Var(&listArtifactArgs.creds, listArtifactArgs.creds.Type(), listArtifactArgs.creds.Description())
 	listArtifactCmd.Flags().BoolVar(&listArtifactArgs.withDigest, "with-digest", true,
-		"Resolve the digest of each version.")
+		"Resolve the digest of each tag.")
+	listArtifactCmd.Flags().IntVar(&listArtifactArgs.limit, "limit", 100,
+		"Limit the number of tags listed in descending lexical order (0 for all).")
 	listArtifactCmd.Flags().StringVarP(&listArtifactArgs.output, "output", "o", "",
 		"The format in which the tags should be printed, can be 'yaml' or 'json'.")
 	listArtifactCmd.Flags().StringVar(&listArtifactArgs.filterRegex, "filter-regex", "",
@@ -92,6 +100,10 @@ func listArtifactCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if listArtifactArgs.limit < 0 {
+		return fmt.Errorf("--limit must be greater than or equal to 0")
+	}
+
 	spin := logger.StartSpinner("fetching tags")
 	defer spin.Stop()
 
@@ -99,16 +111,23 @@ func listArtifactCmdRun(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	opts := oci.Options(ctx, listArtifactArgs.creds.String(), rootArgs.registryInsecure)
-	list, err := oci.ListArtifactTags(ociURL, oci.ListArtifactOptions{
+	list, total, err := oci.ListArtifactTags(ctx, ociURL, oci.ListArtifactOptions{
 		WithDigest:   listArtifactArgs.withDigest,
 		FilterRegex:  listArtifactArgs.filterRegex,
 		FilterSemver: listArtifactArgs.filterSemver,
+		Limit:        listArtifactArgs.limit,
 	}, opts)
 	if err != nil {
 		return err
 	}
 
 	spin.Stop()
+
+	if listArtifactArgs.limit > 0 && total > listArtifactArgs.limit {
+		log := LoggerFrom(cmd.Context())
+		log.Info(fmt.Sprintf("showing %d of %d tags, use --limit 0 for all",
+			listArtifactArgs.limit, total))
+	}
 
 	if listArtifactArgs.output == "" {
 		var rows [][]string

--- a/cmd/timoni/artifact_list_test.go
+++ b/cmd/timoni/artifact_list_test.go
@@ -45,7 +45,7 @@ func Test_ListArtifact(t *testing.T) {
 		t.Helper()
 		g := NewWithT(t)
 
-		output, err := executeCommand(fmt.Sprintf("artifact ls oci://%s -o json %s", aURL, args))
+		output, _, err := executeCommandWithOutErr(fmt.Sprintf("artifact ls oci://%s -o json %s", aURL, args))
 		g.Expect(err).ToNot(HaveOccurred())
 
 		var list []apiv1.ArtifactReference
@@ -148,6 +148,35 @@ func Test_ListArtifact(t *testing.T) {
 		_, err := executeCommand(fmt.Sprintf("artifact ls oci://%s --filter-semver 'junk'", aURL))
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("invalid semver filter"))
+	})
+
+	t.Run("limits the tags", func(t *testing.T) {
+		g := NewWithT(t)
+		stdout, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"artifact ls oci://%s --limit 2 -o json",
+			aURL,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var list []apiv1.ArtifactReference
+		g.Expect(json.Unmarshal([]byte(stdout), &list)).To(Succeed())
+		var tags []string
+		for _, ref := range list {
+			tags = append(tags, ref.Tag)
+		}
+		g.Expect(tags).To(Equal([]string{"latest", "dev", "2.0.0"}))
+		g.Expect(stderr).To(ContainSubstring("showing 2 of 4 tags, use --limit 0 for all"))
+	})
+
+	t.Run("limits the filtered tags", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(listTags(t, "--filter-semver '>=1.0.0' --limit 1")).To(Equal([]string{"2.0.0"}))
+	})
+
+	t.Run("fails for negative limit", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand("artifact ls oci://registry.example.com/org/app --limit -1")
+		g.Expect(err).To(MatchError("--limit must be greater than or equal to 0"))
 	})
 
 	t.Run("fails for invalid output format", func(t *testing.T) {

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -114,16 +114,29 @@ func TestRestoreSignalHandlingAfterCancellation(t *testing.T) {
 }
 
 func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
+	buf := new(bytes.Buffer)
+	err := executeCommandWithStreams(cmd, in, buf, buf)
+	return buf.String(), err
+}
+
+// executeCommandWithOutErr runs the command and returns the stdout
+// and stderr streams separately, the logger writes to stderr.
+func executeCommandWithOutErr(cmd string) (string, string, error) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err := executeCommandWithStreams(cmd, nil, stdout, stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func executeCommandWithStreams(cmd string, in io.Reader, stdout, stderr io.Writer) error {
 	defer resetCmdArgs()
 	args, err := shellwords.Parse(cmd)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	buf := new(bytes.Buffer)
-
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
 	rootCmd.SetArgs(args)
 	// Always set the input stream so a reader injected by a previous
 	// test does not leak into commands that read stdin.
@@ -132,7 +145,7 @@ func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
 	}
 	rootCmd.SetIn(in)
 
-	zcfg := zerolog.ConsoleWriter{Out: buf, NoColor: true}
+	zcfg := zerolog.ConsoleWriter{Out: stderr, NoColor: true}
 	zcfg.PartsExclude = []string{
 		zerolog.TimestampFieldName,
 		zerolog.LevelFieldName,
@@ -142,9 +155,7 @@ func executeCommandWithIn(cmd string, in io.Reader) (string, error) {
 	runtimeLog.SetLogger(cliLogger)
 
 	_, err = rootCmd.ExecuteC()
-	result := buf.String()
-
-	return result, err
+	return err
 }
 
 func resetCmdArgs() {
@@ -160,8 +171,8 @@ func resetCmdArgs() {
 		name: "default",
 	}
 	listArgs = listFlags{}
-	listModArgs = listModFlags{withDigest: true}
-	listArtifactArgs = listArtifactFlags{withDigest: true}
+	listModArgs = listModFlags{withDigest: true, limit: 100}
+	listArtifactArgs = listArtifactFlags{withDigest: true, limit: 100}
 	pullModArgs = pullModFlags{}
 	pushModArgs = pushModFlags{}
 	buildModArgs = buildModFlags{format: "oci-archive"}

--- a/cmd/timoni/mod_list.go
+++ b/cmd/timoni/mod_list.go
@@ -35,19 +35,23 @@ var listModCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: []string{"ls"},
 	Short:   "List the versions of a module",
-	Long:    `The list command prints a table with the module versions and their digests.`,
-	Example: `  # Print the versions and digests of a module
-  timoni mod list oci://docker.io/org/app 
+	Long: `The list command prints a table with the module versions and their digests.
+By default, the newest 100 versions are listed, use '--limit 0' to list all versions.`,
+	Example: `  # Print the newest 100 versions and their digests
+  timoni mod list oci://docker.io/org/app
 
-  # Print the versions without digests
-  timoni mod list oci://docker.io/org/app --with-digest=false
+  # Print the newest 10 versions
+  timoni mod list oci://docker.io/org/app --limit 10
+
+  # Print all the versions without digests
+  timoni mod list oci://docker.io/org/app --limit 0 --with-digest=false
 
   # Print the versions of a module from GitHub Container Registry
   timoni mod list oci://ghcr.io/org/manifests/app \
 	--creds timoni:$GITHUB_TOKEN
 
   # Check if a version is published using the JSON output
-  timoni mod list oci://ghcr.io/org/modules/app -o json | \
+  timoni mod list oci://ghcr.io/org/modules/app --limit 0 -o json | \
 	jq -e --arg v "1.0.0" 'any(.[]; .version == $v)'
 `,
 	RunE: listModCmdRun,
@@ -56,6 +60,7 @@ var listModCmd = &cobra.Command{
 type listModFlags struct {
 	creds      flags.Credentials
 	withDigest bool
+	limit      int
 	output     string
 }
 
@@ -65,6 +70,8 @@ func init() {
 	listModCmd.Flags().Var(&listModArgs.creds, listModArgs.creds.Type(), listModArgs.creds.Description())
 	listModCmd.Flags().BoolVar(&listModArgs.withDigest, "with-digest", true,
 		"Resolve the digest of each version.")
+	listModCmd.Flags().IntVar(&listModArgs.limit, "limit", 100,
+		"Limit the number of versions listed, newest first (0 for all).")
 	listModCmd.Flags().StringVarP(&listModArgs.output, "output", "o", "",
 		"The format in which the versions should be printed, can be 'yaml' or 'json'.")
 	modCmd.AddCommand(listModCmd)
@@ -80,6 +87,10 @@ func listModCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if listModArgs.limit < 0 {
+		return fmt.Errorf("--limit must be greater than or equal to 0")
+	}
+
 	spin := logger.StartSpinner("fetching versions")
 	defer spin.Stop()
 
@@ -87,12 +98,21 @@ func listModCmdRun(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	opts := oci.Options(ctx, listModArgs.creds.String(), rootArgs.registryInsecure)
-	list, err := oci.ListModuleVersions(ociURL, listModArgs.withDigest, opts)
+	list, total, err := oci.ListModuleVersions(ctx, ociURL, oci.ListModuleOptions{
+		WithDigest: listModArgs.withDigest,
+		Limit:      listModArgs.limit,
+	}, opts)
 	if err != nil {
 		return err
 	}
 
 	spin.Stop()
+
+	if listModArgs.limit > 0 && total > listModArgs.limit {
+		log := LoggerFrom(cmd.Context())
+		log.Info(fmt.Sprintf("showing %d of %d versions, use --limit 0 for all",
+			listModArgs.limit, total))
+	}
 
 	if listModArgs.output == "" {
 		var rows [][]string

--- a/cmd/timoni/mod_list_test.go
+++ b/cmd/timoni/mod_list_test.go
@@ -101,6 +101,54 @@ func Test_ListMod(t *testing.T) {
 		}
 	})
 
+	t.Run("limits the versions", func(t *testing.T) {
+		g := NewWithT(t)
+		stdout, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"mod ls oci://%s --limit 2",
+			modURL,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(stdout).To(ContainSubstring(apiv1.LatestVersion))
+		g.Expect(stdout).To(ContainSubstring("2.0.0"))
+		g.Expect(stdout).To(ContainSubstring("1.1.0-rc.1"))
+		g.Expect(stdout).ToNot(ContainSubstring("1.0.0"))
+		g.Expect(stdout).ToNot(ContainSubstring("showing"))
+		g.Expect(stderr).To(ContainSubstring("showing 2 of 3 versions, use --limit 0 for all"))
+	})
+
+	t.Run("keeps the JSON output clean when limited", func(t *testing.T) {
+		g := NewWithT(t)
+		stdout, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"mod ls oci://%s --limit 1 -o json",
+			modURL,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var list []apiv1.ModuleReference
+		g.Expect(json.Unmarshal([]byte(stdout), &list)).To(Succeed())
+		g.Expect(list).To(HaveLen(2))
+		g.Expect(list[0].Version).To(Equal(apiv1.LatestVersion))
+		g.Expect(list[1].Version).To(Equal("2.0.0"))
+		g.Expect(stderr).To(ContainSubstring("showing 1 of 3 versions"))
+	})
+
+	t.Run("prints no notice when all versions fit", func(t *testing.T) {
+		g := NewWithT(t)
+		_, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"mod ls oci://%s --limit 0",
+			modURL,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stderr).ToNot(ContainSubstring("showing"))
+	})
+
+	t.Run("fails for negative limit", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand("mod ls oci://registry.example.com/org/module --limit -1")
+		g.Expect(err).To(MatchError("--limit must be greater than or equal to 0"))
+	})
+
 	t.Run("fails for invalid output format", func(t *testing.T) {
 		g := NewWithT(t)
 		_, err := executeCommand("mod ls oci://registry.example.com/org/module -o junk")

--- a/docs/ai-agents.mdx
+++ b/docs/ai-agents.mdx
@@ -6,14 +6,6 @@ description: "Equip AI coding agents with the Timoni skills and the docs MCP ser
 Timoni ships **agent skills** and a **documentation MCP server** so that AI coding agents
 can operate Timoni end-to-end: from authoring modules and bundles to orchestrating multi-cluster deployments.
 
-<Tip>
-**Evaluated with agents**
-
-The skills are evaluated by running agents against them with no other documentation,
-on realistic tasks that cover the full lifecycle: from discovering a module's config schema
-to previewing changes with a server-side diff, applying, checking status and cleaning up.
-</Tip>
-
 ## Agent skills
 
 Timoni publishes its skills following the [Agent Skills](https://agentskills.io) standard.
@@ -24,7 +16,7 @@ when a task calls for it.
 
 <Tabs sync={false}>
   <Tab title="skills CLI">
-    Install all the Timoni skills into any supported agent (Claude Code, Cursor, Codex, Copilot and others) with:
+    Install all the Timoni skills for supported agents (Claude Code, Cursor, Codex, Copilot and others) with:
 
     ```shell
     npx skills add https://timoni.sh
@@ -32,20 +24,9 @@ when a task calls for it.
 
     The command discovers the skills from the Timoni website and places them in the agent's skills directory.
   </Tab>
-  <Tab title="Claude Code">
-    Add a skill to a project so that it is shared with your team:
-
-    ```shell
-    mkdir -p .claude/skills/timoni
-    curl -sL https://timoni.sh/.well-known/agent-skills/timoni/SKILL.md \
-      -o .claude/skills/timoni/SKILL.md
-    ```
-
-    To make the skill available in all your projects, place it under `~/.claude/skills/timoni/SKILL.md` instead.
-  </Tab>
   <Tab title="Manual">
-    Download a skill file and place it in the skills directory of your agent,
-    in a sub-directory named after the skill:
+    Download the skill file into a directory named `timoni`,
+    inside your agent's skills directory:
 
     ```shell
     mkdir -p timoni
@@ -68,6 +49,14 @@ when a task calls for it.
 | Module authoring | Scaffold a module, define the config schema, template objects, vendor CRDs, add tests and health checks |
 | Distribution | Push, tag, sign and verify modules and bundles in container registries |
 | Safety | Preview with `--diff` and `--dry-run`, namespace scoping, and the apply, prune and wait semantics |
+
+<Tip>
+**Tested end-to-end**
+
+The skills are periodically evaluated by running agents against them with no other documentation,
+on realistic tasks that cover the full lifecycle: from discovering a module's config schema
+to previewing changes with a server-side diff, applying, checking status and cleaning up.
+</Tip>
 
 ## Docs MCP server
 
@@ -164,9 +153,3 @@ With the skills installed and the MCP server connected, agents can carry out tas
 - *Write a runtime for the `staging` and `production` kube contexts and apply the bundle to both, with two replicas in staging and three in production.*
 - *Scaffold a Timoni module for my web app with a typed config for the image, replicas and ingress host, vendor the cert-manager CRDs, and add a test job.*
 - *Upgrade all the instances in the `monitoring` namespace to the latest module versions and report their status.*
-
-<Tip>
-Agents operating Timoni follow the same safe workflow as humans: validate with `timoni mod vet` and `timoni bundle vet`,
-preview with `--diff` or `--dry-run`, apply, then confirm with `timoni status`.
-Scope an agent's cluster access with a dedicated kube context and namespace when trying it out.
-</Tip>

--- a/docs/cue/module/publishing.mdx
+++ b/docs/cue/module/publishing.mdx
@@ -187,7 +187,10 @@ Timoni offers a command for listing all the versions available in a
 container registry for a particular module.
 
 The `timoni mod list oci://<module-url>` prints a table with the versions order
-by semver and the OCI digest corresponding to each version.
+by semver and the OCI digest corresponding to each version. The newest 100 versions
+are listed by default, use `--limit 0` to list all of them or `--limit <n>` to
+change the number of versions shown. Pass `--with-digest=false` to skip the
+digest lookups when only the version list is needed.
 
 Example:
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Timoni"
+title: "Package Manager for Kubernetes"
 description: "Distribution and lifecycle management for cloud-native applications, powered by CUE."
 mode: "custom"
 ---
@@ -30,15 +30,13 @@ mode: "custom"
           </a>
         </div>
       </div>
-      <div className="flex justify-center lg:justify-end">
-        <div className="tm-gradient rounded-2xl p-10 shadow-xl lg:p-12">
-          <img
-            src="/images/logo_icons.svg"
-            alt="Timoni"
-            className="w-56 max-w-full lg:w-72"
-            noZoom
-          />
-        </div>
+      <div className="hidden lg:flex lg:justify-end">
+        <img
+          src="/images/logo_icons.svg"
+          alt="Timoni"
+          className="tm-hero-logo w-64 max-w-full lg:w-80"
+          noZoom
+        />
       </div>
     </div>
   </section>
@@ -162,7 +160,7 @@ mode: "custom"
               <span className="tm-check">
                 <Icon icon="check" />
               </span>
-              <span>Skills evaluated by running agents through the full deployment lifecycle.</span>
+              <span>Skills tested end-to-end with various LLMs.</span>
             </li>
             <li className="flex gap-3">
               <span className="tm-check">
@@ -188,7 +186,7 @@ mode: "custom"
         </div>
         <CardGroup cols={1}>
           <Card title="Agent skills" icon="wand-magic-sparkles" href="/ai-agents#agent-skills" horizontal>
-            Install the Timoni skills into any agent with: <span className="block mt-1"><code>{"npx skills add https://timoni.sh"}</code></span>
+            Install the Timoni skills for any agent with: <span className="block mt-1"><code>{"npx skills add https://timoni.sh"}</code></span>
           </Card>
           <Card title="Docs MCP server" icon="plug" href="/ai-agents#docs-mcp-server" horizontal>
             Connect your agent to grep and fetch the docs: <span className="block mt-1"><code>{"https://timoni.sh/mcp"}</code></span>
@@ -286,7 +284,7 @@ mode: "custom"
         </div>
       </div>
       <div className="tm-footer-bottom mt-10 flex flex-wrap items-center justify-between gap-4 pt-6 text-sm text-gray-500 dark:text-gray-400">
-        <span>Copyright 2026 Stefan Prodan. Released under the Apache 2.0 license.</span>
+        <span>Copyright © 2026 <a href="https://stefanprodan.com">Stefan Prodan</a></span>
         <span className="tm-footer-socials">
           <a href="https://github.com/stefanprodan/timoni" aria-label="GitHub"><Icon icon="github" iconType="brands" /></a>
           <a href="https://cloud-native.slack.com/team/ULPRMFH38" aria-label="Slack"><Icon icon="slack" iconType="brands" /></a>

--- a/docs/style.css
+++ b/docs/style.css
@@ -202,8 +202,9 @@ html.dark #navbar .navbar-link > a:hover > svg {
   height: 30px;
 }
 
-/* Brand icons on the landing page cards: paint the local SVGs with the primary color, like the built-in icons. */
-[data-component-part="card-icon"] img[src^="/images/icons/"] {
+/* Brand icons on the landing page cards: paint the local SVGs with the primary color, like the built-in icons.
+   The src is matched by substring, the hosted site serves the icons from an absolute CDN URL. */
+[data-component-part="card-icon"] img[src*="/images/icons/"] {
   object-fit: none;
   object-position: -9999px -9999px;
   background-color: rgb(var(--primary));
@@ -212,22 +213,37 @@ html.dark #navbar .navbar-link > a:hover > svg {
   mask-size: contain;
 }
 
-html.dark [data-component-part="card-icon"] img[src^="/images/icons/"] {
+html.dark [data-component-part="card-icon"] img[src*="/images/icons/"] {
   background-color: rgb(var(--primary-light));
 }
 
-[data-component-part="card-icon"] img[src="/images/icons/kubernetes.svg"] {
+[data-component-part="card-icon"] img[src*="/images/icons/kubernetes.svg"] {
   mask-image: url("/images/icons/kubernetes.svg");
 }
 
-[data-component-part="card-icon"] img[src="/images/icons/helm.svg"] {
+[data-component-part="card-icon"] img[src*="/images/icons/helm.svg"] {
   mask-image: url("/images/icons/helm.svg");
 }
 
-[data-component-part="card-icon"] img[src="/images/icons/cue.svg"] {
+[data-component-part="card-icon"] img[src*="/images/icons/cue.svg"] {
   mask-image: url("/images/icons/cue.svg");
 }
 
-[data-component-part="card-icon"] img[src="/images/icons/flux.svg"] {
+[data-component-part="card-icon"] img[src*="/images/icons/flux.svg"] {
   mask-image: url("/images/icons/flux.svg");
+}
+
+/* Hero logo: paint the single-color SVG to match the theme, black on light and white on dark. */
+img.tm-hero-logo {
+  object-fit: none;
+  object-position: -9999px -9999px;
+  background-color: #111827;
+  mask-image: url("/images/logo_icons.svg");
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+}
+
+html.dark img.tm-hero-logo {
+  background-color: #fff;
 }

--- a/internal/oci/artifact_test.go
+++ b/internal/oci/artifact_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -51,7 +52,7 @@ func TestArtifactOperations(t *testing.T) {
 	err = TagArtifact(digestURL, apiv1.LatestVersion, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	list, err := ListArtifactTags(imgURL, ListArtifactOptions{WithDigest: true}, opts)
+	list, _, err := ListArtifactTags(ctx, imgURL, ListArtifactOptions{WithDigest: true}, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(list)).To(BeEquivalentTo(2))
 	g.Expect(list[0].Tag).To(BeEquivalentTo(apiv1.LatestVersion))
@@ -84,4 +85,70 @@ func TestArtifactOperations(t *testing.T) {
 
 	err = PullArtifact(imgVersionURL, dstPath, apiv1.AnyContentType, opts)
 	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestListArtifactTags(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	srcPath := "testdata/module/"
+	imgURL := fmt.Sprintf("oci://%s/%s", dockerRegistry, rnd("my-artifact", 5))
+	opts := Options(ctx, "", false)
+
+	tags := []string{"1.0.0", "1.1.0", "2.0.0", "dev", "stable"}
+	digests := map[string]string{}
+	for _, tag := range tags {
+		digestURL, err := PushArtifact(fmt.Sprintf("%s:%s", imgURL, tag), srcPath, nil, "generic", map[string]string{}, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+		digests[tag] = digestURL[strings.LastIndex(digestURL, "@")+1:]
+	}
+	g.Expect(TagArtifact(fmt.Sprintf("%s:%s", imgURL, "2.0.0"), apiv1.LatestVersion, opts)).To(Succeed())
+
+	// descending lexical order
+	expected := []string{"stable", "dev", "2.0.0", "1.1.0", "1.0.0"}
+
+	t.Run("lists all tags with digests", func(t *testing.T) {
+		g := NewWithT(t)
+		list, total, err := ListArtifactTags(ctx, imgURL, ListArtifactOptions{WithDigest: true}, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(total).To(Equal(len(tags)))
+		g.Expect(list).To(HaveLen(len(tags) + 1))
+		g.Expect(list[0].Tag).To(Equal(apiv1.LatestVersion))
+		for i, tag := range expected {
+			g.Expect(list[i+1].Tag).To(Equal(tag))
+			g.Expect(list[i+1].Digest).To(Equal(digests[tag]))
+		}
+	})
+
+	t.Run("limits the tags", func(t *testing.T) {
+		g := NewWithT(t)
+		list, total, err := ListArtifactTags(ctx, imgURL, ListArtifactOptions{WithDigest: true, Limit: 2}, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(total).To(Equal(len(tags)))
+		g.Expect(list).To(HaveLen(3))
+		g.Expect(list[0].Tag).To(Equal(apiv1.LatestVersion))
+		g.Expect(list[1].Tag).To(Equal("stable"))
+		g.Expect(list[2].Tag).To(Equal("dev"))
+	})
+
+	t.Run("limits the filtered tags", func(t *testing.T) {
+		g := NewWithT(t)
+		list, total, err := ListArtifactTags(ctx, imgURL, ListArtifactOptions{FilterSemver: ">=1.0.0", Limit: 2}, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(total).To(Equal(3))
+		g.Expect(list).To(HaveLen(2))
+		g.Expect(list[0].Tag).To(Equal("2.0.0"))
+		g.Expect(list[0].Digest).To(BeEmpty())
+		g.Expect(list[1].Tag).To(Equal("1.1.0"))
+	})
+
+	t.Run("propagates digest errors", func(t *testing.T) {
+		g := NewWithT(t)
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+
+		_, _, err := ListArtifactTags(cancelled, imgURL, ListArtifactOptions{WithDigest: true}, opts)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to get digest for"))
+	})
 }

--- a/internal/oci/list_artifact.go
+++ b/internal/oci/list_artifact.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oci
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"sort"
@@ -41,25 +42,32 @@ type ListArtifactOptions struct {
 	// FilterSemver is a semantic version range used to filter the tags,
 	// all tags are returned if empty.
 	FilterSemver string
+
+	// Limit caps the number of tags returned in descending lexical order,
+	// all tags are returned if 0. The latest tag, when present,
+	// is always included and does not count towards the limit.
+	Limit int
 }
 
 // ListArtifactTags performs the following operations:
-// - fetches the digest of the latest tag (if it exists)
-// - lists all the tags from the artifact repository
-// - filters the tags based on the regex and semver expressions (if configured to do so)
-// - fetches the digest of each tag (if configured to do so)
-// - returns an array of ArtifactReference objects
-func ListArtifactTags(ociURL string, listOpts ListArtifactOptions, opts []crane.Option) ([]apiv1.ArtifactReference, error) {
+//   - fetches the digest of the latest tag (if it exists)
+//   - lists all the tags from the artifact repository
+//   - filters the tags based on the regex and semver expressions (if configured to do so)
+//   - truncates the tags to the configured limit
+//   - fetches the digest of each tag concurrently (if configured to do so)
+//   - returns an array of ArtifactReference objects along with the total
+//     number of tags found before the limit was applied (excluding latest)
+func ListArtifactTags(ctx context.Context, ociURL string, listOpts ListArtifactOptions, opts []crane.Option) ([]apiv1.ArtifactReference, int, error) {
 	var list []apiv1.ArtifactReference
 
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	filter, err := newTagFilter(listOpts.FilterRegex, listOpts.FilterSemver)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	withDigest := listOpts.WithDigest
@@ -80,31 +88,38 @@ func ListArtifactTags(ociURL string, listOpts ListArtifactOptions, opts []crane.
 
 	tags, err := crane.ListTags(repoURL, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("listing tags failed: %w", err)
+		return nil, 0, fmt.Errorf("listing tags failed: %w", err)
 	}
 
 	sort.Slice(tags, func(i, j int) bool { return tags[i] > tags[j] })
 
+	filtered := make([]string, 0, len(tags))
 	for _, tag := range tags {
 		if tag == name.DefaultTag || !filter.matches(tag) {
 			continue
 		}
-		digest := ""
-		if withDigest {
-			d, err := crane.Digest(fmt.Sprintf("%s:%s", repoURL, tag), opts...)
-			if err != nil {
-				return nil, fmt.Errorf("faild to get digest for '%s': %w", tag, err)
-			}
-			digest = d
+		filtered = append(filtered, tag)
+	}
+	total := len(filtered)
+	tags = limitTags(filtered, listOpts.Limit)
+
+	digests := make([]string, len(tags))
+	if withDigest {
+		digests, err = resolveDigests(ctx, repoURL, tags, opts)
+		if err != nil {
+			return nil, 0, err
 		}
+	}
+
+	for i, tag := range tags {
 		list = append(list, apiv1.ArtifactReference{
 			Repository: ociURL,
 			Tag:        tag,
-			Digest:     digest,
+			Digest:     digests[i],
 		})
 	}
 
-	return list, nil
+	return list, total, nil
 }
 
 // tagFilter filters OCI tags by regular expression and semantic version range.

--- a/internal/oci/list_digests.go
+++ b/internal/oci/list_digests.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"golang.org/x/sync/errgroup"
+)
+
+// digestConcurrency is the maximum number of digest requests
+// issued in parallel when listing tags.
+const digestConcurrency = 8
+
+// resolveDigests fetches the manifest digest of each tag concurrently
+// and returns the digests in the same order as the tags.
+// The first failure cancels the pending requests and is returned
+// with the tag that caused it.
+func resolveDigests(ctx context.Context, repoURL string, tags []string, opts []crane.Option) ([]string, error) {
+	digests := make([]string, len(tags))
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(digestConcurrency)
+	opts = append(append([]crane.Option{}, opts...), crane.WithContext(ctx))
+
+	for i, tag := range tags {
+		g.Go(func() error {
+			d, err := crane.Digest(fmt.Sprintf("%s:%s", repoURL, tag), opts...)
+			if err != nil {
+				return fmt.Errorf("failed to get digest for '%s': %w", tag, err)
+			}
+			digests[i] = d
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return digests, nil
+}
+
+// limitTags returns the first limit tags, or all tags when limit is 0.
+func limitTags(tags []string, limit int) []string {
+	if limit > 0 && len(tags) > limit {
+		return tags[:limit]
+	}
+	return tags
+}

--- a/internal/oci/list_module.go
+++ b/internal/oci/list_module.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oci
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -27,25 +28,40 @@ import (
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
 
+// ListModuleOptions holds the options for listing the versions
+// of a module repository.
+type ListModuleOptions struct {
+	// WithDigest enables the resolving of the digest for each version.
+	WithDigest bool
+
+	// Limit caps the number of versions returned, newest first,
+	// all versions are returned if 0. The latest tag, when present,
+	// is always included and does not count towards the limit.
+	Limit int
+}
+
 // ListModuleVersions performs the following operations:
-// - lists all the tags from to this module repository
-// - filters and orders the tags based on semver
-// - fetches the digest of the latest version
-// - fetches the digest of each version (if configured to do so)
-// - returns an array of ModuleReference objects
-func ListModuleVersions(ociURL string, withDigest bool, opts []crane.Option) ([]apiv1.ModuleReference, error) {
+//   - lists all the tags from to this module repository
+//   - filters and orders the tags based on semver
+//   - truncates the versions to the configured limit
+//   - fetches the digest of the latest version
+//   - fetches the digest of each version concurrently (if configured to do so)
+//   - returns an array of ModuleReference objects along with the total
+//     number of versions found before the limit was applied (excluding latest)
+func ListModuleVersions(ctx context.Context, ociURL string, listOpts ListModuleOptions, opts []crane.Option) ([]apiv1.ModuleReference, int, error) {
 	var list []apiv1.ModuleReference
+	withDigest := listOpts.WithDigest
 
 	ref, err := parseArtifactRef(ociURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	repoURL := ref.Context().Name()
 
 	tags, err := crane.ListTags(repoURL, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("listing tags failed: %w", err)
+		return nil, 0, fmt.Errorf("listing tags failed: %w", err)
 	}
 
 	var versions []*semver.Version
@@ -58,6 +74,13 @@ func ListModuleVersions(ociURL string, withDigest bool, opts []crane.Option) ([]
 	}
 	sort.Sort(sort.Reverse(semver.Collection(versions)))
 
+	tags = make([]string, 0, len(versions))
+	for _, v := range versions {
+		tags = append(tags, v.String())
+	}
+	total := len(tags)
+	tags = limitTags(tags, listOpts.Limit)
+
 	if digest, err := crane.Digest(fmt.Sprintf("%s:%s", repoURL, name.DefaultTag), opts...); err == nil {
 		if !withDigest {
 			digest = ""
@@ -69,22 +92,21 @@ func ListModuleVersions(ociURL string, withDigest bool, opts []crane.Option) ([]
 		})
 	}
 
-	for _, v := range versions {
-		digest := ""
-		if withDigest {
-			d, err := crane.Digest(fmt.Sprintf("%s:%s", repoURL, v.String()), opts...)
-			if err != nil {
-				return nil, fmt.Errorf("faild to get digest for '%s': %w", v.String(), err)
-			}
-			digest = d
+	digests := make([]string, len(tags))
+	if withDigest {
+		digests, err = resolveDigests(ctx, repoURL, tags, opts)
+		if err != nil {
+			return nil, 0, err
 		}
-		list = append(list, apiv1.ModuleReference{
-			Repository: ociURL,
-			Version:    v.String(),
-			Digest:     digest,
-		})
-
 	}
 
-	return list, nil
+	for i, tag := range tags {
+		list = append(list, apiv1.ModuleReference{
+			Repository: ociURL,
+			Version:    tag,
+			Digest:     digests[i],
+		})
+	}
+
+	return list, total, nil
 }

--- a/internal/oci/module_test.go
+++ b/internal/oci/module_test.go
@@ -55,7 +55,7 @@ func TestModuleOperations(t *testing.T) {
 	err = TagArtifact(digestURL, apiv1.LatestVersion, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	list, err := ListModuleVersions(imgURL, true, opts)
+	list, _, err := ListModuleVersions(ctx, imgURL, ListModuleOptions{WithDigest: true}, opts)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(list)).To(BeEquivalentTo(2))
 	g.Expect(list[0].Version).To(BeEquivalentTo(apiv1.LatestVersion))
@@ -157,4 +157,94 @@ func TestWriteCachedLayer(t *testing.T) {
 	contents, err := os.ReadFile(cachedLayer)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(contents).To(Equal([]byte("layer")))
+}
+
+func TestListModuleVersions(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	srcPath := "testdata/module/"
+	imgURL := fmt.Sprintf("oci://%s/%s", dockerRegistry, rnd("my-module", 5))
+	opts := Options(ctx, "", false)
+
+	const count = 25
+	versions := make([]string, 0, count)
+	digests := map[string]string{}
+	for i := range count {
+		v := fmt.Sprintf("1.0.%d", i)
+		annotations := map[string]string{apiv1.VersionAnnotation: v}
+		digestURL, err := PushModule(fmt.Sprintf("%s:%s", imgURL, v), srcPath, nil, annotations, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+		versions = append(versions, v)
+		digests[v] = digestURL[strings.LastIndex(digestURL, "@")+1:]
+	}
+	g.Expect(TagArtifact(fmt.Sprintf("%s:%s", imgURL, versions[count-1]), apiv1.LatestVersion, opts)).To(Succeed())
+
+	// newest first
+	expected := make([]string, 0, count)
+	for i := count - 1; i >= 0; i-- {
+		expected = append(expected, versions[i])
+	}
+
+	t.Run("lists all versions with digests", func(t *testing.T) {
+		g := NewWithT(t)
+		list, total, err := ListModuleVersions(ctx, imgURL, ListModuleOptions{WithDigest: true}, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(total).To(Equal(count))
+		g.Expect(list).To(HaveLen(count + 1))
+		g.Expect(list[0].Version).To(Equal(apiv1.LatestVersion))
+		g.Expect(list[0].Digest).To(Equal(digests[versions[count-1]]))
+		for i, v := range expected {
+			g.Expect(list[i+1].Version).To(Equal(v))
+			g.Expect(list[i+1].Digest).To(Equal(digests[v]))
+			g.Expect(list[i+1].Repository).To(Equal(imgURL))
+		}
+	})
+
+	t.Run("limits to the newest versions", func(t *testing.T) {
+		g := NewWithT(t)
+		list, total, err := ListModuleVersions(ctx, imgURL, ListModuleOptions{WithDigest: true, Limit: 10}, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(total).To(Equal(count))
+		g.Expect(list).To(HaveLen(11))
+		g.Expect(list[0].Version).To(Equal(apiv1.LatestVersion))
+		for i, v := range expected[:10] {
+			g.Expect(list[i+1].Version).To(Equal(v))
+			g.Expect(list[i+1].Digest).To(Equal(digests[v]))
+		}
+	})
+
+	t.Run("limits without digests", func(t *testing.T) {
+		g := NewWithT(t)
+		list, total, err := ListModuleVersions(ctx, imgURL, ListModuleOptions{Limit: 3}, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(total).To(Equal(count))
+		g.Expect(list).To(HaveLen(4))
+		for _, ref := range list {
+			g.Expect(ref.Digest).To(BeEmpty())
+		}
+	})
+
+	t.Run("ignores non-semver tags", func(t *testing.T) {
+		g := NewWithT(t)
+		otherURL := fmt.Sprintf("oci://%s/%s", dockerRegistry, rnd("my-module", 5))
+		_, err := PushModule(fmt.Sprintf("%s:%s", otherURL, "dev"), srcPath, nil, map[string]string{}, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		list, total, err := ListModuleVersions(ctx, otherURL, ListModuleOptions{WithDigest: true, Limit: 10}, opts)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(total).To(BeZero())
+		g.Expect(list).To(BeEmpty())
+	})
+
+	t.Run("propagates digest errors", func(t *testing.T) {
+		g := NewWithT(t)
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+
+		list, _, err := ListModuleVersions(cancelled, imgURL, ListModuleOptions{WithDigest: true}, opts)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(MatchRegexp(`failed to get digest for '1\.0\.\d+'`))
+		g.Expect(list).To(BeNil())
+	})
 }

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -81,7 +81,7 @@ below.
 | Task | Command |
 |------|---------|
 | Log in to a registry | `echo $TOKEN \| timoni registry login ghcr.io -u <user> --password-stdin` |
-| List published versions | `timoni mod list oci://<repo>` |
+| List published versions | `timoni mod list oci://<repo>` (newest 100; `--limit 0` for all, `--with-digest=false` to skip digests) |
 | Pull a module to disk | `timoni mod pull oci://<repo> -v <version> -o ./module` |
 | Verify signature on pull | `... mod pull ... --verify=cosign --cosign-key=cosign.pub`, or keyless: `--verify=cosign --certificate-identity-regexp=<re> --certificate-oidc-issuer=<url>` |
 | Create a module | `timoni mod init <name> --blueprint oci://ghcr.io/stefanprodan/timoni/blueprints/starter` |


### PR DESCRIPTION
Speed up `timoni mod list` and `timoni artifact list` by resolving digests  concurrently (8 goroutines).

The newest 100 versions are listed by default, pass `--limit=0` for all.
