### PR TITLE
feat(blueprint): container images ref standard 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ cue-vet: build ## Vet and fmt CUE files.
 	./bin/timoni mod vet ./internal/engine/fetcher/testdata/module
 	./bin/timoni fmt ./internal/engine/testdata/module-values
 
-REDIS_VER=$(shell grep 'tag:' examples/redis/values.cue | awk '{ print $$2 }' | tr -d '"' | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+REDIS_VER=$(shell grep 'tag:' examples/redis/images.cue | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
 push-redis: build
 	./bin/timoni mod push ./examples/redis oci://ghcr.io/stefanprodan/modules/redis -v $(REDIS_VER) --latest --resolve-symlinks \
 		-a 'org.opencontainers.image.source=https://github.com/stefanprodan/timoni/tree/main/examples/redis'  \

--- a/blueprints/starter/images.cue
+++ b/blueprints/starter/images.cue
@@ -1,0 +1,10 @@
+package main
+
+// The container images tracked from the upstream releases.
+values: {
+	image: {
+		repository: *"docker.io/nginxinc/nginx-unprivileged" | string
+		tag:        *"1-alpine" | string
+		digest:     *"" | string
+	}
+}

--- a/blueprints/starter/templates/config.cue
+++ b/blueprints/starter/templates/config.cue
@@ -38,11 +38,8 @@ import (
 
 	// The image allows setting the container image repository,
 	// tag, digest and pull policy.
-	image: timoniv1.#Image & {
-		repository: *"docker.io/nginxinc/nginx-unprivileged" | string
-		tag:        *"1-alpine" | string
-		digest:     *"" | string
-	}
+	// The default image repository, tag and digest are set in `images.cue`.
+	image!: timoniv1.#Image
 
 	// The securityContextPreset selects how the workload identity defaults
 	// are applied. The `hardened` preset pins the UID/GID the container

--- a/docs/bundle.mdx
+++ b/docs/bundle.mdx
@@ -23,7 +23,7 @@ bundle: {
 		redis: {
 			module: {
 				url:     "oci://ghcr.io/stefanprodan/modules/redis"
-				version: "8.10.0"
+				version: "8.10.1"
 			}
 			namespace: "podinfo"
 			values: maxmemory: 256
@@ -69,8 +69,8 @@ Apply the Bundle on the cluster:
   <Tab title="output">
       ```text
       applying instance redis
-      pulling oci://ghcr.io/stefanprodan/modules/redis:8.10.0
-      using module timoni.sh/redis version 8.10.0
+      pulling oci://ghcr.io/stefanprodan/modules/redis:8.10.1
+      using module timoni.sh/redis version 8.10.1
       installing redis in namespace podinfo
       Namespace/podinfo created
       applying master
@@ -116,7 +116,7 @@ Build the Bundle and print the resulting Kubernetes resources for all the Bundle
       metadata:
         labels:
           app.kubernetes.io/part-of: redis
-          app.kubernetes.io/version: 8.10.0
+          app.kubernetes.io/version: 8.10.1
         name: redis
         namespace: podinfo
       ---
@@ -149,7 +149,7 @@ List the managed resources from a bundle and their rollout status:
   <Tab title="output">
      ```text
      last applied 2024-03-03T20:21:19Z
-     module oci://ghcr.io/stefanprodan/modules/redis:8.10.0
+     module oci://ghcr.io/stefanprodan/modules/redis:8.10.1
      digest: sha256:4f377b66fd6d608f6a347bbef5b4fcd1aaff3dfa253b1c8437ae8e11fa08b70a
      ServiceAccount/podinfo/redis Current Resource is current
      ConfigMap/podinfo/redis Current Resource is always ready
@@ -181,7 +181,7 @@ List the instances in Bundle `podinfo` across all namespaces:
      ```text
      NAME    NAMESPACE         MODULE                                          VERSION LAST APPLIED          BUNDLE
      podinfo podinfo           oci://ghcr.io/stefanprodan/modules/podinfo      6.14.0   2024-03-03T16:20:07Z  podinfo
-     redis   podinfo           oci://ghcr.io/stefanprodan/modules/redis        8.10.0   2024-03-03T16:20:00Z  podinfo
+     redis   podinfo           oci://ghcr.io/stefanprodan/modules/redis        8.10.1   2024-03-03T16:20:00Z  podinfo
      ```
   </Tab>
 </Tabs>

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -99,7 +99,7 @@ bundle: {
 		redis: {
 			module: {
 				url:     "oci://ghcr.io/stefanprodan/modules/redis"
-				version: "8.10.0"
+				version: "8.10.1"
 			}
 			namespace: "podinfo"
 			values: maxmemory: 256

--- a/docs/cue/module/initialization.mdx
+++ b/docs/cue/module/initialization.mdx
@@ -37,6 +37,7 @@ myapp
 │   ├── config.cue # Config schema and default values
 │   ├── deployment.cue # Kubernetes Deployment template
 │   └── service.cue # Kubernetes Service template
+├── images.cue # Container images defaults
 ├── timoni.cue # Timoni entry point
 ├── timoni.ignore # Timoni ignore rules
 ├── values.cue # Timoni values placeholder 
@@ -419,6 +420,38 @@ if #config.service.annotations != _|_ {
 
 Besides mapping the config fields to the Kubernetes object fields, we can also
 set fixed values, like the port `protocol` and `name` fields.
+
+### Container images
+
+The `images.cue` file from the module root holds the default
+repository, tag and digest of the container images used by the module:
+
+```cue
+package main
+
+// The container images tracked from the upstream releases.
+values: {
+	image: {
+		repository: *"docker.io/nginxinc/nginx-unprivileged" | string
+		tag:        *"1-alpine" | string
+		digest:     *"" | string
+	}
+}
+
+```
+
+The `image` field is declared as required in the `#Config` definition,
+and its default values come from `images.cue`:
+
+```cue
+#Config: {
+	image!: timoniv1.#Image
+}
+
+```
+
+Users can override the image repository, tag or digest with their own values.
+To update the images to a new version, edit the defaults in `images.cue`.
 
 ## Extend the module config
 

--- a/docs/module.mdx
+++ b/docs/module.mdx
@@ -35,6 +35,7 @@ Example of a module's root directory:
 │   ├── config.cue # Config schema and default values
 │   ├── deployment.cue # Kubernetes Deployment template
 │   └── service.cue # Kubernetes Service template
+├── images.cue # Container images defaults
 ├── timoni.cue # Timoni entry point
 ├── timoni.ignore # Timoni ignore rules
 ├── values.cue # Timoni values placeholder 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -221,7 +221,7 @@ bundle: {
 		redis: {
 			module: {
 				url:     "oci://ghcr.io/stefanprodan/modules/redis"
-				version: "8.10.0"
+				version: "8.10.1"
 			}
 			namespace: "podinfo"
 			values: maxmemory: 256

--- a/examples/bundles/podinfo.cue
+++ b/examples/bundles/podinfo.cue
@@ -10,8 +10,8 @@ bundle: {
 		redis: {
 			module: {
 				url:     "oci://ghcr.io/stefanprodan/modules/redis"
-				version: "8.10.0"
-				digest:  "sha256:c9b8cb8410dadca29cd64732f51c84432a210216e01866e1f112c7ffd531cd65"
+				version: "8.10.1"
+				digest:  "sha256:7f24e8f7e49132c90789464dcf5b82eb137e378c97735eec36efbe0d1caeb872"
 			}
 			namespace: "podinfo"
 			values: {

--- a/examples/minimal/images.cue
+++ b/examples/minimal/images.cue
@@ -1,0 +1,15 @@
+package main
+
+// The container images tracked from the upstream releases.
+values: {
+	image: {
+		repository: *"docker.io/nginx" | string
+		tag:        *"1.31.4-alpine" | string
+		digest:     *"sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913" | string
+	}
+	test: image: {
+		repository: *"docker.io/curlimages/curl" | string
+		tag:        *"8.21.0" | string
+		digest:     *"sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13" | string
+	}
+}

--- a/examples/minimal/templates/config.cue
+++ b/examples/minimal/templates/config.cue
@@ -38,7 +38,7 @@ import (
 
 	// The image allows setting the container image repository,
 	// tag, digest and pull policy.
-	// The default image repository and tag is set in `values.cue`.
+	// The default image repository, tag and digest are set in `images.cue`.
 	image!: timoniv1.#Image
 
 	// The resources allows setting the container resource requirements.
@@ -94,6 +94,7 @@ import (
 	}
 
 	// Test Job disabled by default.
+	// The test image defaults are set in `images.cue`.
 	test: {
 		enabled: *false | bool
 		image!:  timoniv1.#Image

--- a/examples/minimal/values.cue
+++ b/examples/minimal/values.cue
@@ -8,14 +8,4 @@ package main
 // Defaults
 values: {
 	message: "Hello World"
-	image: {
-		repository: "docker.io/nginx"
-		digest:     "sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752"
-		tag:        "1.31.3-alpine"
-	}
-	test: image: {
-		repository: "docker.io/curlimages/curl"
-		digest:     "sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13"
-		tag:        "8.21.0"
-	}
 }

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -33,7 +33,7 @@ The Redis cluster can be accessed using the following Kubernetes Services:
 To install a specific module version:
 
 ```shell
-timoni -n default apply redis oci://ghcr.io/stefanprodan/modules/redis -v 8.10.0
+timoni -n default apply redis oci://ghcr.io/stefanprodan/modules/redis -v 8.10.1
 ```
 
 To change the [default configuration](#configuration),

--- a/examples/redis/images.cue
+++ b/examples/redis/images.cue
@@ -1,0 +1,10 @@
+package main
+
+// The container images tracked from the upstream releases.
+values: {
+	image: {
+		repository: *"docker.io/redis" | string
+		tag:        *"8.10.1-alpine" | string
+		digest:     *"sha256:becdda6c7f4b3fb42e42fd7f120bbf5c54c4caaaf16f26da24e4563d2c1f0576" | string
+	}
+}

--- a/examples/redis/templates/config/config.cue
+++ b/examples/redis/templates/config/config.cue
@@ -41,8 +41,10 @@ import (
 	}
 	password?: string & =~"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
 
-	// Container image
-	image: timoniv1.#Image
+	// The image allows setting the container image repository,
+	// tag, digest and pull policy.
+	// The default image repository, tag and digest are set in `images.cue`.
+	image!: timoniv1.#Image
 	imagePullSecrets?: [...corev1.LocalObjectReference]
 
 	// Resource requirements

--- a/examples/redis/values.cue
+++ b/examples/redis/values.cue
@@ -2,10 +2,4 @@
 
 package main
 
-values: {
-	image: {
-		repository: "docker.io/redis"
-		tag:        "8.10.0-alpine"
-		digest:     "sha256:978f0e01593e65eed801f2402944efcd936d43b5027e4908a7897baf88ed6241"
-	}
-}
+values: {}

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -279,6 +279,7 @@ myapp/
 │   ├── config.cue     # #Config schema with defaults, #Instance
 │   ├── deployment.cue # #Deployment: {#config: #Config, ...}
 │   └── service.cue
+├── images.cue         # container images defaults (repository, tag, digest)
 ├── timoni.cue         # entry point: values, timoni.instance, timoni.apply
 ├── timoni.ignore      # files excluded from mod push
 ├── values.cue         # placeholder for user values

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -130,7 +130,7 @@ bundle: {
 		redis: {
 			module: {
 				url:     "oci://ghcr.io/stefanprodan/modules/redis"
-				version: "8.10.0"
+				version: "8.10.1"
 			}
 			namespace: "podinfo"
 			values: maxmemory: 256


### PR DESCRIPTION
This RP introduces a new standard for how to set default values for container images referenced by modules.  

The `images.cue` file from the module root holds the default repository, tag and digest of the container images used by the module:

```cue
package main

// The container images tracked from the upstream releases.
values: {
	image: {
		repository: *"docker.io/nginx" | string
		tag:        *"1.31.4-alpine" | string
		digest:     *"sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913" | string
	}
	test: image: {
		repository: *"docker.io/curlimages/curl" | string
		tag:        *"8.21.0" | string
		digest:     *"sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13" | string
	}
}
```

The `image` field is declared as required in the `#Config` definition, and its default values come from `images.cue`:

```cue
#Config: {
	image!: timoniv1.#Image
}
```

Users can override the image repository, tag or digest with their own values.
Module authors update the images to a new version, edit the defaults in `images.cue`.