### PR TITLE
feat(cli): exit 1 when applying with `--diff` to signal drift 

### DIFF
--- a/cmd/timoni/apply.go
+++ b/cmd/timoni/apply.go
@@ -85,7 +85,13 @@ The apply command performs the following steps:
   --values ./values-1.yaml \
   --values ./values-2.json
 `,
-	RunE: runApplyCmd,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := runApplyCmd(cmd, args)
+		if applyArgs.diff {
+			return diffExitErr(err)
+		}
+		return err
+	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		switch len(args) {
 		case 0:
@@ -128,7 +134,7 @@ func init() {
 	applyCmd.Flags().BoolVar(&applyArgs.dryrun, "dry-run", false,
 		"Perform a server-side apply dry run.")
 	applyCmd.Flags().BoolVar(&applyArgs.diff, "diff", false,
-		"Perform a server-side apply dry run and prints the diff.")
+		"Perform a server-side apply dry run and prints the diff. Exits with code 1 if drift is detected and code 2 on errors.")
 	applyCmd.Flags().BoolVar(&applyArgs.wait, "wait", true,
 		"Wait for the applied Kubernetes objects to become ready.")
 	applyCmd.Flags().Var(&applyArgs.creds, applyArgs.creds.Type(), applyArgs.creds.Description())

--- a/cmd/timoni/apply_test.go
+++ b/cmd/timoni/apply_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/reconciler"
 )
 
 func TestApply(t *testing.T) {
@@ -425,5 +427,176 @@ func TestApply_GlobalResources(t *testing.T) {
 		))
 		g.Expect(err).ToNot(HaveOccurred())
 		t.Log("\n", output)
+	})
+}
+
+func TestApply_Diff(t *testing.T) {
+	modPath := "testdata/module"
+	name := rnd("my-instance")
+	namespace := rnd("my-namespace")
+
+	t.Run("detects drift at first install", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -p main --diff",
+			namespace,
+			name,
+			modPath,
+		))
+		t.Log("\n", output)
+		g.Expect(err).To(HaveOccurred())
+
+		var exitErr *ExitError
+		g.Expect(errors.As(err, &exitErr)).To(BeTrue())
+		g.Expect(exitErr.Code).To(Equal(1))
+
+		var driftErr *reconciler.InstanceDriftError
+		g.Expect(errors.As(err, &driftErr)).To(BeTrue())
+		g.Expect(driftErr.Name).To(Equal(name))
+		g.Expect(driftErr.Namespace).To(Equal(namespace))
+	})
+
+	t.Run("exits cleanly when in sync", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -p main --wait",
+			namespace,
+			name,
+			modPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -p main --diff",
+			namespace,
+			name,
+			modPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		t.Log("\n", output)
+	})
+
+	t.Run("detects drift for changed values", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -f %s -p main --diff",
+			namespace,
+			name,
+			modPath,
+			modPath+"-values/example.com.cue",
+		))
+		t.Log("\n", output)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("drift detected"))
+		g.Expect(output).To(ContainSubstring("example.com"))
+
+		var exitErr *ExitError
+		g.Expect(errors.As(err, &exitErr)).To(BeTrue())
+		g.Expect(exitErr.Code).To(Equal(1))
+	})
+
+	t.Run("dry run exits cleanly on drift", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -f %s -p main --dry-run",
+			namespace,
+			name,
+			modPath,
+			modPath+"-values/example.com.cue",
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		t.Log("\n", output)
+	})
+
+	t.Run("skips drift for one-off resources", func(t *testing.T) {
+		g := NewWithT(t)
+		valuesPath := filepath.Join(t.TempDir(), "values.cue")
+		valuesData := fmt.Sprintf(`values: {
+	domain: "example.oneoff"
+	metadata: annotations: "%s": "%s"
+}`, apiv1.IfNotPresentAction, apiv1.EnabledValue)
+		g.Expect(os.WriteFile(valuesPath, []byte(valuesData), 0644)).To(Succeed())
+
+		output, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -f %s -p main --diff",
+			namespace,
+			name,
+			modPath,
+			valuesPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		t.Log("\n", output)
+	})
+
+	t.Run("detects drift for stale resources", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -f %s -p main --diff",
+			namespace,
+			name,
+			modPath,
+			modPath+"-values/server-only.cue",
+		))
+		t.Log("\n", output)
+		g.Expect(err).To(MatchError(ContainSubstring("drift detected")))
+	})
+
+	t.Run("ignores absent stale resources", func(t *testing.T) {
+		g := NewWithT(t)
+		clientCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-client", name),
+				Namespace: namespace,
+			},
+		}
+		g.Expect(envTestClient.Delete(context.Background(), clientCM)).To(Succeed())
+
+		output, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -f %s -p main --diff",
+			namespace,
+			name,
+			modPath,
+			modPath+"-values/server-only.cue",
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		t.Log("\n", output)
+	})
+
+	t.Run("skips drift for prune-disabled stale resources", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -f %s -p main --wait",
+			namespace,
+			name,
+			modPath,
+			modPath+"-values/skip-prune.cue",
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s -f %s -f %s -p main --diff",
+			namespace,
+			name,
+			modPath,
+			modPath+"-values/skip-prune.cue",
+			modPath+"-values/server-only.cue",
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		t.Log("\n", output)
+	})
+
+	t.Run("exits with failure code on errors", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"apply -n %s %s %s --diff",
+			namespace,
+			name,
+			"testdata/does-not-exist",
+		))
+		g.Expect(err).To(HaveOccurred())
+
+		var exitErr *ExitError
+		g.Expect(errors.As(err, &exitErr)).To(BeTrue())
+		g.Expect(exitErr.Code).To(Equal(2))
 	})
 }

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -60,7 +60,13 @@ var bundleApplyCmd = &cobra.Command{
   cat ./bundle_secrets.cue | timoni bundle apply -f ./bundle.cue -f -
 `,
 	Args: cobra.NoArgs,
-	RunE: runBundleApplyCmd,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		err := runBundleApplyCmd(cmd)
+		if bundleApplyArgs.diff {
+			return diffExitErr(err)
+		}
+		return err
+	},
 }
 
 type bundleApplyFlags struct {
@@ -87,14 +93,14 @@ func init() {
 	bundleApplyCmd.Flags().BoolVar(&bundleApplyArgs.dryrun, "dry-run", false,
 		"Perform a server-side apply dry run.")
 	bundleApplyCmd.Flags().BoolVar(&bundleApplyArgs.diff, "diff", false,
-		"Perform a server-side apply dry run and prints the diff.")
+		"Perform a server-side apply dry run and prints the diff. Exits with code 1 if drift is detected and code 2 on errors.")
 	bundleApplyCmd.Flags().BoolVar(&bundleApplyArgs.wait, "wait", true,
 		"Wait for the applied Kubernetes objects to become ready.")
 	bundleApplyCmd.Flags().Var(&bundleApplyArgs.creds, bundleApplyArgs.creds.Type(), bundleApplyArgs.creds.Description())
 	bundleCmd.AddCommand(bundleApplyCmd)
 }
 
-func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
+func runBundleApplyCmd(cmd *cobra.Command) error {
 	start := time.Now()
 	files := bundleApplyArgs.files
 	if len(files) == 0 {
@@ -153,6 +159,8 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	moduleCache := make(map[moduleCacheKey]*fetchedModule)
+
+	var driftErrs []error
 
 	for _, cluster := range clusters {
 		kubeconfigArgs.Context = &cluster.KubeContext
@@ -229,22 +237,37 @@ func runBundleApplyCmd(cmd *cobra.Command, _ []string) error {
 			log.Info(startMsg)
 		}
 
+		clusterDrifts := len(driftErrs)
 		for _, instance := range bundle.Instances {
 			instance.Cluster = cluster.Name
-			if err := applyBundleInstance(logr.NewContext(ctx, log), instance, kubeVersion, tmpDir, modDirs[instance.Name], cmd.OutOrStdout()); err != nil {
+			err := applyBundleInstance(logr.NewContext(ctx, log), instance, kubeVersion, tmpDir, modDirs[instance.Name], cmd.OutOrStdout())
+			if err != nil {
+				// In diff mode, keep diffing the remaining instances and
+				// report the drifted ones at the end of the run.
+				var driftErr *reconciler.InstanceDriftError
+				if errors.As(err, &driftErr) {
+					if !cluster.IsDefault() {
+						err = fmt.Errorf("%w on cluster %s", err, cluster.Name)
+					}
+					driftErrs = append(driftErrs, err)
+					continue
+				}
 				return err
 			}
 		}
 
 		elapsed := time.Since(start)
 		if bundleApplyArgs.dryrun || bundleApplyArgs.diff {
-			log.Info(fmt.Sprintf("applied successfully %s",
-				logger.ColorizeDryRun("(server dry run)")))
+			if len(driftErrs) == clusterDrifts {
+				log.Info(fmt.Sprintf("applied successfully %s",
+					logger.ColorizeDryRun("(server dry run)")))
+			}
 		} else {
 			log.Info(fmt.Sprintf("applied successfully in %s", elapsed.Round(time.Second)))
 		}
 	}
-	return nil
+
+	return errors.Join(driftErrs...)
 }
 
 // fetchedModule holds the local root directory and resolved reference of a

--- a/cmd/timoni/bundle_apply_test.go
+++ b/cmd/timoni/bundle_apply_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -920,4 +921,124 @@ runtime: {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(output).To(ContainSubstring(version))
 	}
+}
+
+func Test_BundleApply_Diff(t *testing.T) {
+	g := NewWithT(t)
+
+	bundleName := rnd("my-bundle")
+	modPath := "testdata/module"
+	namespace := rnd("my-namespace")
+	modName := rnd("my-mod")
+	modURL := fmt.Sprintf("%s/%s", dockerRegistry, modName)
+	modVer := "1.0.0"
+
+	_, err := executeCommand(fmt.Sprintf(
+		"mod push %s oci://%s -v %s --resolve-symlinks",
+		modPath,
+		modURL,
+		modVer,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	bundleTmpl := `
+bundle: {
+	apiVersion: "v1alpha1"
+	name: "%[1]s"
+	instances: {
+		frontend: {
+			module: {
+				url:     "oci://%[2]s"
+				version: "%[3]s"
+			}
+			namespace: "%[4]s"
+			values: server: enabled: false
+		}
+		backend: {
+			module: {
+				url:     "oci://%[2]s"
+				version: "%[3]s"
+			}
+			namespace: "%[4]s"
+			values: domain: "%[5]s"
+		}
+	}
+}
+`
+
+	bundleFor := func(domain string) string {
+		data := fmt.Sprintf(bundleTmpl, bundleName, modURL, modVer, namespace, domain)
+		path := filepath.Join(t.TempDir(), "bundle.cue")
+		g.Expect(os.WriteFile(path, []byte(data), 0644)).To(Succeed())
+		return path
+	}
+
+	t.Run("detects drift for all instances at first install", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"bundle apply -f %s -p main --diff",
+			bundleFor("example.internal"),
+		))
+		t.Log("\n", output)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("drift detected for instance frontend"))
+		g.Expect(err.Error()).To(ContainSubstring("drift detected for instance backend"))
+
+		var exitErr *ExitError
+		g.Expect(errors.As(err, &exitErr)).To(BeTrue())
+		g.Expect(exitErr.Code).To(Equal(1))
+	})
+
+	t.Run("exits cleanly when in sync", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"bundle apply -f %s -p main --wait",
+			bundleFor("example.internal"),
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output, err := executeCommand(fmt.Sprintf(
+			"bundle apply -f %s -p main --diff",
+			bundleFor("example.internal"),
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		t.Log("\n", output)
+	})
+
+	t.Run("detects drift for changed values", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"bundle apply -f %s -p main --diff",
+			bundleFor("example.k8s"),
+		))
+		t.Log("\n", output)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("drift detected for instance backend"))
+		g.Expect(err.Error()).ToNot(ContainSubstring("drift detected for instance frontend"))
+		g.Expect(output).To(ContainSubstring("example.k8s"))
+
+		var exitErr *ExitError
+		g.Expect(errors.As(err, &exitErr)).To(BeTrue())
+		g.Expect(exitErr.Code).To(Equal(1))
+	})
+
+	t.Run("dry run exits cleanly on drift", func(t *testing.T) {
+		g := NewWithT(t)
+		output, err := executeCommand(fmt.Sprintf(
+			"bundle apply -f %s -p main --dry-run",
+			bundleFor("example.k8s"),
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		t.Log("\n", output)
+	})
+
+	t.Run("exits with failure code on errors", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand("bundle apply -f testdata/does-not-exist.cue -p main --diff")
+		g.Expect(err).To(HaveOccurred())
+
+		var exitErr *ExitError
+		g.Expect(errors.As(err, &exitErr)).To(BeTrue())
+		g.Expect(exitErr.Code).To(Equal(2))
+	})
 }

--- a/cmd/timoni/errors.go
+++ b/cmd/timoni/errors.go
@@ -17,13 +17,40 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 
-	"cuelang.org/go/cue/errors"
+	cueerrors "cuelang.org/go/cue/errors"
+
+	"github.com/stefanprodan/timoni/internal/reconciler"
 )
 
 func describeErr(moduleRoot, description string, err error) error {
-	return fmt.Errorf("%s:\n%s", description, errors.Details(err, &errors.Config{
+	return fmt.Errorf("%s:\n%s", description, cueerrors.Details(err, &cueerrors.Config{
 		Cwd: moduleRoot,
 	}))
+}
+
+// ExitError wraps an error with the code the process exits with,
+// overriding the default exit code of 1 used for plain errors.
+type ExitError struct {
+	Err  error
+	Code int
+}
+
+func (e *ExitError) Error() string { return e.Err.Error() }
+func (e *ExitError) Unwrap() error { return e.Err }
+
+// diffExitErr maps the result of an apply command run in diff mode to the
+// flux CLI exit code convention: 0 when the cluster state is in sync,
+// 1 when drift is detected and 2 when the dry run fails.
+func diffExitErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var driftErr *reconciler.InstanceDriftError
+	if errors.As(err, &driftErr) {
+		return &ExitError{Err: err, Code: 1}
+	}
+	return &ExitError{Err: err, Code: 2}
 }

--- a/cmd/timoni/main.go
+++ b/cmd/timoni/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/signal"
 	"path"
@@ -109,7 +110,13 @@ func main() {
 		// Set the logger err to nil to pretty print
 		// the error message on multiple lines.
 		cliLogger.Error(nil, err.Error())
-		os.Exit(1)
+
+		exitCode := 1
+		var exitErr *ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.Code
+		}
+		os.Exit(exitCode)
 	}
 }
 

--- a/cmd/timoni/mask_secrets_test.go
+++ b/cmd/timoni/mask_secrets_test.go
@@ -60,8 +60,8 @@ func TestApply_DiffMasksSecrets(t *testing.T) {
 		modPath,
 		valuesPath,
 	))
-	g.Expect(err).ToNot(HaveOccurred())
 	t.Log("\n", output)
+	g.Expect(err).To(MatchError(ContainSubstring("drift detected")))
 
 	g.Expect(output).To(ContainSubstring("Secret/%s/%s configured", namespace, name))
 	g.Expect(output).To(ContainSubstring("*** (before)"))

--- a/docs/bundle.mdx
+++ b/docs/bundle.mdx
@@ -399,6 +399,11 @@ timoni bundle apply --dry-run --diff -f bundle.cue
 The values of the Kubernetes Secrets `data` entries are masked in the diff
 output: changed entries are printed as `*** (before)` and `*** (after)`.
 
+When the cluster state is in sync with the bundle definition, the command
+exits with code 0. When drift is detected, it exits with code 1, and when
+the dry run fails, it exits with code 2. This allows using
+`timoni bundle apply --diff` as a drift check in CI.
+
 ### Force Upgrade
 
 If an upgrade contains changes to immutable fields, such as changing the image

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -172,6 +172,8 @@ Apply the config to the podinfo module to perform an upgrade:
 Before running an upgrade, you can review the changes that will
 be made on the cluster with `timoni apply --dry-run --diff`.
 The values of the Kubernetes Secrets data entries are masked in the diff output.
+With `--diff`, the command exits with code 1 when drift is detected and
+with code 2 when the dry run fails.
 
 ## Uninstall a module instance
 

--- a/internal/dyff/dyff.go
+++ b/internal/dyff/dyff.go
@@ -30,7 +30,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/gonvenience/ytbx"
 	"github.com/homeport/dyff/pkg/dyff"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
@@ -87,6 +89,15 @@ func DiffYAML(liveFile, mergedFile string, output io.Writer) error {
 	return printer.Print(output, report)
 }
 
+// InstanceDryRunDiff performs a server-side apply dry run of the instance
+// objects and logs the pending change of each one. When withDiff is set, the
+// field changes of the objects that differ from the cluster state are printed
+// to w in YAML diff format, and the dry-run failures are aggregated into the
+// returned error. It returns true if applying the instance would change the
+// cluster state, i.e. if any object would be created, configured or deleted.
+// Mirroring the apply and prune semantics, existing objects annotated as
+// one-off are skipped, and stale objects that are absent from the cluster or
+// annotated with prune disabled are not counted as pending deletions.
 func InstanceDryRunDiff(ctx context.Context,
 	rm *ssa.ResourceManager,
 	objects []*unstructured.Unstructured,
@@ -94,10 +105,16 @@ func InstanceDryRunDiff(ctx context.Context,
 	nsExists bool,
 	tmpDir string,
 	withDiff bool,
-	w io.Writer) error {
+	w io.Writer) (bool, error) {
 	log := logr.FromContextOrDiscard(ctx)
 	diffOpts := ssa.DefaultDiffOptions()
+	diffOpts.IfNotPresentSelector = map[string]string{
+		apiv1.IfNotPresentAction: apiv1.EnabledValue,
+	}
 	sort.Sort(ssa.SortableUnstructureds(objects))
+
+	changed := !nsExists
+	failed := 0
 
 	for _, r := range objects {
 		if !nsExists {
@@ -108,6 +125,7 @@ func InstanceDryRunDiff(ctx context.Context,
 		change, liveObject, mergedObject, err := rm.Diff(ctx, r, diffOpts)
 		if err != nil {
 			if ssaerr.IsImmutableError(err) {
+				changed = true
 				if ssautil.AnyInMetadata(r, map[string]string{
 					apiv1.ForceAction: apiv1.EnabledValue,
 				}) {
@@ -116,10 +134,15 @@ func InstanceDryRunDiff(ctx context.Context,
 					log.Error(nil, logger.ColorizeJoin(r, "immutable", logger.DryRunServer))
 				}
 			} else {
+				failed++
 				log.Error(err, logger.ColorizeUnstructured(r))
 			}
 
 			continue
+		}
+
+		if change.Action == ssa.CreatedAction || change.Action == ssa.ConfiguredAction {
+			changed = true
 		}
 
 		log.Info(logger.ColorizeJoin(change, logger.DryRunServer))
@@ -127,24 +150,41 @@ func InstanceDryRunDiff(ctx context.Context,
 			liveYAML, _ := yaml.Marshal(liveObject)
 			liveFile := filepath.Join(tmpDir, "live.yaml")
 			if err := os.WriteFile(liveFile, liveYAML, 0644); err != nil {
-				return err
+				return changed, err
 			}
 
 			mergedYAML, _ := yaml.Marshal(mergedObject)
 			mergedFile := filepath.Join(tmpDir, "merged.yaml")
 			if err := os.WriteFile(mergedFile, mergedYAML, 0644); err != nil {
-				return err
+				return changed, err
 			}
 
 			if err := DiffYAML(liveFile, mergedFile, w); err != nil {
-				return err
+				return changed, err
 			}
 		}
 	}
 
 	for _, r := range staleObjects {
+		existingObject := &unstructured.Unstructured{}
+		existingObject.SetGroupVersionKind(r.GroupVersionKind())
+		err := rm.Client().Get(ctx, client.ObjectKeyFromObject(r), existingObject)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err == nil && ssautil.AnyInMetadata(existingObject, map[string]string{
+			apiv1.PruneAction: apiv1.DisabledValue,
+		}) {
+			log.Info(logger.ColorizeJoin(r, ssa.SkippedAction, logger.DryRunServer))
+			continue
+		}
+		changed = true
 		log.Info(logger.ColorizeJoin(r, ssa.DeletedAction, logger.DryRunServer))
 	}
 
-	return nil
+	if withDiff && failed > 0 {
+		return changed, fmt.Errorf("dry run failed for %d resource(s)", failed)
+	}
+
+	return changed, nil
 }

--- a/internal/reconciler/interactive.go
+++ b/internal/reconciler/interactive.go
@@ -57,6 +57,10 @@ func NewInteractiveReconciler(log logr.Logger, copts *CommonOptions, iopts *Inte
 	return reconciler
 }
 
+// ApplyInstance reconciles the instance objects onto the cluster. In dry-run
+// and diff mode it performs a server-side apply dry run instead, and in diff
+// mode it returns an InstanceDriftError when applying the instance would
+// change the cluster state.
 func (r *InteractiveReconciler) ApplyInstance(ctx context.Context, log logr.Logger, builder *engine.ModuleBuilder, buildResult cue.Value) error {
 	namespaceExists, err := r.NamespaceExists(ctx)
 	if err != nil {
@@ -68,8 +72,13 @@ func (r *InteractiveReconciler) ApplyInstance(ctx context.Context, log logr.Logg
 			log.Info(logger.ColorizeJoin(logger.ColorizeSubject("Namespace/"+r.Namespace()),
 				ssa.CreatedAction, logger.DryRunServer))
 		}
-		if err := r.DryRunDiff(logr.NewContext(ctx, log), namespaceExists); err != nil {
+		changed, err := r.DryRunDiff(logr.NewContext(ctx, log), namespaceExists)
+		if err != nil {
 			return err
+		}
+
+		if r.Diff && changed {
+			return &InstanceDriftError{Name: r.Name(), Namespace: r.Namespace()}
 		}
 
 		log.Info(logger.ColorizeJoin("applied successfully", logger.ColorizeDryRun("(server dry run)")))
@@ -101,7 +110,10 @@ func (r *InteractiveReconciler) ApplyInstance(ctx context.Context, log logr.Logg
 	return r.applyInstanceStages(ctx, log, builder, buildResult)
 }
 
-func (r *InteractiveReconciler) DryRunDiff(ctx context.Context, namespaceExists bool) error {
+// DryRunDiff performs a server-side apply dry run of the instance objects,
+// printing the field changes when running in diff mode. It returns true if
+// applying the instance would change the cluster state.
+func (r *InteractiveReconciler) DryRunDiff(ctx context.Context, namespaceExists bool) (bool, error) {
 	return dyff.InstanceDryRunDiff(
 		ctx,
 		r.resourceManager,

--- a/internal/reconciler/types.go
+++ b/internal/reconciler/types.go
@@ -95,6 +95,17 @@ type ReadinessError struct {
 func (e *ReadinessError) Error() string { return e.Err.Error() }
 func (e *ReadinessError) Unwrap() error { return e.Err }
 
+// InstanceDriftError is returned by InteractiveReconciler.ApplyInstance in
+// diff mode when applying the instance would change the cluster state.
+type InstanceDriftError struct {
+	Name      string
+	Namespace string
+}
+
+func (e *InstanceDriftError) Error() string {
+	return fmt.Sprintf("drift detected for instance %s in namespace %s", e.Name, e.Namespace)
+}
+
 type InstanceOwnershipConflict struct{ InstanceName, CurrentOwnerBundle string }
 type InstanceOwnershipConflictErr []InstanceOwnershipConflict
 

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author: Stefan Prodan
   homepage: https://timoni.sh
   source: https://github.com/stefanprodan/timoni
-  version: "0.1.0"
+  version: "0.1.1"
 ---
 
 # Timoni
@@ -156,7 +156,7 @@ bundle: {
   cluster (add `--print-value` to inspect the computed bundle),
   `timoni bundle build -f bundle.cue` renders the manifests offline, and
   `timoni bundle apply -f bundle.cue --diff` previews the changes against the
-  cluster before applying.
+  cluster before applying (exits 1 on drift, 2 on failure).
 - Instances are applied in declaration order, each waiting for readiness
   before the next (`--wait=false` disables waiting). Deletion runs in reverse
   order.
@@ -338,7 +338,9 @@ regardless. Everything else prints plaintext: `bundle vet --print-value`,
   alphanumerics with `-`, `_` or `.` inside, 63 chars max; Kubernetes object
   names generated from them still follow Kubernetes rules.
 - `--dry-run` reports the action per object (created, configured, unchanged)
-  without applying; `--diff` does the same and also prints the field changes.
+  without applying; `--diff` does the same and also prints the field changes,
+  exiting with code 1 when drift is detected and code 2 when the dry run
+  fails, so it doubles as a drift check in CI.
 - Objects removed from a module are pruned on the next apply. Guard
   data-bearing objects with `action.timoni.sh/prune: "disabled"`.
 - Immutable-field changes (Job template, StatefulSet volume claims, Service

--- a/test/Makefile
+++ b/test/Makefile
@@ -44,8 +44,11 @@ fleet-deploy: # Deploy the apps bundle across the fleet using the locally built 
 	-r $(REPOSITORY_ROOT)/test/manifests/runtime.cue
 
 .PHONY: fleet-deploy-check
-fleet-deploy-check: # Check the status of the apps bundle across the fleet using the locally built timoni
+fleet-deploy-check: # Check the status and drift of the apps bundle across the fleet using the locally built timoni
 	$(REPOSITORY_ROOT)/bin/timoni bundle status \
+	-f $(REPOSITORY_ROOT)/test/manifests/apps.cue \
+	-r $(REPOSITORY_ROOT)/test/manifests/runtime.cue
+	$(REPOSITORY_ROOT)/bin/timoni bundle apply --diff \
 	-f $(REPOSITORY_ROOT)/test/manifests/apps.cue \
 	-r $(REPOSITORY_ROOT)/test/manifests/runtime.cue
 


### PR DESCRIPTION
Make `timoni apply --diff` and `timoni bundle apply --diff` follow the flux CLI exit code convention: 0 when the cluster state is in sync, 1 when drift is detected and 2 when the dry run fails.

Drift covers objects that would be created, configured or pruned, including immutable field changes. Mirroring the apply and prune semantics, existing objects annotated as one-off are skipped, and stale objects absent from the cluster or annotated with prune disabled are not counted as pending deletions.

In diff mode, `bundle apply` keeps diffing the remaining instances and clusters when one drifts and reports all drifted instances at the end of the run. The `--dry-run` exit codes are unchanged.
