### PR TITLE
feat(bundle): add `--offline` flag to `bundle vet`

### DIFF
--- a/cmd/timoni/bundle_vet.go
+++ b/cmd/timoni/bundle_vet.go
@@ -39,6 +39,15 @@ var bundleVetCmd = &cobra.Command{
 	Short:   "Validate a bundle definition",
 	Long: `The bundle vet command validates that a bundle definition conforms
 with Timoni's schema and optionally prints the computed value.
+
+The clusters are contacted only when the runtime reads values from
+Kubernetes resources. With --offline, the runtime values come from the
+environment variables with the same names; a missing value is reported
+and the bundle default is used, or the validation fails when there is
+no default.
+
+The instance values are not validated against the module schemas,
+use the bundle build command for that.
 `,
 	Example: `  # Validate a bundle and list its instances
   timoni bundle vet -f bundle.cue
@@ -54,6 +63,14 @@ with Timoni's schema and optionally prints the computed value.
   -f bundle.cue \
   -r runtime.cue \
   --print-value
+
+  # Validate a bundle without cluster access,
+  # with the runtime values taken from the environment
+  export DB_PASSWORD=dummy
+  timoni bundle vet \
+  -f bundle.cue \
+  -r runtime.cue \
+  --offline
 `,
 	Args: cobra.NoArgs,
 	RunE: runBundleVetCmd,
@@ -63,6 +80,7 @@ type bundleVetFlags struct {
 	pkg        flags.Package
 	files      []string
 	printValue bool
+	offline    bool
 }
 
 var bundleVetArgs bundleVetFlags
@@ -73,9 +91,12 @@ func init() {
 		"The local path to bundle.cue files.")
 	bundleVetCmd.Flags().BoolVar(&bundleVetArgs.printValue, "print-value", false,
 		"Print the computed value of the bundle.")
+	bundleVetCmd.Flags().BoolVar(&bundleVetArgs.offline, "offline", false,
+		"Validate without cluster access, taking the runtime values from the environment.")
 	bundleCmd.AddCommand(bundleVetCmd)
 }
 
+// runBundleVetCmd validates a bundle definition with runtime values from the environment or clusters.
 func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 	log := LoggerFrom(cmd.Context())
 	files := bundleVetArgs.files
@@ -108,13 +129,23 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 
 	runtimeValues := make(map[string]string)
 
-	if bundleArgs.runtimeFromEnv {
+	if bundleArgs.runtimeFromEnv || bundleVetArgs.offline {
 		maps.Copy(runtimeValues, engine.GetEnv())
 	}
 
 	rt, err := buildRuntime(bundleArgs.runtimeFiles, bundleArgs.workdir)
 	if err != nil {
 		return err
+	}
+
+	if bundleVetArgs.offline {
+		for _, ref := range rt.Refs {
+			for key := range ref.Expressions {
+				if _, found := runtimeValues[key]; !found {
+					log.Info(fmt.Sprintf("runtime value %s not found in environment, using the bundle default", key))
+				}
+			}
+		}
 	}
 
 	clusters := rt.SelectClusters(bundleArgs.runtimeCluster, bundleArgs.runtimeClusterGroup)
@@ -134,16 +165,18 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 		maps.Copy(clusterValues, runtimeValues)
 
 		// add values from cluster
-		rm, err := runtime.NewResourceManager(kubeconfigArgs)
-		if err != nil {
-			return err
+		if len(rt.Refs) > 0 && !bundleVetArgs.offline {
+			rm, err := runtime.NewResourceManager(kubeconfigArgs)
+			if err != nil {
+				return err
+			}
+			reader := runtime.NewResourceReader(rm)
+			rv, err := reader.Read(kctx, rt.Refs)
+			if err != nil {
+				return err
+			}
+			maps.Copy(clusterValues, rv)
 		}
-		reader := runtime.NewResourceReader(rm)
-		rv, err := reader.Read(kctx, rt.Refs)
-		if err != nil {
-			return err
-		}
-		maps.Copy(clusterValues, rv)
 
 		// add cluster info
 		maps.Copy(clusterValues, cluster.NameGroupValues())

--- a/cmd/timoni/bundle_vet_test.go
+++ b/cmd/timoni/bundle_vet_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func Test_BundleVet(t *testing.T) {
@@ -197,6 +202,197 @@ bundle: {
 			g.Expect(err.Error()).To(MatchRegexp(tt.matchErr))
 		})
 	}
+}
+
+func Test_BundleVet_Offline(t *testing.T) {
+	runtimeValueName := strings.ToUpper(strings.ReplaceAll(rnd("bundle-vet"), "-", "_"))
+	secretName := rnd("bundle-vet")
+	behaviorDir := t.TempDir()
+
+	defaultBundle := `
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "offline-test"
+	instances: app: {
+		module: {
+			url:     "oci://docker.io/test"
+			version: "latest"
+		}
+		namespace: "default"
+		values: {}
+	}
+}
+`
+	defaultBundlePath := filepath.Join(behaviorDir, "default-bundle.cue")
+	g := NewWithT(t)
+	g.Expect(os.WriteFile(defaultBundlePath, []byte(defaultBundle), 0644)).To(Succeed())
+
+	runtimeBundle := fmt.Sprintf(`
+bundle: {
+	_cluster:      "default" @timoni(runtime:string:TIMONI_CLUSTER_NAME)
+	_runtimeValue: *"bundle-default" | string @timoni(runtime:string:%s)
+
+	apiVersion: "v1alpha1"
+	name:       "offline-test"
+	instances: app: {
+		module: {
+			url:     "oci://docker.io/test"
+			version: "latest"
+		}
+		namespace: "default"
+		values: {
+			cluster:      _cluster
+			runtimeValue: _runtimeValue
+		}
+	}
+}
+`, runtimeValueName)
+	runtimeBundlePath := filepath.Join(behaviorDir, "runtime-bundle.cue")
+	g.Expect(os.WriteFile(runtimeBundlePath, []byte(runtimeBundle), 0644)).To(Succeed())
+
+	runtimeNoRefs := `
+runtime: {
+	apiVersion: "v1alpha1"
+	name:       "offline-test"
+	clusters: "offline-cluster": {
+		group:       "testing"
+		kubeContext: "missing"
+	}
+}
+`
+	runtimeNoRefsPath := filepath.Join(behaviorDir, "runtime-no-refs.cue")
+	g.Expect(os.WriteFile(runtimeNoRefsPath, []byte(runtimeNoRefs), 0644)).To(Succeed())
+
+	runtimeWithRefs := fmt.Sprintf(`
+runtime: {
+	apiVersion: "v1alpha1"
+	name:       "offline-test"
+	clusters: "envtest": {
+		group:       "testing"
+		kubeContext: "envtest"
+	}
+	values: [
+		{
+			query: "k8s:v1:Secret:kube-system:%s"
+			for: {
+				%q: "obj.data.value"
+			}
+		},
+	]
+}
+`, secretName, runtimeValueName)
+	runtimeWithRefsPath := filepath.Join(behaviorDir, "runtime-with-refs.cue")
+	g.Expect(os.WriteFile(runtimeWithRefsPath, []byte(runtimeWithRefs), 0644)).To(Succeed())
+
+	t.Run("vets the default runtime without a kubeconfig", func(t *testing.T) {
+		g := NewWithT(t)
+		useMissingKubeconfig(t)
+
+		output, err := executeCommand(fmt.Sprintf("bundle vet -f %s", defaultBundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("instance is valid"))
+		g.Expect(output).To(ContainSubstring("i:app"))
+	})
+
+	t.Run("vets runtime clusters without refs or a kubeconfig", func(t *testing.T) {
+		g := NewWithT(t)
+		useMissingKubeconfig(t)
+
+		output, err := executeCommand(fmt.Sprintf(
+			"bundle vet -f %s -r %s -p main --print-value",
+			runtimeBundlePath, runtimeNoRefsPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring(`"offline-cluster": bundle`))
+		g.Expect(output).To(ContainSubstring("cluster:"))
+		g.Expect(output).To(ContainSubstring(`"offline-cluster"`))
+	})
+
+	t.Run("requires a kubeconfig for runtime refs", func(t *testing.T) {
+		g := NewWithT(t)
+		useMissingKubeconfig(t)
+
+		_, err := executeCommand(fmt.Sprintf(
+			"bundle vet -f %s -r %s -p main --print-value",
+			runtimeBundlePath, runtimeWithRefsPath,
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("loading kubeconfig failed"))
+	})
+
+	t.Run("offline injects runtime refs from the environment", func(t *testing.T) {
+		g := NewWithT(t)
+		useMissingKubeconfig(t)
+		t.Setenv(runtimeValueName, "environment-value")
+
+		output, err := executeCommand(fmt.Sprintf(
+			"bundle vet -f %s -r %s -p main --offline --print-value",
+			runtimeBundlePath, runtimeWithRefsPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring(`runtimeValue: "environment-value"`))
+	})
+
+	t.Run("offline logs missing runtime refs and uses bundle defaults", func(t *testing.T) {
+		g := NewWithT(t)
+		useMissingKubeconfig(t)
+		_, found := os.LookupEnv(runtimeValueName)
+		g.Expect(found).To(BeFalse())
+
+		stdout, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"bundle vet -f %s -r %s -p main --offline --print-value",
+			runtimeBundlePath, runtimeWithRefsPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stdout).To(ContainSubstring(`runtimeValue: *"bundle-default" | string`))
+		expectedLog := fmt.Sprintf("runtime value %s not found in environment, using the bundle default", runtimeValueName)
+		g.Expect(stderr).To(ContainSubstring(expectedLog))
+	})
+
+	t.Run("cluster values override environment values", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv(runtimeValueName, "environment-value")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: "kube-system",
+			},
+			StringData: map[string]string{"value": "cluster-value"},
+		}
+		g.Expect(envTestClient.Create(context.Background(), secret, &client.CreateOptions{
+			FieldManager: "timoni",
+		})).To(Succeed())
+		t.Cleanup(func() {
+			_ = envTestClient.Delete(context.Background(), secret)
+		})
+
+		output, err := executeCommand(fmt.Sprintf(
+			"bundle vet -f %s -r %s -p main --runtime-from-env --print-value",
+			runtimeBundlePath, runtimeWithRefsPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring(`runtimeValue: "cluster-value"`))
+		g.Expect(output).ToNot(ContainSubstring("environment-value"))
+
+		output, err = executeCommand(fmt.Sprintf(
+			"bundle vet -f %s -r %s -p main --offline --print-value",
+			runtimeBundlePath, runtimeWithRefsPath,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring(`runtimeValue: "environment-value"`))
+		g.Expect(output).ToNot(ContainSubstring("cluster-value"))
+	})
+}
+
+// useMissingKubeconfig points commands at a nonexistent kubeconfig for the duration of a test.
+func useMissingKubeconfig(t *testing.T) {
+	t.Helper()
+	original := kubeconfigArgs.KubeConfig
+	missing := filepath.Join(t.TempDir(), "missing-kubeconfig")
+	kubeconfigArgs.KubeConfig = &missing
+	t.Cleanup(func() {
+		kubeconfigArgs.KubeConfig = original
+	})
 }
 
 func Test_BundleVet_PrintValue(t *testing.T) {

--- a/docs/bundle-runtime.mdx
+++ b/docs/bundle-runtime.mdx
@@ -411,4 +411,6 @@ timoni bundle apply -f bundle.cue --runtime-from-env
 
 When using `timoni bundle apply --runtime runtime.cue --runtime-from-env`,
 the values coming from the Runtime take precedence over the Environment.
+Use `timoni bundle vet --offline` to validate with Runtime values from the
+environment without connecting to the clusters.
 </Tip>

--- a/docs/bundle.mdx
+++ b/docs/bundle.mdx
@@ -560,16 +560,27 @@ timoni bundle vet -f bundle.cue -f extras.cue
 ```
 
 If the validation passes, Timoni will list all the instances found in the computed bundle.
+The command runs without cluster access unless the selected Runtime declares `values`
+that read from Kubernetes resources.
 
-When `--print-value` is specified, Timoni will write the Bundle computed value to stdout.
-
-Example:
+With `--offline`, Timoni does not connect to the clusters and takes the Runtime values
+from the environment variables with the same names.
 
 ```shell
-timoni bundle vet -f bundle.cue --runtime-from-env --print-value
+export DB_PASSWORD=dummy
+timoni bundle vet -f bundle.cue -r runtime.cue --offline --print-value
 ```
 
-Printing the computed value is particular useful when debugging runtime attributes.
+When a value declared by the Runtime is missing from the environment, Timoni reports it
+and uses the Bundle default. The validation fails if the value has no default.
+The clusters declared in the Runtime are still evaluated one by one, with
+`TIMONI_CLUSTER_NAME` and `TIMONI_CLUSTER_GROUP` set for each of them.
+
+When `--print-value` is specified, Timoni will write the Bundle computed value to stdout.
+Printing the computed value is particularly useful when debugging runtime attributes.
+
+Note that the vet command does not fetch the modules, so the instance values are
+not validated against the module schemas. Use `timoni bundle build` for that.
 
 ### Update module versions
 

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -66,6 +66,7 @@ below.
 | Task | Command |
 |------|---------|
 | Validate | `timoni bundle vet -f bundle.cue` |
+| Validate without a cluster | `timoni bundle vet -f bundle.cue -r runtime.cue --offline` |
 | Validate and print the computed bundle | `timoni bundle vet -f bundle.cue --print-value` |
 | Preview | `timoni bundle apply -f bundle.cue --diff` |
 | Apply | `timoni bundle apply -f bundle.cue [-f bundle_secrets.cue]` |
@@ -373,7 +374,7 @@ regardless. Everything else prints plaintext: `bundle vet --print-value`,
 1. Pin the version: `timoni mod list oci://<repo>`; use a digest where tags are mutable.
 2. Read the docs: `timoni mod show readme oci://<repo> -v <version>`, then
    the schema: `timoni mod show config oci://<repo> -v <version>`.
-3. Validate offline: `timoni build ...` or `timoni bundle vet -f bundle.cue`.
+3. Validate offline: `timoni build ...` or `timoni bundle vet -f bundle.cue --offline`.
 4. Preview: `--diff`, review pruned and recreated objects.
 5. Apply, then `timoni status` / `timoni bundle status`.
 6. Confirm merged values with `inspect values` only where the output is not logged.


### PR DESCRIPTION
Read runtime values from the cluster only when the runtime declares resource references. With --offline, the values are taken from the environment variables with the same names and the clusters are never contacted.