### PR TITLE
feat(bundle): validate custom resources with CRD schema + CEL

### DIFF
--- a/cmd/timoni/build.go
+++ b/cmd/timoni/build.go
@@ -32,6 +32,7 @@ import (
 	"cuelang.org/go/cue/format"
 	cuejson "cuelang.org/go/encoding/json"
 	cueyaml "cuelang.org/go/encoding/yaml"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
@@ -40,6 +41,7 @@ import (
 	"github.com/stefanprodan/timoni/internal/engine"
 	"github.com/stefanprodan/timoni/internal/engine/fetcher"
 	"github.com/stefanprodan/timoni/internal/flags"
+	"github.com/stefanprodan/timoni/internal/logger"
 	"github.com/stefanprodan/timoni/internal/mask"
 )
 
@@ -48,6 +50,9 @@ var buildCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(2),
 	Aliases: []string{"template"},
 	Short:   "Build an instance from a module and print the resulting Kubernetes resources",
+	Long: `The build command builds an instance from a module and prints the resulting Kubernetes resources.
+
+Custom resources are validated against the CRD schemas vendored in the module and the CRDs rendered by the module. A violation fails the command and nothing is written. Use --validate=false to disable the validation.`,
 	Example: `  # Build an instance from a local module
   timoni build app ./path/to/module --output yaml
 
@@ -78,6 +83,7 @@ type buildFlags struct {
 	valuesFiles []string
 	output      string
 	maskSecrets bool
+	validate    bool
 	creds       flags.Credentials
 }
 
@@ -93,6 +99,8 @@ func init() {
 		"The format in which the Kubernetes objects should be printed, can be 'yaml' or 'json'.")
 	buildCmd.Flags().BoolVar(&buildArgs.maskSecrets, "mask-secrets", false,
 		"Hide the values of Kubernetes Secrets in the printed objects.")
+	buildCmd.Flags().BoolVar(&buildArgs.validate, "validate", true,
+		"Validate the custom resources against their CRD schemas and CEL rules.")
 	buildCmd.Flags().Var(&buildArgs.creds, buildArgs.creds.Type(), buildArgs.creds.Description())
 
 	rootCmd.AddCommand(buildCmd)
@@ -202,6 +210,24 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 		objects = append(objects, set.Objects...)
 	}
 
+	if buildArgs.validate {
+		vendoredCRDs, err := builder.GetVendoredCRDs()
+		if err != nil {
+			return fmt.Errorf("validation failed: %w", err)
+		}
+		crdValidator := engine.NewCRDValidator()
+		if err := crdValidator.AddVendoredCRDs(vendoredCRDs); err != nil {
+			return fmt.Errorf("validation failed: %w", err)
+		}
+		if err := crdValidator.AddCRDs(objects); err != nil {
+			return fmt.Errorf("validation failed: %w", err)
+		}
+		validationErrs := crdValidator.ValidateObjects(cmd.Context(), objects)
+		if invalid := logValidationErrors(LoggerFrom(cmd.Context()), validationErrs, ""); invalid > 0 {
+			return fmt.Errorf("validation failed, %d invalid custom resource(s)", invalid)
+		}
+	}
+
 	if buildArgs.maskSecrets {
 		for i, obj := range objects {
 			objects[i] = mask.SecretData(obj)
@@ -241,6 +267,21 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("unknown --output=%s, can be yaml or json", buildArgs.output)
 	}
+}
+
+// logValidationErrors logs one error line per violation, prefixed with the
+// instance name when set, and returns the number of invalid custom resources.
+func logValidationErrors(log logr.Logger, validationErrs []engine.ValidationError, instance string) int {
+	invalid := make(map[string]struct{})
+	for _, e := range validationErrs {
+		invalid[e.Object] = struct{}{}
+		msg := fmt.Sprintf("%s %s", logger.ColorizeSubject(e.Object), logger.ColorizeError(e.Err))
+		if instance != "" {
+			msg = fmt.Sprintf("instance %s: %s", logger.ColorizeSubject(instance), msg)
+		}
+		log.Error(nil, msg)
+	}
+	return len(invalid)
 }
 
 func convertToCue(cmd *cobra.Command, paths []string) ([][]byte, error) {

--- a/cmd/timoni/build_test.go
+++ b/cmd/timoni/build_test.go
@@ -229,6 +229,45 @@ func TestBuild(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("invalid value 19"))
 	})
+
+	t.Run("validates custom resources", func(t *testing.T) {
+		g := NewWithT(t)
+		name := rnd("widget")
+		namespace := rnd("widgets")
+		stdout, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"build -n %s %s testdata/module-cel -p main",
+			namespace, name,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stdout).To(ContainSubstring("kind: Widget"))
+		g.Expect(stderr).To(BeEmpty())
+	})
+
+	t.Run("fails when a custom resource violates a CEL rule", func(t *testing.T) {
+		g := NewWithT(t)
+		name := rnd("widget")
+		namespace := rnd("widgets")
+		stdout, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"build -n %s %s testdata/module-cel -p main -f testdata/module-cel-values/widget-invalid.cue",
+			namespace, name,
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("validation failed, 1 invalid custom resource(s)"))
+		g.Expect(stdout).To(BeEmpty())
+		g.Expect(stderr).To(ContainSubstring("spec: minReplicas must not exceed replicas"))
+	})
+
+	t.Run("can disable custom resource validation", func(t *testing.T) {
+		g := NewWithT(t)
+		name := rnd("widget")
+		namespace := rnd("widgets")
+		stdout, _, err := executeCommandWithOutErr(fmt.Sprintf(
+			"build -n %s %s testdata/module-cel -p main -f testdata/module-cel-values/widget-invalid.cue --validate=false",
+			namespace, name,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stdout).To(ContainSubstring("kind: Widget"))
+	})
 }
 
 func TestBuildRejectsInvalidOutputBeforeInput(t *testing.T) {

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -29,6 +29,7 @@ import (
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/engine"
@@ -43,6 +44,8 @@ var bundleApplyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "Install or upgrade instances from a bundle",
 	Long: `The bundle apply command installs or upgrades the instances defined in a bundle.
+
+Custom resources are validated against the CRD schemas vendored in the modules and the CRDs rendered by the instance and by the earlier instances of the bundle. A violation fails the command before the instance is applied. Use --validate=false to disable the validation.
 `,
 	Example: `  # Install all instances from a bundle
   timoni bundle apply -f bundle.cue
@@ -77,6 +80,7 @@ type bundleApplyFlags struct {
 	wait               bool
 	force              bool
 	overwriteOwnership bool
+	validate           bool
 	creds              flags.Credentials
 }
 
@@ -96,6 +100,8 @@ func init() {
 		"Perform a server-side apply dry run and prints the diff. Exits with code 1 if drift is detected and code 2 on errors.")
 	bundleApplyCmd.Flags().BoolVar(&bundleApplyArgs.wait, "wait", true,
 		"Wait for the applied Kubernetes objects to become ready.")
+	bundleApplyCmd.Flags().BoolVar(&bundleApplyArgs.validate, "validate", true,
+		"Validate the custom resources against their CRD schemas and CEL rules.")
 	bundleApplyCmd.Flags().Var(&bundleApplyArgs.creds, bundleApplyArgs.creds.Type(), bundleApplyArgs.creds.Description())
 	bundleCmd.AddCommand(bundleApplyCmd)
 }
@@ -238,9 +244,10 @@ func runBundleApplyCmd(cmd *cobra.Command) error {
 		}
 
 		clusterDrifts := len(driftErrs)
+		crdValidator := engine.NewCRDValidator()
 		for _, instance := range bundle.Instances {
 			instance.Cluster = cluster.Name
-			err := applyBundleInstance(logr.NewContext(ctx, log), instance, kubeVersion, tmpDir, modDirs[instance.Name], cmd.OutOrStdout())
+			err := applyBundleInstance(logr.NewContext(ctx, log), instance, kubeVersion, tmpDir, modDirs[instance.Name], crdValidator, cmd.OutOrStdout())
 			if err != nil {
 				// In diff mode, keep diffing the remaining instances and
 				// report the drifted ones at the end of the run.
@@ -333,14 +340,15 @@ func fetchBundleInstanceModule(ctx context.Context, instance *apiv1.BundleInstan
 	return cached.dir, nil
 }
 
-// applyBundleInstance builds an instance and reconciles its Kubernetes
-// objects onto the cluster. The instance is compiled in its own CUE context
-// so that the memory used during the build can be reclaimed once the objects
-// are extracted, keeping the peak usage constant regardless of how many
-// instances a bundle contains. The module directory is shared between the
-// instances referencing the same module version and is never modified; the
-// instance schema and values are injected as in-memory overlays.
-func applyBundleInstance(ctx context.Context, instance *apiv1.BundleInstance, kubeVersion string, rootDir string, modDir string, diffOutput io.Writer) error {
+// applyBundleInstance builds and validates an instance, then reconciles its
+// Kubernetes objects onto the cluster. The instance is compiled in its own
+// CUE context so that the memory used during the build can be reclaimed once
+// the objects are extracted, keeping the peak usage constant regardless of
+// how many instances a bundle contains. The module directory is shared
+// between the instances referencing the same module version and is never
+// modified; the instance schema and values are injected as in-memory
+// overlays. The validator carries schemas registered by earlier instances.
+func applyBundleInstance(ctx context.Context, instance *apiv1.BundleInstance, kubeVersion string, rootDir string, modDir string, crdValidator *engine.CRDValidator, diffOutput io.Writer) error {
 	log := loggerBundleInstance(ctx, instance.Bundle, instance.Cluster, instance.Name, true)
 
 	builder := engine.NewModuleBuilder(
@@ -373,6 +381,32 @@ func applyBundleInstance(ctx context.Context, instance *apiv1.BundleInstance, ku
 	buildResult, err := builder.Build()
 	if err != nil {
 		return describeErr(modDir, "build failed for "+instance.Name, err)
+	}
+
+	if bundleApplyArgs.validate {
+		applySets, err := builder.GetApplySets(buildResult)
+		if err != nil {
+			return fmt.Errorf("failed to extract objects: %w", err)
+		}
+		var objects []*unstructured.Unstructured
+		for _, set := range applySets {
+			objects = append(objects, set.Objects...)
+		}
+
+		vendoredCRDs, err := builder.GetVendoredCRDs()
+		if err != nil {
+			return fmt.Errorf("validation failed: %w", err)
+		}
+		if err := crdValidator.AddVendoredCRDs(vendoredCRDs); err != nil {
+			return fmt.Errorf("validation failed: %w", err)
+		}
+		if err := crdValidator.AddCRDs(objects); err != nil {
+			return fmt.Errorf("validation failed: %w", err)
+		}
+		validationErrs := crdValidator.ValidateObjects(ctx, objects)
+		if invalid := logValidationErrors(log, validationErrs, instance.Name); invalid > 0 {
+			return fmt.Errorf("validation failed, %d invalid custom resource(s)", invalid)
+		}
 	}
 
 	r := reconciler.NewInteractiveReconciler(log,

--- a/cmd/timoni/bundle_apply_test.go
+++ b/cmd/timoni/bundle_apply_test.go
@@ -30,6 +30,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
@@ -1040,5 +1042,100 @@ bundle: {
 		var exitErr *ExitError
 		g.Expect(errors.As(err, &exitErr)).To(BeTrue())
 		g.Expect(exitErr.Code).To(Equal(2))
+	})
+}
+
+func Test_BundleApply_CustomResourceValidation(t *testing.T) {
+	g := NewWithT(t)
+
+	celURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("module-cel"))
+	crURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("module-cel-cr"))
+	for _, module := range []struct {
+		path string
+		url  string
+	}{
+		{path: "testdata/module-cel", url: celURL},
+		{path: "testdata/module-cel-cr", url: crURL},
+	} {
+		_, err := executeCommand(fmt.Sprintf(
+			"mod push %s oci://%s -v 1.0.0 --resolve-symlinks",
+			module.path, module.url,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	namespace := rnd("validation")
+	bundleName := rnd("validation")
+	bundleData := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "%[1]s"
+	instances: {
+		operator: {
+			module: {url: "oci://%[2]s", version: "1.0.0"}
+			namespace: "%[4]s"
+			values: customResources: false
+		}
+		app: {
+			module: {url: "oci://%[3]s", version: "1.0.0"}
+			namespace: "%[4]s"
+			values: minReplicas: 5
+		}
+	}
+}
+`, bundleName, celURL, crURL, namespace)
+	bundlePath := filepath.Join(t.TempDir(), "bundle.cue")
+	g.Expect(os.WriteFile(bundlePath, []byte(bundleData), 0o644)).To(Succeed())
+
+	t.Cleanup(func() {
+		_, _ = executeCommand(fmt.Sprintf("delete -n %s app --wait", namespace))
+		_, _ = executeCommand(fmt.Sprintf("delete -n %s operator --wait", namespace))
+	})
+
+	t.Run("stops before applying an invalid custom resource", func(t *testing.T) {
+		g := NewWithT(t)
+		_, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"bundle apply -f %s -p main --wait", bundlePath,
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("validation failed, 1 invalid custom resource(s)"))
+		g.Expect(stderr).To(ContainSubstring("instance app: Widget/" + namespace + "/app spec: minReplicas must not exceed replicas"))
+
+		crd := &unstructured.Unstructured{}
+		crd.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition",
+		})
+		err = envTestClient.Get(context.Background(), client.ObjectKey{Name: "widgets.testing.timoni.sh"}, crd)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		widget := &unstructured.Unstructured{}
+		widget.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "testing.timoni.sh", Version: "v1", Kind: "Widget",
+		})
+		err = envTestClient.Get(context.Background(), client.ObjectKey{Name: "app", Namespace: namespace}, widget)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	t.Run("returns exit code two in diff mode", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"bundle apply -f %s -p main --diff", bundlePath,
+		))
+		g.Expect(err).To(HaveOccurred())
+
+		var exitErr *ExitError
+		g.Expect(errors.As(err, &exitErr)).To(BeTrue())
+		g.Expect(exitErr.Code).To(Equal(2))
+		g.Expect(exitErr.Error()).To(ContainSubstring("validation failed, 1 invalid custom resource(s)"))
+	})
+
+	t.Run("leaves the validation to the API server when disabled", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand(fmt.Sprintf(
+			"bundle apply -f %s -p main --wait --validate=false", bundlePath,
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).ToNot(ContainSubstring("validation failed, 1 invalid custom resource(s)"))
+		g.Expect(err.Error()).To(ContainSubstring("minReplicas must not exceed replicas"))
 	})
 }

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -27,6 +27,7 @@ import (
 	goruntime "runtime"
 	"sort"
 	"strings"
+	"sync"
 
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/fluxcd/pkg/ssa"
@@ -47,6 +48,8 @@ var bundleBuildCmd = &cobra.Command{
 	Aliases: []string{"template"},
 	Short:   "Build and print the resulting Kubernetes resources for all instances from a Bundle",
 	Long: `The bundle build command builds and prints the resulting Kubernetes resources for all instances defined in a Bundle.
+
+Custom resources are validated against the CRD schemas vendored in the modules and the CRDs rendered by any instance of the bundle. A violation fails the command and nothing is written. Use --validate=false to disable the validation.
 `,
 	Example: `  # Build all instances from a bundle and print the manifests to stdout
   timoni bundle build -f bundle.cue
@@ -69,6 +72,7 @@ type bundleBuildFlags struct {
 	outputDir   string
 	concurrency int
 	maskSecrets bool
+	validate    bool
 }
 
 var bundleBuildArgs bundleBuildFlags
@@ -84,6 +88,8 @@ func init() {
 		"The number of instances to build concurrently, defaults to the number of CPU cores capped at 8.")
 	bundleBuildCmd.Flags().BoolVar(&bundleBuildArgs.maskSecrets, "mask-secrets", false,
 		"Hide the values of Kubernetes Secrets in the printed objects, ignored with --output-dir.")
+	bundleBuildCmd.Flags().BoolVar(&bundleBuildArgs.validate, "validate", true,
+		"Validate the custom resources against their CRD schemas and CEL rules.")
 	bundleCmd.AddCommand(bundleBuildCmd)
 }
 
@@ -122,47 +128,9 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 	bm := engine.NewBundleBuilder(ctx, files)
 	bm.SetWorkdir(workdir)
 
-	workspace := apiv1.RuntimeDefaultName
-	runtimeValues := make(map[string]string)
-
-	if bundleArgs.runtimeFromEnv {
-		maps.Copy(runtimeValues, engine.GetEnv())
-	}
-
-	if len(bundleArgs.runtimeFiles) > 0 {
-		kctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
-		defer cancel()
-
-		rt, err := buildRuntime(bundleArgs.runtimeFiles, bundleArgs.workdir)
-		if err != nil {
-			return err
-		}
-
-		clusters := rt.SelectClusters(bundleArgs.runtimeCluster, bundleArgs.runtimeClusterGroup)
-		if len(clusters) > 1 {
-			return errors.New("you must select a cluster with --runtime-cluster")
-		}
-		if len(clusters) == 0 {
-			return errors.New("no cluster found")
-		}
-
-		cluster := clusters[0]
-		workspace = cluster.Name
-		kubeconfigArgs.Context = &cluster.KubeContext
-
-		rm, err := runtime.NewResourceManager(kubeconfigArgs)
-		if err != nil {
-			return err
-		}
-
-		reader := runtime.NewResourceReader(rm)
-		rv, err := reader.Read(kctx, rt.Refs)
-		if err != nil {
-			return err
-		}
-
-		maps.Copy(runtimeValues, rv)
-		maps.Copy(runtimeValues, cluster.NameGroupValues())
+	workspace, runtimeValues, err := resolveBundleBuildRuntime(cmd)
+	if err != nil {
+		return err
 	}
 
 	if err := bm.InitWorkspace(workspace, runtimeValues); err != nil {
@@ -192,25 +160,144 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		modDirs[instance.Name] = modDir
 	}
 
-	if bundleBuildArgs.outputDir != "" {
-		return writeBundleInstancesToDir(cmd, bundle.Instances, modDirs)
+	// Build the instances concurrently, each in its own CUE context, and
+	// retain the objects in the order defined by the bundle.
+	objectsByInstance := make([][]*unstructured.Unstructured, len(bundle.Instances))
+	var vendoredCache *vendoredCRDCache
+	if bundleBuildArgs.validate {
+		vendoredCache = &vendoredCRDCache{crds: make(map[string][]*unstructured.Unstructured)}
 	}
-
-	// Build the instances concurrently, each in its own CUE context,
-	// and assemble the manifests in the order defined by the bundle.
-	manifests := make([]string, len(bundle.Instances))
 	eg := errgroup.Group{}
 	eg.SetLimit(buildConcurrency())
 	for i, instance := range bundle.Instances {
 		eg.Go(func() error {
-			objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name])
+			objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name], vendoredCache)
 			if err != nil {
 				return err
 			}
+			objectsByInstance[i] = objects
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
 
+	if bundleBuildArgs.validate {
+		if err := validateBundleInstanceObjects(cmd, bundle.Instances, modDirs, objectsByInstance, vendoredCache); err != nil {
+			return err
+		}
+	}
+
+	if bundleBuildArgs.outputDir != "" {
+		return writeBundleInstancesToDir(cmd, bundle.Instances, objectsByInstance)
+	}
+
+	return printBundleInstances(cmd, bundle.Instances, objectsByInstance)
+}
+
+// resolveBundleBuildRuntime returns the workspace name and the runtime values
+// for the bundle build: the process environment with --runtime-from-env, and
+// the values read from the single cluster selected by --runtime.
+func resolveBundleBuildRuntime(cmd *cobra.Command) (string, map[string]string, error) {
+	workspace := apiv1.RuntimeDefaultName
+	runtimeValues := make(map[string]string)
+
+	if bundleArgs.runtimeFromEnv {
+		maps.Copy(runtimeValues, engine.GetEnv())
+	}
+
+	if len(bundleArgs.runtimeFiles) == 0 {
+		return workspace, runtimeValues, nil
+	}
+
+	kctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
+	defer cancel()
+
+	rt, err := buildRuntime(bundleArgs.runtimeFiles, bundleArgs.workdir)
+	if err != nil {
+		return "", nil, err
+	}
+
+	clusters := rt.SelectClusters(bundleArgs.runtimeCluster, bundleArgs.runtimeClusterGroup)
+	if len(clusters) > 1 {
+		return "", nil, errors.New("you must select a cluster with --runtime-cluster")
+	}
+	if len(clusters) == 0 {
+		return "", nil, errors.New("no cluster found")
+	}
+
+	cluster := clusters[0]
+	workspace = cluster.Name
+	kubeconfigArgs.Context = &cluster.KubeContext
+
+	rm, err := runtime.NewResourceManager(kubeconfigArgs)
+	if err != nil {
+		return "", nil, err
+	}
+
+	reader := runtime.NewResourceReader(rm)
+	rv, err := reader.Read(kctx, rt.Refs)
+	if err != nil {
+		return "", nil, err
+	}
+
+	maps.Copy(runtimeValues, rv)
+	maps.Copy(runtimeValues, cluster.NameGroupValues())
+
+	return workspace, runtimeValues, nil
+}
+
+// validateBundleInstanceObjects validates the custom resources of all the
+// instances against the vendored CRDs, registered once per module, and the
+// CRDs rendered by the instances in bundle order; the rendered CRDs take
+// precedence for the same kind versions.
+func validateBundleInstanceObjects(cmd *cobra.Command, instances []*apiv1.BundleInstance, modDirs map[string]string,
+	objectsByInstance [][]*unstructured.Unstructured, vendoredCache *vendoredCRDCache) error {
+	crdValidator := engine.NewCRDValidator()
+	registered := make(map[string]bool)
+	for _, instance := range instances {
+		modDir := modDirs[instance.Name]
+		if registered[modDir] {
+			continue
+		}
+		registered[modDir] = true
+		vendoredCRDs, _ := vendoredCache.get(modDir)
+		if err := crdValidator.AddVendoredCRDs(vendoredCRDs); err != nil {
+			return fmt.Errorf("validation failed: %w", err)
+		}
+	}
+	for _, objects := range objectsByInstance {
+		if err := crdValidator.AddCRDs(objects); err != nil {
+			return fmt.Errorf("validation failed: %w", err)
+		}
+	}
+
+	invalid := 0
+	log := LoggerFrom(cmd.Context())
+	for i, objects := range objectsByInstance {
+		validationErrs := crdValidator.ValidateObjects(cmd.Context(), objects)
+		invalid += logValidationErrors(log, validationErrs, instances[i].Name)
+	}
+	if invalid > 0 {
+		return fmt.Errorf("validation failed, %d invalid custom resource(s)", invalid)
+	}
+	return nil
+}
+
+// printBundleInstances marshals the objects of each instance to YAML
+// concurrently, masking the Secret values with --mask-secrets, and writes
+// the manifests to the command output in the order defined by the bundle.
+func printBundleInstances(cmd *cobra.Command, instances []*apiv1.BundleInstance, objectsByInstance [][]*unstructured.Unstructured) error {
+	manifests := make([]string, len(instances))
+	eg := errgroup.Group{}
+	eg.SetLimit(buildConcurrency())
+	for i := range instances {
+		eg.Go(func() error {
+			objects := objectsByInstance[i]
 			if bundleBuildArgs.maskSecrets {
-				for i, obj := range objects {
-					objects[i] = mask.SecretData(obj)
+				for j, obj := range objects {
+					objects[j] = mask.SecretData(obj)
 				}
 			}
 
@@ -218,7 +305,6 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 			if err != nil {
 				return err
 			}
-
 			manifests[i] = m
 			return nil
 		})
@@ -228,12 +314,12 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 	}
 
 	var sb strings.Builder
-	for i, instance := range bundle.Instances {
+	for i, instance := range instances {
 		sb.WriteString("---\n")
 		sb.WriteString(fmt.Sprintf("# Instance: %s\n", instance.Name))
 		sb.WriteString("---\n")
 		sb.WriteString(manifests[i])
-		if i < len(bundle.Instances)-1 {
+		if i < len(instances)-1 {
 			sb.WriteString("\n")
 		}
 	}
@@ -260,28 +346,23 @@ func buildConcurrency() int {
 	return min(goruntime.NumCPU(), 8)
 }
 
-// writeBundleInstancesToDir writes the resources of each instance to the
-// output directory as a tree: one directory per instance and one file per
-// resource, named with the same convention as 'kustomize build -o <dir>'.
-func writeBundleInstancesToDir(cmd *cobra.Command, instances []*apiv1.BundleInstance, modDirs map[string]string) error {
+// writeBundleInstancesToDir writes previously built resources to the output
+// directory as a tree: one directory per instance and one file per resource,
+// named with the same convention as 'kustomize build -o <dir>'.
+func writeBundleInstancesToDir(cmd *cobra.Command, instances []*apiv1.BundleInstance, objectsByInstance [][]*unstructured.Unstructured) error {
 	outputDir := bundleBuildArgs.outputDir
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	// Build the instances and write their resources concurrently, each
-	// instance in its own CUE context and its own directory, then report
-	// the results in the order defined by the bundle.
+	// Write each instance to its own directory concurrently, then report the
+	// results in the order defined by the bundle.
 	exported := make([]string, len(instances))
 	eg := errgroup.Group{}
 	eg.SetLimit(buildConcurrency())
 	for i, instance := range instances {
 		eg.Go(func() error {
-			objects, err := buildBundleInstanceObjects(instance, modDirs[instance.Name])
-			if err != nil {
-				return err
-			}
-
+			objects := objectsByInstance[i]
 			instanceDir := filepath.Join(outputDir, instance.Name)
 			if err := os.MkdirAll(instanceDir, 0o755); err != nil {
 				return fmt.Errorf("failed to create instance directory: %w", err)
@@ -357,14 +438,38 @@ func resourceFileName(obj *unstructured.Unstructured, withNamespace bool) string
 	return fileName
 }
 
+// vendoredCRDCache stores extracted vendored CRDs by module directory.
+type vendoredCRDCache struct {
+	mu   sync.Mutex
+	crds map[string][]*unstructured.Unstructured
+}
+
+// get returns the cached vendored CRDs for a module directory.
+func (c *vendoredCRDCache) get(modDir string) ([]*unstructured.Unstructured, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	crds, ok := c.crds[modDir]
+	return crds, ok
+}
+
+// put caches vendored CRDs for a module directory.
+func (c *vendoredCRDCache) put(modDir string, crds []*unstructured.Unstructured) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.crds[modDir] = crds
+}
+
 // buildBundleInstanceObjects builds an instance and returns its sorted
 // Kubernetes objects. The instance is compiled in its own CUE context so
 // that the memory used during the build can be reclaimed once the objects
-// are extracted, keeping the peak usage constant regardless of how many
-// instances a bundle contains. The module directory is shared between the
-// instances referencing the same module version and is never modified; the
-// instance schema and values are injected as in-memory overlays.
-func buildBundleInstanceObjects(instance *apiv1.BundleInstance, modDir string) ([]*unstructured.Unstructured, error) {
+// are extracted, leaving only the rendered objects of the built instances
+// in memory until they are written. The module directory is shared between
+// the instances referencing the same module version and is never modified;
+// the instance schema and values are injected as in-memory overlays.
+// When a cache is given, the CRDs vendored in the module are extracted
+// while the CUE context is alive and stored in the cache under the module
+// directory, unless another instance of the same module stored them already.
+func buildBundleInstanceObjects(instance *apiv1.BundleInstance, modDir string, cache *vendoredCRDCache) ([]*unstructured.Unstructured, error) {
 	builder := engine.NewModuleBuilder(
 		nil,
 		instance.Name,
@@ -404,6 +509,16 @@ func buildBundleInstanceObjects(instance *apiv1.BundleInstance, modDir string) (
 		objects = append(objects, set.Objects...)
 	}
 	sort.Sort(ssa.SortableUnstructureds(objects))
+
+	if cache != nil {
+		if _, found := cache.get(modDir); !found {
+			vendoredCRDs, err := builder.GetVendoredCRDs()
+			if err != nil {
+				return nil, fmt.Errorf("failed to extract vendored CRDs: %w", err)
+			}
+			cache.put(modDir, vendoredCRDs)
+		}
+	}
 
 	return objects, nil
 }

--- a/cmd/timoni/bundle_build_test.go
+++ b/cmd/timoni/bundle_build_test.go
@@ -710,3 +710,118 @@ bundle: {
 		g.Expect(out.Len()).To(BeZero())
 	})
 }
+
+func Test_BundleBuild_CustomResourceValidation(t *testing.T) {
+	g := NewWithT(t)
+
+	celURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("module-cel"))
+	crURL := fmt.Sprintf("%s/%s", dockerRegistry, rnd("module-cel-cr"))
+	for _, module := range []struct {
+		path string
+		url  string
+	}{
+		{path: "testdata/module-cel", url: celURL},
+		{path: "testdata/module-cel-cr", url: crURL},
+	} {
+		_, err := executeCommand(fmt.Sprintf(
+			"mod push %s oci://%s -v 1.0.0 --resolve-symlinks",
+			module.path, module.url,
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	writeBundle := func(instances string) string {
+		path := filepath.Join(t.TempDir(), "bundle.cue")
+		data := fmt.Sprintf(`
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "validation"
+	instances: {
+%s
+	}
+}
+`, instances)
+		g.Expect(os.WriteFile(path, []byte(data), 0o644)).To(Succeed())
+		return path
+	}
+
+	twoCELInstances := fmt.Sprintf(`
+		valid: {
+			module: {url: "oci://%[1]s", version: "1.0.0"}
+			namespace: "apps"
+		}
+		invalid: {
+			module: {url: "oci://%[1]s", version: "1.0.0"}
+			namespace: "apps"
+			values: minReplicas: 5
+		}`, celURL)
+
+	t.Run("fails before writing stdout for an invalid instance", func(t *testing.T) {
+		g := NewWithT(t)
+		stdout, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"bundle build -f %s -p main", writeBundle(twoCELInstances),
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("validation failed, 1 invalid custom resource(s)"))
+		g.Expect(stdout).To(BeEmpty())
+		g.Expect(stderr).To(ContainSubstring("instance invalid: Widget/apps/invalid spec: minReplicas must not exceed replicas"))
+	})
+
+	t.Run("fails before writing the output directory", func(t *testing.T) {
+		g := NewWithT(t)
+		outputDir := filepath.Join(t.TempDir(), "manifests")
+		_, _, err := executeCommandWithOutErr(fmt.Sprintf(
+			"bundle build -f %s -p main --output-dir %s", writeBundle(twoCELInstances), outputDir,
+		))
+		g.Expect(err).To(HaveOccurred())
+		_, statErr := os.Stat(outputDir)
+		g.Expect(os.IsNotExist(statErr)).To(BeTrue())
+	})
+
+	crossInstance := fmt.Sprintf(`
+		crd: {
+			module: {url: "oci://%[1]s", version: "1.0.0"}
+			namespace: "apps"
+		}
+		app: {
+			module: {url: "oci://%[2]s", version: "1.0.0"}
+			namespace: "apps"
+			values: minReplicas: 5
+		}`, celURL, crURL)
+
+	t.Run("uses CRDs rendered by another instance", func(t *testing.T) {
+		g := NewWithT(t)
+		stdout, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"bundle build -f %s -p main", writeBundle(crossInstance),
+		))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(stdout).To(BeEmpty())
+		g.Expect(stderr).To(ContainSubstring("instance app: Widget/apps/app spec: minReplicas must not exceed replicas"))
+	})
+
+	crOnly := fmt.Sprintf(`
+		app: {
+			module: {url: "oci://%[1]s", version: "1.0.0"}
+			namespace: "apps"
+			values: minReplicas: 5
+		}`, crURL)
+
+	t.Run("skips custom resources without a known schema", func(t *testing.T) {
+		g := NewWithT(t)
+		stdout, stderr, err := executeCommandWithOutErr(fmt.Sprintf(
+			"bundle build -f %s -p main", writeBundle(crOnly),
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stdout).To(ContainSubstring("kind: Widget"))
+		g.Expect(stderr).To(BeEmpty())
+	})
+
+	t.Run("can disable custom resource validation", func(t *testing.T) {
+		g := NewWithT(t)
+		stdout, _, err := executeCommandWithOutErr(fmt.Sprintf(
+			"bundle build -f %s -p main --validate=false", writeBundle(twoCELInstances),
+		))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stdout).To(ContainSubstring("# Instance: invalid"))
+	})
+}

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -183,7 +183,7 @@ func executeCommandWithStreams(cmd string, in io.Reader, stdout, stderr io.Write
 func resetCmdArgs() {
 	applyArgs = applyFlags{}
 	fmtArgs = fmtFlags{}
-	buildArgs = buildFlags{output: "yaml"}
+	buildArgs = buildFlags{output: "yaml", validate: true}
 	deleteArgs = deleteFlags{}
 	statusArgs = statusFlags{}
 	inspectModuleArgs = inspectModuleFlags{}
@@ -201,11 +201,11 @@ func resetCmdArgs() {
 	pushModArgs = pushModFlags{}
 	buildModArgs = buildModFlags{format: "oci-archive"}
 	bundleArgs = bundleFlags{}
-	bundleApplyArgs = bundleApplyFlags{}
+	bundleApplyArgs = bundleApplyFlags{validate: true}
 	bundleVetArgs = bundleVetFlags{}
 	bundleUpdateArgs = bundleUpdateFlags{level: engine.UpdateLevelNone}
 	bundleDelArgs = bundleDelFlags{}
-	bundleBuildArgs = bundleBuildFlags{}
+	bundleBuildArgs = bundleBuildFlags{validate: true}
 	vendorCrdArgs = vendorCrdFlags{}
 	vendorK8sArgs = vendorK8sFlags{}
 	pushArtifactArgs = pushArtifactFlags{

--- a/cmd/timoni/mod_vet.go
+++ b/cmd/timoni/mod_vet.go
@@ -181,15 +181,14 @@ func runVetModCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("build failed, no objects to apply")
 	}
 
-	// Register the CRD schemas vendored in the imported packages first,
-	// so that the CRDs rendered by the module take precedence for the
-	// same kind versions.
-	imports, err := builder.GetImports()
+	// The CRDs rendered by the module take precedence over the schemas
+	// vendored in the imported packages for the same kind versions.
+	vendoredCRDs, err := builder.GetVendoredCRDs()
 	if err != nil {
 		return fmt.Errorf("build failed: %w", err)
 	}
 	crdValidator := engine.NewCRDValidator()
-	if err := crdValidator.AddPackages(imports); err != nil {
+	if err := crdValidator.AddVendoredCRDs(vendoredCRDs); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 	if err := crdValidator.AddCRDs(objects); err != nil {

--- a/cmd/timoni/testdata/module-cel-cr/cue.mod/module.cue
+++ b/cmd/timoni/testdata/module-cel-cr/cue.mod/module.cue
@@ -1,0 +1,2 @@
+module: "timoni.sh/test-cel-cr"
+language: version: "v0.17.1"

--- a/cmd/timoni/testdata/module-cel-cr/timoni.cue
+++ b/cmd/timoni/testdata/module-cel-cr/timoni.cue
@@ -1,0 +1,31 @@
+package main
+
+values: {
+	replicas:    *3 | int
+	minReplicas: *1 | int
+}
+
+timoni: {
+	apiVersion: "v1alpha1"
+
+	instance: {
+		config: metadata: {
+			name:      string @tag(name)
+			namespace: string @tag(namespace)
+		}
+		objects: widget: {
+			apiVersion: "testing.timoni.sh/v1"
+			kind:       "Widget"
+			metadata: {
+				name:      config.metadata.name
+				namespace: config.metadata.namespace
+			}
+			spec: {
+				replicas:    values.replicas
+				minReplicas: values.minReplicas
+			}
+		}
+	}
+
+	apply: app: [for obj in instance.objects {obj}]
+}

--- a/cmd/timoni/testdata/module-cel-cr/values.cue
+++ b/cmd/timoni/testdata/module-cel-cr/values.cue
@@ -3,8 +3,6 @@
 package main
 
 values: {
-	replicas:        3
-	minReplicas:     1
-	size:            "small"
-	customResources: true
+	replicas:    3
+	minReplicas: 1
 }

--- a/cmd/timoni/testdata/module-cel/timoni.cue
+++ b/cmd/timoni/testdata/module-cel/timoni.cue
@@ -6,9 +6,10 @@ import (
 
 // Define the schema for the user-supplied values.
 values: {
-	replicas:    *3 | int
-	minReplicas: *1 | int
-	size:        *"small" | string
+	replicas:        *3 | int
+	minReplicas:     *1 | int
+	size:            *"small" | string
+	customResources: *true | bool
 }
 
 // Define how Timoni should build, validate and
@@ -22,9 +23,10 @@ timoni: {
 				name:      string @tag(name)
 				namespace: string @tag(namespace)
 			}
-			replicas:    values.replicas
-			minReplicas: values.minReplicas
-			size:        values.size
+			replicas:        values.replicas
+			minReplicas:     values.minReplicas
+			size:            values.size
+			customResources: values.customResources
 		}
 
 		objects: {
@@ -65,26 +67,28 @@ timoni: {
 				}
 			}
 
-			widget: {
-				apiVersion: "testing.timoni.sh/v1"
-				kind:       "Widget"
-				metadata: {
-					name:      config.metadata.name
-					namespace: config.metadata.namespace
+			if config.customResources {
+				widget: {
+					apiVersion: "testing.timoni.sh/v1"
+					kind:       "Widget"
+					metadata: {
+						name:      config.metadata.name
+						namespace: config.metadata.namespace
+					}
+					spec: {
+						replicas:    config.replicas
+						minReplicas: config.minReplicas
+					}
 				}
-				spec: {
-					replicas:    config.replicas
-					minReplicas: config.minReplicas
-				}
-			}
 
-			// The Gadget CRD is vendored in cue.mod/gen along with its CEL rules.
-			gadget: gadgetv1.#Gadget & {
-				metadata: {
-					name:      config.metadata.name
-					namespace: config.metadata.namespace
+				// The Gadget CRD is vendored in cue.mod/gen along with its CEL rules.
+				gadget: gadgetv1.#Gadget & {
+					metadata: {
+						name:      config.metadata.name
+						namespace: config.metadata.namespace
+					}
+					spec: size: config.size
 				}
-				spec: size: config.size
 			}
 		}
 	}

--- a/docs/bundle.mdx
+++ b/docs/bundle.mdx
@@ -385,6 +385,11 @@ The apply command performs the following actions for each instance:
 - Applies the Kubernetes resources on the cluster.
 - Creates or updates the instance inventory with the last applied resources IDs.
 
+Before applying an instance, Timoni validates its custom resources against the
+CRD schemas vendored in the module and the CRDs rendered by the instance and by
+the earlier instances of the bundle. A violation fails the apply before the
+instance is written to the cluster. Use `--validate=false` to disable the validation.
+
 ### Diff Upgrade
 
 After editing a bundle file, you can review the changes that will
@@ -458,6 +463,15 @@ Example:
 ```shell
 timoni bundle build -f bundle.cue
 ```
+
+#### Validation
+
+The custom resources of every instance are validated against the CRD schemas
+vendored in the modules and the CRDs rendered by any instance of the bundle, with
+the same checks as the Kubernetes API server, see
+[custom resource validation](/cue/module/custom-resources#custom-resource-validation).
+A violation fails the build before anything is written to stdout or to the output
+directory. Use `--validate=false` to disable the validation.
 
 To print the manifests without exposing credentials, for example when sharing
 the output or reviewing it in a CI log, use the `--mask-secrets` flag which

--- a/docs/cue/module/custom-resources.mdx
+++ b/docs/cue/module/custom-resources.mdx
@@ -201,3 +201,9 @@ vetting with debug values
 HTTPRoute/default/app spec.endpoints: spec.rules[0].filters[0]: filter.requestRedirect must be specified for RequestRedirect filter.type
 validation failed, 1 invalid custom resource(s)
 ```
+
+The same checks run in `timoni build`, `timoni bundle build` and `timoni bundle apply`,
+where only the violations are reported and `--validate=false` disables the validation.
+In a bundle, the custom resources of an instance are also validated against the
+CRDs rendered by the other instances, with `bundle apply` by the instances applied
+before it, see [bundle validation](/bundle#validation).

--- a/internal/engine/crd_validator.go
+++ b/internal/engine/crd_validator.go
@@ -71,24 +71,6 @@ func NewCRDValidator() *CRDValidator {
 	return &CRDValidator{schemas: make(map[schema.GroupVersionKind]*crdSchema)}
 }
 
-// AddPackages registers the CRD schemas embedded by 'timoni mod vendor crd'
-// in the given CUE packages, ignoring packages without an embedded schema.
-func (v *CRDValidator) AddPackages(packages []ModuleImport) error {
-	for _, pkg := range packages {
-		crd, found, err := embeddedCRD(pkg.Value)
-		if err != nil {
-			return fmt.Errorf("invalid %s field in package %s: %w", crdField, pkg.Path, err)
-		}
-		if !found {
-			continue
-		}
-		if err := v.AddCRD(crd); err != nil {
-			return fmt.Errorf("invalid %s field in package %s: %w", crdField, pkg.Path, err)
-		}
-	}
-	return nil
-}
-
 // AddCRDs registers the schemas of the CustomResourceDefinitions found in
 // the given objects, ignoring objects of any other kind.
 func (v *CRDValidator) AddCRDs(objects []*unstructured.Unstructured) error {
@@ -103,12 +85,32 @@ func (v *CRDValidator) AddCRDs(objects []*unstructured.Unstructured) error {
 	return nil
 }
 
+// AddVendoredCRDs registers the schemas of the given CustomResourceDefinitions
+// vendored with 'timoni mod vendor crd', skipping the kind versions already
+// registered, so that the CRDs added with AddCRDs take precedence over the
+// vendored schemas regardless of the registration order.
+func (v *CRDValidator) AddVendoredCRDs(crds []*unstructured.Unstructured) error {
+	for _, crd := range crds {
+		if err := v.addCRD(crd, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // AddCRD registers the schema of every version of the given
 // CustomResourceDefinition, replacing schemas previously registered
 // for the same kind versions. A version whose schema cannot be compiled
 // is registered with the compilation error, reported by Validate for
 // every object of that kind version.
 func (v *CRDValidator) AddCRD(crd *unstructured.Unstructured) error {
+	return v.addCRD(crd, false)
+}
+
+// addCRD registers the schema of every version of the given
+// CustomResourceDefinition, skipping the kind versions already registered
+// when keepExisting is set.
+func (v *CRDValidator) addCRD(crd *unstructured.Unstructured, keepExisting bool) error {
 	group, versions, err := crdVersions(crd)
 	if err != nil {
 		return err
@@ -118,6 +120,9 @@ func (v *CRDValidator) AddCRD(crd *unstructured.Unstructured) error {
 
 	for _, ver := range versions {
 		gvk := schema.GroupVersionKind{Group: group, Version: ver.name, Kind: kind}
+		if _, registered := v.schemas[gvk]; registered && keepExisting {
+			continue
+		}
 		s := &crdSchema{
 			pruneUnknown: !preserveUnknown,
 			dropStatus:   ver.statusSubresource,
@@ -203,6 +208,38 @@ func (v *CRDValidator) Validate(ctx context.Context, object *unstructured.Unstru
 	errs := make([]error, 0, len(msgs))
 	for _, msg := range msgs {
 		errs = append(errs, errors.New(msg))
+	}
+	return errs
+}
+
+// ValidationError is a violation found by ValidateObjects in the
+// custom resource identified by its kind, namespace and name.
+type ValidationError struct {
+	Object string
+	Err    error
+}
+
+// Error returns the object identifier followed by the violation.
+func (e ValidationError) Error() string {
+	return e.Object + " " + e.Err.Error()
+}
+
+// Unwrap returns the violation.
+func (e ValidationError) Unwrap() error {
+	return e.Err
+}
+
+// ValidateObjects checks every object with a registered schema and returns
+// one ValidationError per violation, in the order of the objects.
+func (v *CRDValidator) ValidateObjects(ctx context.Context, objects []*unstructured.Unstructured) []ValidationError {
+	var errs []ValidationError
+	for _, object := range objects {
+		if !v.HasSchema(object.GroupVersionKind()) {
+			continue
+		}
+		for _, err := range v.Validate(ctx, object) {
+			errs = append(errs, ValidationError{Object: ssautil.FmtUnstructured(object), Err: err})
+		}
 	}
 	return errs
 }

--- a/internal/engine/crd_validator_test.go
+++ b/internal/engine/crd_validator_test.go
@@ -621,6 +621,69 @@ func TestCRDValidator_AddCRDs(t *testing.T) {
 	g.Expect(v.HasSchema(objects[0].GroupVersionKind())).To(BeTrue())
 }
 
+func TestCRDValidator_AddVendoredCRDs(t *testing.T) {
+	rendered := readTestCRD(t, testCRDWithRules)
+	vendored := readTestCRD(t, strings.ReplaceAll(testCRDWithRules,
+		"minReplicas must not exceed replicas", "vendored rule"))
+	invalid := newTestWidget("v1", map[string]any{
+		"replicas":    int64(1),
+		"minReplicas": int64(5),
+	})
+
+	t.Run("does not replace a rendered schema", func(t *testing.T) {
+		g := NewWithT(t)
+		v := NewCRDValidator()
+		g.Expect(v.AddCRDs([]*unstructured.Unstructured{rendered})).To(Succeed())
+		g.Expect(v.AddVendoredCRDs([]*unstructured.Unstructured{vendored})).To(Succeed())
+
+		errs := v.Validate(context.Background(), invalid)
+		g.Expect(errs).To(HaveLen(1))
+		g.Expect(errs[0].Error()).To(ContainSubstring("minReplicas must not exceed replicas"))
+	})
+
+	t.Run("is replaced by a rendered schema", func(t *testing.T) {
+		g := NewWithT(t)
+		v := NewCRDValidator()
+		g.Expect(v.AddVendoredCRDs([]*unstructured.Unstructured{vendored})).To(Succeed())
+		g.Expect(v.AddCRDs([]*unstructured.Unstructured{rendered})).To(Succeed())
+
+		errs := v.Validate(context.Background(), invalid)
+		g.Expect(errs).To(HaveLen(1))
+		g.Expect(errs[0].Error()).To(ContainSubstring("minReplicas must not exceed replicas"))
+	})
+
+	t.Run("keeps the first vendored schema", func(t *testing.T) {
+		g := NewWithT(t)
+		v := NewCRDValidator()
+		g.Expect(v.AddVendoredCRDs([]*unstructured.Unstructured{vendored})).To(Succeed())
+		g.Expect(v.AddVendoredCRDs([]*unstructured.Unstructured{rendered})).To(Succeed())
+
+		errs := v.Validate(context.Background(), invalid)
+		g.Expect(errs).To(HaveLen(1))
+		g.Expect(errs[0].Error()).To(ContainSubstring("vendored rule"))
+	})
+}
+
+func TestCRDValidator_ValidateObjects(t *testing.T) {
+	g := NewWithT(t)
+	v := NewCRDValidator()
+	g.Expect(v.AddCRD(readTestCRD(t, testCRDWithRules))).To(Succeed())
+
+	unknown := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "test", "namespace": "default"},
+	}}
+	invalid := newTestWidget("v1", map[string]any{
+		"replicas":    int64(1),
+		"minReplicas": int64(5),
+	})
+
+	errs := v.ValidateObjects(context.Background(), []*unstructured.Unstructured{unknown, invalid})
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0]).To(MatchError("Widget/default/test spec: minReplicas must not exceed replicas"))
+}
+
 // writeTestModule writes a module importing the given CUE packages,
 // each placed under cue.mod at the given relative directory.
 func writeTestModule(t *testing.T, packages map[string]string) string {
@@ -714,7 +777,7 @@ func TestImporter_EmbeddedCRD(t *testing.T) {
 	})
 }
 
-func TestCRDValidator_AddPackages(t *testing.T) {
+func TestModuleBuilder_GetVendoredCRDs(t *testing.T) {
 	g := NewWithT(t)
 	widgetV1 := schema.GroupVersionKind{Group: "testing.timoni.sh", Version: "v1", Kind: "Widget"}
 	widgetV2 := schema.GroupVersionKind{Group: "testing.timoni.sh", Version: "v2", Kind: "Widget"}
@@ -733,12 +796,12 @@ func TestCRDValidator_AddPackages(t *testing.T) {
 		_, err := builder.Build()
 		g.Expect(err).ToNot(HaveOccurred())
 
-		imports, err := builder.GetImports()
+		vendoredCRDs, err := builder.GetVendoredCRDs()
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(imports).To(HaveLen(2))
+		g.Expect(vendoredCRDs).To(HaveLen(2))
 
 		v := NewCRDValidator()
-		g.Expect(v.AddPackages(imports)).To(Succeed())
+		g.Expect(v.AddVendoredCRDs(vendoredCRDs)).To(Succeed())
 		g.Expect(v.HasSchema(widgetV1)).To(BeTrue())
 		g.Expect(v.HasSchema(widgetV2)).To(BeTrue())
 
@@ -776,11 +839,12 @@ func TestCRDValidator_AddPackages(t *testing.T) {
 		_, err := builder.Build()
 		g.Expect(err).ToNot(HaveOccurred())
 
-		imports, err := builder.GetImports()
+		vendoredCRDs, err := builder.GetVendoredCRDs()
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(vendoredCRDs).To(BeEmpty())
 
 		v := NewCRDValidator()
-		g.Expect(v.AddPackages(imports)).To(Succeed())
+		g.Expect(v.AddVendoredCRDs(vendoredCRDs)).To(Succeed())
 		g.Expect(v.HasSchema(widgetV1)).To(BeFalse())
 	})
 
@@ -793,11 +857,7 @@ func TestCRDValidator_AddPackages(t *testing.T) {
 		_, err := builder.Build()
 		g.Expect(err).ToNot(HaveOccurred())
 
-		imports, err := builder.GetImports()
-		g.Expect(err).ToNot(HaveOccurred())
-
-		v := NewCRDValidator()
-		err = v.AddPackages(imports)
+		_, err = builder.GetVendoredCRDs()
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("invalid _crd field in package testing.timoni.sh/widget/v1"))
 	})
@@ -835,19 +895,18 @@ import p "testing.timoni.sh/widget/v1"
 		_, err := builder.Build()
 		g.Expect(err).ToNot(HaveOccurred())
 
-		imports, err := builder.GetImports()
+		vendoredCRDs, err := builder.GetVendoredCRDs()
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(imports).To(HaveLen(1))
-		g.Expect(imports[0].Path).To(Equal("testing.timoni.sh/widget/v1"))
+		g.Expect(vendoredCRDs).To(HaveLen(1))
 
 		v := NewCRDValidator()
-		g.Expect(v.AddPackages(imports)).To(Succeed())
+		g.Expect(v.AddVendoredCRDs(vendoredCRDs)).To(Succeed())
 		g.Expect(v.HasSchema(widgetV1)).To(BeTrue())
 	})
 
 	t.Run("requires a built module", func(t *testing.T) {
 		builder := NewModuleBuilder(cuecontext.New(), "test", "default", t.TempDir(), defaultPackage)
-		_, err := builder.GetImports()
+		_, err := builder.GetVendoredCRDs()
 		g.Expect(err).To(MatchError("module not built"))
 	})
 }

--- a/internal/engine/module_builder.go
+++ b/internal/engine/module_builder.go
@@ -29,6 +29,7 @@ import (
 	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/load"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 )
@@ -274,6 +275,28 @@ func (b *ModuleBuilder) GetImports() ([]ModuleImport, error) {
 		return nil, err
 	}
 	return values, nil
+}
+
+// GetVendoredCRDs returns the CustomResourceDefinitions embedded in the CUE
+// packages imported by the module compiled with Build. Packages without an
+// embedded CustomResourceDefinition are ignored.
+func (b *ModuleBuilder) GetVendoredCRDs() ([]*unstructured.Unstructured, error) {
+	imports, err := b.GetImports()
+	if err != nil {
+		return nil, err
+	}
+
+	var crds []*unstructured.Unstructured
+	for _, pkg := range imports {
+		crd, found, err := embeddedCRD(pkg.Value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s field in package %s: %w", crdField, pkg.Path, err)
+		}
+		if found {
+			crds = append(crds, crd)
+		}
+	}
+	return crds, nil
 }
 
 // GetAPIVersion returns the list of API version of the Timoni's CUE definition.

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author: Stefan Prodan
   homepage: https://timoni.sh
   source: https://github.com/stefanprodan/timoni
-  version: "0.2.0"
+  version: "0.3.0"
 ---
 
 # Timoni
@@ -324,8 +324,9 @@ myapp/
   stale definitions of the file's API groups. `timoni mod vet`
   validates the module's custom resources against the vendored CRDs and the
   CRDs rendered by the module with the API server checks (OpenAPI schema,
-  list map/set uniqueness, CEL rules). Add `timoni: healthChecks:` entries for
-  CRs that are not kstatus-compliant.
+  list map/set uniqueness, CEL rules). The same checks run in `build`,
+  `bundle build` and `bundle apply`, `--validate=false` disables them.
+  Add `timoni: healthChecks:` entries for CRs that are not kstatus-compliant.
 - Test jobs: emit Jobs in a final `apply: test:` set with the
   `action.timoni.sh/force: "enabled"` annotation and a checksum of the config
   in the pod template; the Job is recreated when that checksum changes, not on


### PR DESCRIPTION
Run the CRD schema and CEL checks of `mod vet` on the custom resources rendered by `timoni build`, `bundle build` and `bundle apply`, using the CRDs vendored in the modules and the CRDs rendered by any instance of the bundle. A violation fails the command before anything is written. The validation can be disabled with  `--validate=false`.