### PR TITLE
fix(runtime): fail fast on health check schema errors

### DIFF
--- a/internal/engine/healthcheck_test.go
+++ b/internal/engine/healthcheck_test.go
@@ -341,7 +341,7 @@ timoni: {
 }
 `)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(checks).To(HaveLen(18))
+	g.Expect(checks).To(HaveLen(19))
 
 	byKind := make(map[string]*HealthCheck, len(checks))
 	for _, hc := range checks {
@@ -351,7 +351,7 @@ timoni: {
 		g.Expect(byKind).To(HaveKey(kind))
 		g.Expect(byKind[kind].GroupKind.Group).To(BeEquivalentTo("gateway.networking.k8s.io"))
 	}
-	for _, kind := range []string{"XListenerSet", "XBackendTrafficPolicy", "XMesh"} {
+	for _, kind := range []string{"XListenerSet", "XBackendTrafficPolicy", "XBackend", "XMesh"} {
 		g.Expect(byKind).To(HaveKey(kind))
 		g.Expect(byKind[kind].GroupKind.Group).To(BeEquivalentTo("gateway.networking.x-k8s.io"))
 	}
@@ -540,6 +540,79 @@ timoni: {
 			expect: HealthStatusInProgress,
 		},
 		{
+			// The live object carries the full route spec and the
+			// controller name in the status: the #object schema must
+			// stay open beyond the fields the check evaluates.
+			name: "route with hostnames and rules is current",
+			kind: "HTTPRoute",
+			object: map[string]any{
+				"apiVersion": "gateway.networking.k8s.io/v1",
+				"kind":       "HTTPRoute",
+				"metadata": map[string]any{
+					"name":       "app",
+					"namespace":  "apps",
+					"generation": int64(2),
+					"labels":     map[string]any{"app.kubernetes.io/name": "app"},
+				},
+				"spec": map[string]any{
+					"parentRefs": []any{ref("gw-a")},
+					"hostnames":  []any{"app.example.com"},
+					"rules": []any{map[string]any{
+						"matches":     []any{map[string]any{"path": map[string]any{"type": "PathPrefix", "value": "/"}}},
+						"backendRefs": []any{map[string]any{"name": "app", "port": int64(80)}},
+					}},
+				},
+				"status": map[string]any{
+					"parents": []any{
+						map[string]any{
+							"parentRef":      ref("gw-a"),
+							"controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+							"conditions": []any{
+								condition("Accepted", "True", 2),
+								condition("ResolvedRefs", "True", 2),
+							},
+						},
+					},
+				},
+			},
+			expect: HealthStatusCurrent,
+		},
+		{
+			// Controllers may leave out of the reported ref the fields
+			// they consider implied, e.g. the namespace of a parent in
+			// the route namespace; the entry still matches the spec ref.
+			name: "route parent reported without the implied fields is current",
+			kind: "HTTPRoute",
+			object: map[string]any{
+				"metadata": map[string]any{"namespace": "apps", "generation": int64(2)},
+				"spec": map[string]any{"parentRefs": []any{
+					map[string]any{"name": "gw-a", "namespace": "apps", "group": "gateway.networking.k8s.io", "kind": "Gateway"},
+				}},
+				"status": map[string]any{
+					"parents": []any{
+						parent(map[string]any{"name": "gw-a"}, condition("Accepted", "True", 2)),
+					},
+				},
+			},
+			expect: HealthStatusCurrent,
+		},
+		{
+			name: "route parent reported with a different namespace is in progress",
+			kind: "HTTPRoute",
+			object: map[string]any{
+				"metadata": map[string]any{"namespace": "apps", "generation": int64(2)},
+				"spec": map[string]any{"parentRefs": []any{
+					map[string]any{"name": "gw-a", "namespace": "apps"},
+				}},
+				"status": map[string]any{
+					"parents": []any{
+						parent(map[string]any{"name": "gw-a", "namespace": "infra"}, condition("Accepted", "True", 2)),
+					},
+				},
+			},
+			expect: HealthStatusInProgress,
+		},
+		{
 			name: "programmed listener set is current",
 			kind: "ListenerSet",
 			object: map[string]any{
@@ -612,6 +685,97 @@ timoni: {
 				},
 			},
 			expect: HealthStatusInProgress,
+		},
+		{
+			name: "policy with the full spec and ancestor status is current",
+			kind: "BackendTLSPolicy",
+			object: map[string]any{
+				"metadata": map[string]any{"name": "tls", "namespace": "apps", "generation": int64(1)},
+				"spec": map[string]any{
+					"targetRefs": []any{map[string]any{"group": "", "kind": "Service", "name": "app"}},
+					"validation": map[string]any{"hostname": "app.example.com", "wellKnownCACertificates": "System"},
+				},
+				"status": map[string]any{
+					"ancestors": []any{map[string]any{
+						"ancestorRef":    ref("gw-a"),
+						"controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+						"conditions":     []any{condition("Accepted", "True", 1), condition("ResolvedRefs", "True", 1)},
+					}},
+				},
+			},
+			expect: HealthStatusCurrent,
+		},
+		{
+			name: "policy with no ancestors is in progress",
+			kind: "XBackendTrafficPolicy",
+			object: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+				"status":   map[string]any{"ancestors": []any{}},
+			},
+			expect: HealthStatusInProgress,
+		},
+		{
+			name: "backend accepted by all parents is current",
+			kind: "XBackend",
+			object: map[string]any{
+				"metadata": map[string]any{"name": "external", "namespace": "apps", "generation": int64(1)},
+				"spec":     map[string]any{"type": "External", "externalHostname": "api.example.com", "port": int64(443), "protocol": "HTTPS"},
+				"status": map[string]any{
+					"parents": []any{
+						map[string]any{
+							"parentRef":      ref("gw-a"),
+							"controllerName": "gateway.envoyproxy.io/gatewayclass-controller",
+							"conditions":     []any{condition("Accepted", "True", 1)},
+						},
+						parent(ref("gw-b"), condition("Accepted", "True", 1)),
+					},
+				},
+			},
+			expect: HealthStatusCurrent,
+		},
+		{
+			name: "backend rejected by one parent is in progress",
+			kind: "XBackend",
+			object: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+				"status": map[string]any{
+					"parents": []any{
+						parent(ref("gw-a"), condition("Accepted", "True", 1)),
+						parent(ref("gw-b"), condition("Accepted", "False", 1)),
+					},
+				},
+			},
+			expect: HealthStatusInProgress,
+		},
+		{
+			name: "backend with stale accepted condition is in progress",
+			kind: "XBackend",
+			object: map[string]any{
+				"metadata": map[string]any{"generation": int64(2)},
+				"status": map[string]any{
+					"parents": []any{
+						parent(ref("gw-a"), condition("Accepted", "True", 1)),
+					},
+				},
+			},
+			expect: HealthStatusInProgress,
+		},
+		{
+			name: "backend referenced by no route is current",
+			kind: "XBackend",
+			object: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+				"status":   map[string]any{"parents": []any{}},
+			},
+			expect: HealthStatusCurrent,
+		},
+		{
+			name: "backend with no status is current",
+			kind: "XBackend",
+			object: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+			},
+			expect: HealthStatusCurrent,
 		},
 		{
 			name: "v1beta1 ready cluster is current",

--- a/internal/runtime/resource_wait.go
+++ b/internal/runtime/resource_wait.go
@@ -105,7 +105,24 @@ func healthCheckResult(hc *engine.HealthCheck, u *unstructured.Unstructured) (*s
 
 	res, err := hc.Evaluate(u.UnstructuredContent())
 	if err != nil {
-		return nil, err
+		// The evaluation is only attempted on objects read from the
+		// cluster, so an error means the health check definition is at
+		// odds with the live object: the #object schema rejects it or an
+		// expression cannot be computed from it. Polling again cannot
+		// change that, so the resource is reported as failed to end the
+		// wait right away instead of running out the timeout as Unknown.
+		return &status.Result{
+			Status:  status.FailedStatus,
+			Message: err.Error(),
+			Conditions: []status.Condition{
+				{
+					Type:    status.ConditionStalled,
+					Status:  corev1.ConditionTrue,
+					Reason:  "HealthCheckError",
+					Message: err.Error(),
+				},
+			},
+		}, nil
 	}
 
 	switch res {

--- a/internal/runtime/resource_wait_test.go
+++ b/internal/runtime/resource_wait_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/fluxcd/cli-utils/pkg/kstatus/status"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/engine"
+)
+
+func Test_healthCheckResult(t *testing.T) {
+	g := NewWithT(t)
+
+	value := cuecontext.New().CompileString(apiv1.InstanceSchema + `
+timoni: {
+	apiVersion: "v1alpha1"
+	instance: {}
+	apply: {}
+	healthChecks: "example.com/Database": #HealthCheck & {
+		group: "example.com"
+		kind:  "Database"
+		#object: status?: {phase?: string, ...}
+		current: #object.status.phase == "Ready"
+		failed:  #object.status.phase == "Failed"
+	}
+}
+`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+	checks, err := (&engine.ModuleBuilder{}).GetHealthChecks(value)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(checks).To(HaveLen(1))
+	hc := checks[0]
+
+	database := func(fields map[string]any) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "example.com/v1",
+			"kind":       "Database",
+			"metadata":   map[string]any{"name": "db", "namespace": "default"},
+		}}
+		for k, v := range fields {
+			u.Object[k] = v
+		}
+		return u
+	}
+
+	tests := []struct {
+		name    string
+		object  *unstructured.Unstructured
+		expect  status.Status
+		message string
+	}{
+		{
+			name:    "ready phase is current",
+			object:  database(map[string]any{"status": map[string]any{"phase": "Ready"}}),
+			expect:  status.CurrentStatus,
+			message: "passed",
+		},
+		{
+			name:    "failed phase is failed",
+			object:  database(map[string]any{"status": map[string]any{"phase": "Failed"}}),
+			expect:  status.FailedStatus,
+			message: "failed",
+		},
+		{
+			name:    "pending phase is in progress",
+			object:  database(map[string]any{"status": map[string]any{"phase": "Pending"}}),
+			expect:  status.InProgressStatus,
+			message: "in progress",
+		},
+		{
+			// A freshly created object without a status is not a
+			// definition problem: the expressions are incomplete and
+			// the object keeps being polled.
+			name:    "object without status is in progress",
+			object:  database(nil),
+			expect:  status.InProgressStatus,
+			message: "in progress",
+		},
+		{
+			name: "object scheduled for deletion is terminating",
+			object: database(map[string]any{
+				"metadata": map[string]any{"name": "db", "deletionTimestamp": "2026-01-01T00:00:00Z"},
+				"status":   map[string]any{"phase": "Ready"},
+			}),
+			expect:  status.TerminatingStatus,
+			message: "scheduled for deletion",
+		},
+		{
+			// The live object contradicts the #object schema declared
+			// by the module: polling cannot fix it, so the wait fails
+			// fast instead of reporting Unknown until the timeout.
+			name:    "object rejected by the schema is failed",
+			object:  database(map[string]any{"status": map[string]any{"phase": int64(5)}}),
+			expect:  status.FailedStatus,
+			message: "does not match the #object schema",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := healthCheckResult(hc, tt.object)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result.Status).To(Equal(tt.expect))
+			g.Expect(result.Message).To(ContainSubstring(tt.message))
+			if tt.expect == status.FailedStatus {
+				g.Expect(result.Conditions).To(HaveLen(1))
+				g.Expect(result.Conditions[0].Type).To(Equal(status.ConditionStalled))
+			}
+		})
+	}
+}
+
+func Test_healthCheckResult_StatusNotYetReported(t *testing.T) {
+	g := NewWithT(t)
+
+	// The check declares the status and its fields as required, the
+	// strictest form a module can write. A live object created moments
+	// ago has no status until its controller reports one: this is not a
+	// schema conflict but an incomplete evaluation, so the resource
+	// stays in progress and keeps being polled instead of failing.
+	value := cuecontext.New().CompileString(apiv1.InstanceSchema + `
+timoni: {
+	apiVersion: "v1alpha1"
+	instance: {}
+	apply: {}
+	healthChecks: "example.com/Database": #HealthCheck & {
+		group: "example.com"
+		kind:  "Database"
+		#object: status: {phase: string, ...}
+		current: #object.status.phase == "Ready"
+		failed:  #object.status.phase == "Failed"
+	}
+}
+`)
+	g.Expect(value.Err()).ToNot(HaveOccurred())
+	checks, err := (&engine.ModuleBuilder{}).GetHealthChecks(value)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	result, err := healthCheckResult(checks[0], &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Database",
+		"metadata":   map[string]any{"name": "db", "namespace": "default", "generation": int64(1)},
+		"spec":       map[string]any{"size": "small"},
+	}})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status).To(Equal(status.InProgressStatus))
+
+	// Once the controller reports the status, the same check resolves.
+	result, err = healthCheckResult(checks[0], &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Database",
+		"metadata":   map[string]any{"name": "db", "namespace": "default", "generation": int64(1)},
+		"status":     map[string]any{"phase": "Ready"},
+	}})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status).To(Equal(status.CurrentStatus))
+}

--- a/schemas/timoni.sh/core/v1alpha1/healthchecklibrary.cue
+++ b/schemas/timoni.sh/core/v1alpha1/healthchecklibrary.cue
@@ -16,9 +16,12 @@ package v1alpha1
 		// Gateway, ListenerSet and XMesh gate on their Accepted and
 		// Programmed status conditions, the *Route kinds are ready when
 		// every parent referenced in their spec has accepted them and
-		// resolved their backend references, and the policy kinds when
-		// accepted by all their ancestors. ReferenceGrant reports no
-		// status and needs no check.
+		// resolved their backend references, the policy kinds when
+		// accepted by all their ancestors, and XBackend when accepted
+		// by all the parents reported for it. ReferenceGrant reports no
+		// status and needs no check. The XListenerSet and BackendLBPolicy
+		// checks cover the older experimental channels where these
+		// kinds are defined.
 		gatewayAPI: {
 			"gateway.networking.k8s.io/GatewayClass": #HealthCheckForCondition & {
 				group:         "gateway.networking.k8s.io"
@@ -58,6 +61,10 @@ package v1alpha1
 				group: "gateway.networking.x-k8s.io"
 				kind:  "XBackendTrafficPolicy"
 			}
+			"gateway.networking.x-k8s.io/XBackend": _#BackendParentsAccepted & {
+				group: "gateway.networking.x-k8s.io"
+				kind:  "XBackend"
+			}
 			...
 		}
 
@@ -89,6 +96,23 @@ package v1alpha1
 	}
 }
 
+// _#ParentRef is the shape shared by the Gateway API parent and
+// ancestor references, as declared in a route spec and as echoed in
+// the route, policy and backend status entries.
+_#ParentRef: {
+	name?:        string
+	namespace?:   string
+	group?:       string
+	kind?:        string
+	sectionName?: string
+	port?:        int
+	...
+}
+
+// _#StatusConditions is the shape of the conditions list reported
+// per parent or ancestor by the Gateway API kinds.
+_#StatusConditions: [...{type?: string, status?: string, observedGeneration?: int, ...}]
+
 // _#RouteParentsAccepted is the shared health check for the Gateway API
 // route kinds, which report their status per parent under
 // 'status.parents' with one entry per parentRef and controller, instead
@@ -98,36 +122,28 @@ package v1alpha1
 // references. Parents that no controller claims are never added to the
 // status, so an unclaimed parent ref keeps the route in progress. As
 // the status echoes the spec refs, an entry matches a parent ref when
-// the fields declared in the ref are reported with equal values. A
-// route with no parent refs is not attached to anything and counts as
-// ready. A condition carrying its own observedGeneration only counts
+// every field declared in both has equal values; a field the
+// controller leaves out of the reported ref, e.g. the namespace of a
+// parent living in the route namespace, does not disqualify the entry.
+// A route with no parent refs is not attached to anything and counts
+// as ready. A condition carrying its own observedGeneration only counts
 // when it matches metadata.generation.
 _#RouteParentsAccepted: #HealthCheck & {
 	group: "gateway.networking.k8s.io"
 	#object: {
 		metadata: {generation?: int, ...}
-		spec?: parentRefs?: [...{
-			name?:        string
-			namespace?:   string
-			group?:       string
-			kind?:        string
-			sectionName?: string
-			port?:        int
+		spec?: {
+			parentRefs?: [..._#ParentRef]
 			...
-		}]
-		status?: parents?: [...{
-			parentRef?: {
-				name?:        string
-				namespace?:   string
-				group?:       string
-				kind?:        string
-				sectionName?: string
-				port?:        int
+		}
+		status?: {
+			parents?: [...{
+				parentRef?:  _#ParentRef
+				conditions?: _#StatusConditions
 				...
-			}
-			conditions?: [...{type?: string, status?: string, observedGeneration?: int, ...}]
+			}]
 			...
-		}]
+		}
 		...
 	}
 
@@ -141,11 +157,11 @@ _#RouteParentsAccepted: #HealthCheck & {
 		if len([
 			for p in #object.status.parents
 			if p.parentRef.name == r.name
-			if [if r.namespace != _|_ {[if p.parentRef.namespace != _|_ {p.parentRef.namespace == r.namespace}, false][0]}, true][0]
-			if [if r.group != _|_ {[if p.parentRef.group != _|_ {p.parentRef.group == r.group}, false][0]}, true][0]
-			if [if r.kind != _|_ {[if p.parentRef.kind != _|_ {p.parentRef.kind == r.kind}, false][0]}, true][0]
-			if [if r.sectionName != _|_ {[if p.parentRef.sectionName != _|_ {p.parentRef.sectionName == r.sectionName}, false][0]}, true][0]
-			if [if r.port != _|_ {[if p.parentRef.port != _|_ {p.parentRef.port == r.port}, false][0]}, true][0]
+			if [if r.namespace != _|_ && p.parentRef.namespace != _|_ {p.parentRef.namespace == r.namespace}, true][0]
+			if [if r.group != _|_ && p.parentRef.group != _|_ {p.parentRef.group == r.group}, true][0]
+			if [if r.kind != _|_ && p.parentRef.kind != _|_ {p.parentRef.kind == r.kind}, true][0]
+			if [if r.sectionName != _|_ && p.parentRef.sectionName != _|_ {p.parentRef.sectionName == r.sectionName}, true][0]
+			if [if r.port != _|_ && p.parentRef.port != _|_ {p.parentRef.port == r.port}, true][0]
 			if len([
 				for c in p.conditions
 				if c.type == "Accepted" && c.status == "True"
@@ -177,10 +193,13 @@ _#RouteParentsAccepted: #HealthCheck & {
 _#PolicyAncestorsAccepted: #HealthCheck & {
 	#object: {
 		metadata: {generation?: int, ...}
-		status?: ancestors?: [...{
-			conditions?: [...{type?: string, status?: string, observedGeneration?: int, ...}]
+		status?: {
+			ancestors?: [...{
+				conditions?: _#StatusConditions
+				...
+			}]
 			...
-		}]
+		}
 		...
 	}
 	current: len(#object.status.ancestors) > 0 && len([
@@ -204,6 +223,55 @@ _#PolicyAncestorsAccepted: #HealthCheck & {
 	]) == len(#object.status.ancestors)
 }
 
+// _#BackendParentsAccepted is the shared health check for the Gateway
+// API backend kinds, which report their conditions per parent under
+// 'status.parents' like the routes do, but declare no parent refs in
+// their spec: the parents are the Gateways of the routes referencing
+// the backend, discovered by the controllers. A backend is ready when
+// every reported parent reports an 'Accepted: True' condition and no
+// 'ResolvedRefs: False' one; an empty list means the backend is not
+// referenced by any route and counts as ready. A condition carrying
+// its own observedGeneration only counts when it matches
+// metadata.generation.
+_#BackendParentsAccepted: #HealthCheck & {
+	#object: {
+		metadata: {generation?: int, ...}
+		status?: {
+			parents?: [...{
+				conditions?: _#StatusConditions
+				...
+			}]
+			...
+		}
+		...
+	}
+
+	_parents: [
+		if #object.status.parents != _|_ {#object.status.parents},
+		[],
+	][0]
+
+	current: len([
+		for p in _parents
+		if len([
+			for c in p.conditions
+			if c.type == "Accepted" && c.status == "True"
+			if [
+				if c.observedGeneration != _|_ {c.observedGeneration == #object.metadata.generation},
+				true,
+			][0] {c},
+		]) > 0
+		if len([
+			for c in p.conditions
+			if c.type == "ResolvedRefs" && c.status == "False"
+			if [
+				if c.observedGeneration != _|_ {c.observedGeneration == #object.metadata.generation},
+				true,
+			][0] {c},
+		]) == 0 {p},
+	]) == len(_parents)
+}
+
 // _#ReadyOrAvailableCondition is the shared health check for custom
 // resources whose readiness condition type differs between their API
 // versions, e.g. the Cluster API kinds gate on Ready in v1beta1 and on
@@ -216,7 +284,7 @@ _#ReadyOrAvailableCondition: #HealthCheck & {
 		metadata: {generation?: int, ...}
 		status?: {
 			observedGeneration?: int
-			conditions?: [...{type?: string, status?: string, observedGeneration?: int, ...}]
+			conditions?:         _#StatusConditions
 			...
 		}
 		...


### PR DESCRIPTION
Report a health check evaluation error as a failed status instead of `Unknown`, which kept the resource polled until the timeout expired. The evaluation only runs on objects read from the cluster, so an error can only come from the check definition, the `#object `schema rejecting the live object or an expression that cannot be computed from it, and
polling cannot fix it.