### PR TITLE
feat: Update bundles from local sources

### DIFF
--- a/api/v1alpha1/module.go
+++ b/api/v1alpha1/module.go
@@ -20,8 +20,8 @@ package v1alpha1
 // denotes the latest stable version of a module.
 const LatestVersion = "latest"
 
-// ModuleReference contains the information necessary to locate
-// a module's OCI artifact in the registry.
+// ModuleReference contains the information needed to locate a module artifact
+// or local source.
 type ModuleReference struct {
 	// Name of the module.
 	Name string `json:"name"`
@@ -30,10 +30,11 @@ type ModuleReference struct {
 	// 'oci://<reg.host>/<org>/<repo>' or 'file://<path>'.
 	Repository string `json:"repository"`
 
-	// Version is the OCI artifact tag in strict semver format.
+	// Version is the strict semantic version of the module release, when known.
 	Version string `json:"version"`
 
-	// Digest of the OCI artifact in the format '<sha-type>:<hex>'.
+	// Digest is an OCI artifact digest or the source-tree digest of an indexed
+	// local module, in the format '<sha-type>:<hex>'.
 	Digest string `json:"digest"`
 
 	// Annotations of the OCI artifact.

--- a/cmd/timoni/bundle_apply.go
+++ b/cmd/timoni/bundle_apply.go
@@ -313,6 +313,7 @@ func fetchBundleInstanceModule(ctx context.Context, instance *apiv1.BundleInstan
 		f, err := fetcher.New(ctx, fetcher.Options{
 			Source:      instance.Module.Repository,
 			Version:     moduleVersion,
+			Digest:      instance.Module.Digest,
 			Destination: dstDir,
 			CacheDir:    rootArgs.cacheDir,
 			Creds:       creds,

--- a/cmd/timoni/bundle_build.go
+++ b/cmd/timoni/bundle_build.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	goruntime "runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -50,6 +51,8 @@ var bundleBuildCmd = &cobra.Command{
 	Long: `The bundle build command builds and prints the resulting Kubernetes resources for all instances defined in a Bundle.
 
 Custom resources are validated against the CRD schemas vendored in the modules and the CRDs rendered by any instance of the bundle. A violation fails the command and nothing is written. Use --validate=false to disable the validation.
+
+With --update, module references are updated, vetted, and built from the same in-memory inputs. Bundle files are written only after vet and build succeed. Use --local-index for extracted local modules and repeatable --oci mappings for local OCI artifacts.
 `,
 	Example: `  # Build all instances from a bundle and print the manifests to stdout
   timoni bundle build -f bundle.cue
@@ -60,6 +63,9 @@ Custom resources are validated against the CRD schemas vendored in the modules a
   # Write the manifests as a directory tree, one directory per instance
   # and one file per resource, named like 'kustomize build -o <dir>'
   timoni bundle build -f bundle.cue --output-dir ./manifests
+
+  # Update an indexed local module and render the updated bundle
+  timoni bundle build --update --local-index module-index.cue -f bundle.cue --runtime-from-env
 `,
 	Args: cobra.NoArgs,
 	RunE: runBundleBuildCmd,
@@ -69,6 +75,10 @@ type bundleBuildFlags struct {
 	pkg         flags.Package
 	files       []string
 	creds       flags.Credentials
+	update      bool
+	level       string
+	localIndex  string
+	localOCI    []string
 	outputDir   string
 	concurrency int
 	maskSecrets bool
@@ -82,6 +92,14 @@ func init() {
 	bundleBuildCmd.Flags().StringSliceVarP(&bundleBuildArgs.files, "file", "f", nil,
 		"The local path to bundle.cue files.")
 	bundleBuildCmd.Flags().Var(&bundleBuildArgs.creds, bundleBuildArgs.creds.Type(), bundleBuildArgs.creds.Description())
+	bundleBuildCmd.Flags().BoolVar(&bundleBuildArgs.update, "update", false,
+		"Update module references before vetting and building the bundle.")
+	bundleBuildCmd.Flags().StringVar(&bundleBuildArgs.level, "level", engine.UpdateLevelNone,
+		"Set the update level for module references without an update attribute: none, patch, minor, or major; requires --update.")
+	bundleBuildCmd.Flags().StringVar(&bundleBuildArgs.localIndex, "local-index", "",
+		"CUE file that maps module identities and semantic versions to verified local sources; requires --update.")
+	bundleBuildCmd.Flags().StringArrayVar(&bundleBuildArgs.localOCI, "oci", nil,
+		"Map a local OCI archive or image layout to a repository as 'oci://repository=path'; repeatable; requires --update.")
 	bundleBuildCmd.Flags().StringVar(&bundleBuildArgs.outputDir, "output-dir", "",
 		"The path to a directory where the manifests are written as a tree, one directory per instance and one file per resource.")
 	bundleBuildCmd.Flags().IntVar(&bundleBuildArgs.concurrency, "concurrency", 0,
@@ -94,9 +112,18 @@ func init() {
 }
 
 func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
-	files := bundleBuildArgs.files
+	files := slices.Clone(bundleBuildArgs.files)
 	if len(files) == 0 {
 		return errors.New("no bundle provided with -f")
+	}
+	if bundleBuildArgs.update && slices.Contains(files, "-") {
+		return errors.New("--update cannot be used with -f -")
+	}
+	if !bundleBuildArgs.update && (cmd.Flags().Changed("level") || cmd.Flags().Changed("local-index") || cmd.Flags().Changed("oci")) {
+		return errors.New("--update is required with --level, --local-index, and --oci")
+	}
+	if bundleBuildArgs.update && bundleBuildArgs.outputDir != "" {
+		return errors.New("--update cannot be used with --output-dir")
 	}
 	var stdinFile string
 	for i, file := range files {
@@ -113,20 +140,27 @@ func runBundleBuildCmd(cmd *cobra.Command, _ []string) error {
 		defer os.Remove(stdinFile)
 	}
 
+	workdir, err := resolveWorkdir(bundleArgs.workdir)
+	if err != nil {
+		return err
+	}
+	if bundleBuildArgs.update {
+		return runBundleBuildWithUpdate(cmd, files, workdir)
+	}
+	return runBundleBuild(cmd, files, workdir, nil)
+}
+
+func runBundleBuild(cmd *cobra.Command, files []string, workdir string, overrides map[string][]byte) error {
 	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(tmpDir)
 
-	workdir, err := resolveWorkdir(bundleArgs.workdir)
-	if err != nil {
-		return err
-	}
-
 	ctx := cuecontext.New()
 	bm := engine.NewBundleBuilder(ctx, files)
 	bm.SetWorkdir(workdir)
+	bm.SetFileOverrides(overrides)
 
 	workspace, runtimeValues, err := resolveBundleBuildRuntime(cmd)
 	if err != nil {

--- a/cmd/timoni/bundle_build_update.go
+++ b/cmd/timoni/bundle_build_update.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/spf13/cobra"
+
+	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/oci"
+)
+
+type bundleUpdateTransaction struct {
+	plan         *engine.UpdatePlan
+	changedFiles []string
+	originals    map[string][]byte
+	updated      map[string][]byte
+	overrides    map[string][]byte
+}
+
+func prepareBundleUpdate(cmd *cobra.Command, files []string, workdir, level, localIndex string, localOCI []string, creds string) (*bundleUpdateTransaction, error) {
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
+	defer cancel()
+
+	updater := engine.NewBundleUpdater(cuecontext.New(), files)
+	updater.SetWorkdir(workdir)
+	if err := updater.SetLevel(level); err != nil {
+		return nil, err
+	}
+
+	lister := engine.ModuleVersionLister(&engine.OCIModuleVersionLister{
+		Opts: oci.Options(ctx, creds, rootArgs.registryInsecure),
+	})
+	var err error
+	if localIndex != "" {
+		localLister, err := engine.NewLocalModuleIndexLister(localIndex, lister)
+		if err != nil {
+			return nil, err
+		}
+		updater.SetLocalIndex(localLister)
+		lister = localLister
+	}
+	if len(localOCI) > 0 {
+		artifactLister, err := engine.NewLocalModuleArtifactLister(localOCI, lister)
+		if err != nil {
+			return nil, err
+		}
+		updater.SetLocalArtifacts(artifactLister)
+		lister = artifactLister
+	}
+
+	if err := updater.Load(); err != nil {
+		return nil, describeErr(workdir, "failed to build bundle", err)
+	}
+
+	plan, err := updater.Plan(ctx, lister)
+	if plan != nil {
+		log := LoggerFrom(cmd.Context())
+		for _, skip := range plan.Skipped {
+			log.Info(fmt.Sprintf("instance %s skipped: %s", skip.Instance, skip.Reason))
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	tx := &bundleUpdateTransaction{
+		plan:      plan,
+		originals: make(map[string][]byte),
+		updated:   make(map[string][]byte),
+		overrides: make(map[string][]byte),
+	}
+	for _, change := range plan.Changes {
+		for _, file := range change.Files {
+			if !slices.Contains(tx.changedFiles, file) {
+				tx.changedFiles = append(tx.changedFiles, file)
+			}
+		}
+	}
+	slices.Sort(tx.changedFiles)
+
+	for _, file := range tx.changedFiles {
+		tx.originals[file], err = updater.Source(file)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(tx.changedFiles) == 0 {
+		return tx, nil
+	}
+
+	if err := updater.Apply(plan); err != nil {
+		return nil, describeErr(workdir, "update failed", err)
+	}
+	for _, file := range tx.changedFiles {
+		tx.updated[file], err = updater.Format(file)
+		if err != nil {
+			return nil, err
+		}
+	}
+	tx.changedFiles = slices.DeleteFunc(tx.changedFiles, func(file string) bool {
+		return bytes.Equal(tx.originals[file], tx.updated[file])
+	})
+	for _, file := range tx.changedFiles {
+		tx.overrides[file] = tx.updated[file]
+		if abs, err := filepath.Abs(file); err == nil {
+			tx.overrides[abs] = tx.updated[file]
+		}
+	}
+	return tx, nil
+}
+
+func runBundleBuildWithUpdate(cmd *cobra.Command, files []string, workdir string) error {
+	tx, err := prepareBundleUpdate(cmd, files, workdir, bundleBuildArgs.level, bundleBuildArgs.localIndex, bundleBuildArgs.localOCI, bundleBuildArgs.creds.String())
+	if err != nil {
+		return err
+	}
+	log := LoggerFrom(cmd.Context())
+	for _, change := range tx.plan.Changes {
+		log.Info(describeChange(change))
+	}
+
+	offline := bundleArgs.runtimeFromEnv || len(bundleArgs.runtimeFiles) == 0
+	if err := runBundleVet(cmd, files, offline, tx.overrides); err != nil {
+		return err
+	}
+
+	var rendered bytes.Buffer
+	out := cmd.OutOrStdout()
+	cmd.SetOut(&rendered)
+	err = runBundleBuild(cmd, files, workdir, tx.overrides)
+	cmd.SetOut(nil)
+	if err != nil {
+		return err
+	}
+
+	if err := writeBundleFiles(tx.changedFiles, tx.originals, tx.updated); err != nil {
+		return err
+	}
+	for _, file := range tx.changedFiles {
+		log.Info(fmt.Sprintf("updated %s", fmtRelPath(file)))
+	}
+	_, err = out.Write(rendered.Bytes())
+	return err
+}

--- a/cmd/timoni/bundle_build_update.go
+++ b/cmd/timoni/bundle_build_update.go
@@ -140,8 +140,7 @@ func runBundleBuildWithUpdate(cmd *cobra.Command, files []string, workdir string
 		log.Info(describeChange(change))
 	}
 
-	offline := bundleArgs.runtimeFromEnv || len(bundleArgs.runtimeFiles) == 0
-	if err := runBundleVet(cmd, files, offline, tx.overrides); err != nil {
+	if err := runBundleUpdateVet(cmd, files, tx.overrides); err != nil {
 		return err
 	}
 

--- a/cmd/timoni/bundle_update.go
+++ b/cmd/timoni/bundle_update.go
@@ -54,6 +54,10 @@ With '--oci', an explicit 'oci://repository=path' mapping adds a local OCI
 archive or image layout for the specified repository. Timoni verifies the
 manifest version and artifact digest; it never infers the repository from the
 path.
+
+With '--vet', Timoni validates the staged bundle before writing updates.
+With '--dry-run --vet', it validates the staged update without writing files.
+Use 'bundle build --update' when the updated modules must also be rendered.
 `,
 	Example: `  # Update the module references according to the policies declared in the bundle
   timoni bundle update -f bundle.cue
@@ -69,6 +73,9 @@ path.
 
   # Update from a local OCI archive, explicitly mapped to its repository
   timoni bundle update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar -f bundle.cue
+
+  # Validate the staged update before writing it
+  timoni bundle update --vet -f bundle.cue
 `,
 	Args: cobra.NoArgs,
 	RunE: runBundleUpdateCmd,
@@ -79,6 +86,7 @@ type bundleUpdateFlags struct {
 	creds      flags.Credentials
 	level      string
 	dryrun     bool
+	vet        bool
 	localIndex string
 	localOCI   []string
 }
@@ -93,6 +101,8 @@ func init() {
 		"The update level for the module references without an update attribute, one of: none, patch, minor, major.")
 	bundleUpdateCmd.Flags().BoolVar(&bundleUpdateArgs.dryrun, "dry-run", false,
 		"Print the available updates without modifying the files.")
+	bundleUpdateCmd.Flags().BoolVar(&bundleUpdateArgs.vet, "vet", false,
+		"Validate the staged bundle before writing updates.")
 	bundleUpdateCmd.Flags().StringVar(&bundleUpdateArgs.localIndex, "local-index", "",
 		"CUE file that maps module identities and semantic versions to verified local sources.")
 	bundleUpdateCmd.Flags().StringArrayVar(&bundleUpdateArgs.localOCI, "oci", nil,
@@ -115,6 +125,12 @@ func runBundleUpdateCmd(cmd *cobra.Command, args []string) error {
 	tx, err := prepareBundleUpdate(cmd, files, workdir, bundleUpdateArgs.level, bundleUpdateArgs.localIndex, bundleUpdateArgs.localOCI, bundleUpdateArgs.creds.String())
 	if err != nil {
 		return err
+	}
+
+	if bundleUpdateArgs.vet {
+		if err := runBundleUpdateVet(cmd, files, tx.overrides); err != nil {
+			return err
+		}
 	}
 
 	if len(tx.plan.Changes) == 0 {
@@ -141,6 +157,13 @@ func runBundleUpdateCmd(cmd *cobra.Command, args []string) error {
 		log.Info(fmt.Sprintf("updated %s", fmtRelPath(file)))
 	}
 	return nil
+}
+
+// runBundleUpdateVet validates a bundle using the runtime semantics of the
+// atomic 'bundle build --update' path.
+func runBundleUpdateVet(cmd *cobra.Command, files []string, overrides map[string][]byte) error {
+	offline := bundleArgs.runtimeFromEnv || len(bundleArgs.runtimeFiles) == 0
+	return runBundleVet(cmd, files, offline, overrides)
 }
 
 // writeBundleFiles writes the updated content of the given files after

--- a/cmd/timoni/bundle_update.go
+++ b/cmd/timoni/bundle_update.go
@@ -49,6 +49,15 @@ that they import:
   @timoni(update:none)                 exclude the module reference from updates
 
 References without an attribute follow the '--level' flag.
+
+With '--local-index', an explicit CUE index maps module identities and semantic
+versions to verified local sources. Matching OCI references can switch to those
+sources; unindexed OCI references continue to use the registry.
+
+With '--oci', an explicit 'oci://repository=path' mapping adds a local OCI
+archive or image layout for the specified repository. Local artifacts are
+verified against their manifest digest and version; the repository is never
+inferred from the path.
 `,
 	Example: `  # Update the module references according to the policies declared in the bundle
   timoni bundle update -f bundle.cue
@@ -58,16 +67,24 @@ References without an attribute follow the '--level' flag.
 
   # Print the available updates without modifying the files
   timoni bundle update -f bundle.cue --dry-run
+
+  # Update an indexed local module
+  timoni bundle update --local-index module-index.cue -f bundle.cue
+
+  # Update from a local OCI archive, explicitly mapped to its repository
+  timoni bundle update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar -f bundle.cue
 `,
 	Args: cobra.NoArgs,
 	RunE: runBundleUpdateCmd,
 }
 
 type bundleUpdateFlags struct {
-	files  []string
-	creds  flags.Credentials
-	level  string
-	dryrun bool
+	files      []string
+	creds      flags.Credentials
+	level      string
+	dryrun     bool
+	localIndex string
+	localOCI   []string
 }
 
 var bundleUpdateArgs bundleUpdateFlags
@@ -80,6 +97,10 @@ func init() {
 		"The update level for the module references without an update attribute, one of: none, patch, minor, major.")
 	bundleUpdateCmd.Flags().BoolVar(&bundleUpdateArgs.dryrun, "dry-run", false,
 		"Print the available updates without modifying the files.")
+	bundleUpdateCmd.Flags().StringVar(&bundleUpdateArgs.localIndex, "local-index", "",
+		"CUE file that maps module identities and semantic versions to verified local sources.")
+	bundleUpdateCmd.Flags().StringArrayVar(&bundleUpdateArgs.localOCI, "oci", nil,
+		"Map a local OCI archive or image layout to a repository as 'oci://repository=path'; repeatable.")
 	bundleCmd.AddCommand(bundleUpdateCmd)
 }
 
@@ -104,13 +125,31 @@ func runBundleUpdateCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	var lister engine.ModuleVersionLister = &engine.OCIModuleVersionLister{
+		Opts: oci.Options(ctx, bundleUpdateArgs.creds.String(), rootArgs.registryInsecure),
+	}
+	var localIndex *engine.LocalModuleIndexLister
+	if bundleUpdateArgs.localIndex != "" {
+		localIndex, err = engine.NewLocalModuleIndexLister(bundleUpdateArgs.localIndex, lister)
+		if err != nil {
+			return err
+		}
+		updater.SetLocalIndex(localIndex)
+		lister = localIndex
+	}
+	if len(bundleUpdateArgs.localOCI) > 0 {
+		artifacts, err := engine.NewLocalModuleArtifactLister(bundleUpdateArgs.localOCI, lister)
+		if err != nil {
+			return err
+		}
+		updater.SetLocalArtifacts(artifacts)
+		lister = artifacts
+	}
+
 	if err := updater.Load(); err != nil {
 		return describeErr(workdir, "failed to build bundle", err)
 	}
 
-	lister := &engine.OCIModuleVersionLister{
-		Opts: oci.Options(ctx, bundleUpdateArgs.creds.String(), rootArgs.registryInsecure),
-	}
 	plan, err := updater.Plan(ctx, lister)
 	if plan != nil {
 		for _, skip := range plan.Skipped {
@@ -229,5 +268,9 @@ func describeChange(change *engine.UpdateChange) string {
 		}
 		to += "@" + change.ToDigest
 	}
-	return fmt.Sprintf("%s: %s %s -> %s", strings.Join(change.Instances, ", "), change.Repository, from, to)
+	source := ""
+	if change.ToSource != "" {
+		source = fmt.Sprintf(" source %s -> %s", change.FromSource, change.ToSource)
+	}
+	return fmt.Sprintf("%s: %s%s %s -> %s", strings.Join(change.Instances, ", "), change.Repository, source, from, to)
 }

--- a/cmd/timoni/bundle_update.go
+++ b/cmd/timoni/bundle_update.go
@@ -18,20 +18,16 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 
-	"cuelang.org/go/cue/cuecontext"
 	"github.com/spf13/cobra"
 
 	"github.com/stefanprodan/timoni/internal/engine"
 	"github.com/stefanprodan/timoni/internal/flags"
 	"github.com/stefanprodan/timoni/internal/logger"
-	"github.com/stefanprodan/timoni/internal/oci"
 )
 
 var bundleUpdateCmd = &cobra.Command{
@@ -51,13 +47,13 @@ that they import:
 References without an attribute follow the '--level' flag.
 
 With '--local-index', an explicit CUE index maps module identities and semantic
-versions to verified local sources. Matching OCI references can switch to those
-sources; unindexed OCI references continue to use the registry.
+versions to verified local sources. A matching OCI reference can switch to one
+of those sources; unindexed OCI references continue to use the registry.
 
 With '--oci', an explicit 'oci://repository=path' mapping adds a local OCI
-archive or image layout for the specified repository. Local artifacts are
-verified against their manifest digest and version; the repository is never
-inferred from the path.
+archive or image layout for the specified repository. Timoni verifies the
+manifest version and artifact digest; it never infers the repository from the
+path.
 `,
 	Example: `  # Update the module references according to the policies declared in the bundle
   timoni bundle update -f bundle.cue
@@ -116,105 +112,32 @@ func runBundleUpdateCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
-	defer cancel()
-
-	updater := engine.NewBundleUpdater(cuecontext.New(), files)
-	updater.SetWorkdir(workdir)
-	if err := updater.SetLevel(bundleUpdateArgs.level); err != nil {
-		return err
-	}
-
-	var lister engine.ModuleVersionLister = &engine.OCIModuleVersionLister{
-		Opts: oci.Options(ctx, bundleUpdateArgs.creds.String(), rootArgs.registryInsecure),
-	}
-	var localIndex *engine.LocalModuleIndexLister
-	if bundleUpdateArgs.localIndex != "" {
-		localIndex, err = engine.NewLocalModuleIndexLister(bundleUpdateArgs.localIndex, lister)
-		if err != nil {
-			return err
-		}
-		updater.SetLocalIndex(localIndex)
-		lister = localIndex
-	}
-	if len(bundleUpdateArgs.localOCI) > 0 {
-		artifacts, err := engine.NewLocalModuleArtifactLister(bundleUpdateArgs.localOCI, lister)
-		if err != nil {
-			return err
-		}
-		updater.SetLocalArtifacts(artifacts)
-		lister = artifacts
-	}
-
-	if err := updater.Load(); err != nil {
-		return describeErr(workdir, "failed to build bundle", err)
-	}
-
-	plan, err := updater.Plan(ctx, lister)
-	if plan != nil {
-		for _, skip := range plan.Skipped {
-			log.Info(fmt.Sprintf("instance %s skipped: %s", skip.Instance, skip.Reason))
-		}
-	}
+	tx, err := prepareBundleUpdate(cmd, files, workdir, bundleUpdateArgs.level, bundleUpdateArgs.localIndex, bundleUpdateArgs.localOCI, bundleUpdateArgs.creds.String())
 	if err != nil {
 		return err
 	}
 
-	if len(plan.Changes) == 0 {
+	if len(tx.plan.Changes) == 0 {
 		log.Info("all module references are up to date")
 		return nil
 	}
 
-	var changedFiles []string
-	for _, change := range plan.Changes {
-		for _, file := range change.Files {
-			if !slices.Contains(changedFiles, file) {
-				changedFiles = append(changedFiles, file)
-			}
-		}
-	}
-	slices.Sort(changedFiles)
-
-	originals := make(map[string][]byte, len(changedFiles))
-	for _, file := range changedFiles {
-		originals[file], err = updater.Source(file)
-		if err != nil {
-			return err
-		}
-	}
-
-	if err := updater.Apply(plan); err != nil {
-		return describeErr(workdir, "update failed", err)
-	}
-
-	updated := make(map[string][]byte, len(changedFiles))
-	for _, file := range changedFiles {
-		updated[file], err = updater.Format(file)
-		if err != nil {
-			return err
-		}
-	}
-
-	for _, change := range plan.Changes {
+	for _, change := range tx.plan.Changes {
 		if _, err := fmt.Fprintln(cmd.OutOrStdout(), describeChange(change)); err != nil {
 			return err
 		}
 	}
 
-	changedFiles = slices.DeleteFunc(changedFiles, func(file string) bool {
-		return bytes.Equal(originals[file], updated[file])
-	})
-
 	if bundleUpdateArgs.dryrun {
 		log.Info(fmt.Sprintf("%d module reference(s) can be updated in %s %s",
-			len(plan.Changes), strings.Join(relPaths(changedFiles), ", "), logger.ColorizeDryRun("(dry run)")))
+			len(tx.plan.Changes), strings.Join(relPaths(tx.changedFiles), ", "), logger.ColorizeDryRun("(dry run)")))
 		return nil
 	}
 
-	if err := writeBundleFiles(changedFiles, originals, updated); err != nil {
+	if err := writeBundleFiles(tx.changedFiles, tx.originals, tx.updated); err != nil {
 		return err
 	}
-	for _, file := range changedFiles {
+	for _, file := range tx.changedFiles {
 		log.Info(fmt.Sprintf("updated %s", fmtRelPath(file)))
 	}
 	return nil

--- a/cmd/timoni/bundle_update.go
+++ b/cmd/timoni/bundle_update.go
@@ -159,8 +159,8 @@ func runBundleUpdateCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runBundleUpdateVet validates a bundle using the runtime semantics of the
-// atomic 'bundle build --update' path.
+// runBundleUpdateVet validates a bundle with the in-memory overrides used by
+// the atomic 'bundle build --update' path.
 func runBundleUpdateVet(cmd *cobra.Command, files []string, overrides map[string][]byte) error {
 	offline := bundleArgs.runtimeFromEnv || len(bundleArgs.runtimeFiles) == 0
 	return runBundleVet(cmd, files, offline, overrides)

--- a/cmd/timoni/bundle_update_test.go
+++ b/cmd/timoni/bundle_update_test.go
@@ -305,7 +305,37 @@ bundle: {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(output).To(ContainSubstring("kind: ConfigMap"))
 		g.Expect(output).To(ContainSubstring("app.kubernetes.io/version: 1.1.0"))
+
+		atomicBundlePath := filepath.Join(root, "atomic-bundle.cue")
+		g.Expect(os.WriteFile(atomicBundlePath, []byte(bundle), 0o644)).To(Succeed())
+		stdout, _, err := executeCommandWithOutErr(fmt.Sprintf("bundle build --update --local-index %s -f %s", indexPath, atomicBundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stdout).To(HavePrefix("---\n"))
+		g.Expect(stdout).To(ContainSubstring("app.kubernetes.io/version: 1.1.0"))
+		g.Expect(readFile(atomicBundlePath)).To(ContainSubstring("file://" + moduleTwo))
+
+		invalidBundlePath := filepath.Join(root, "invalid-bundle.cue")
+		invalidBundle := strings.Replace(bundle, "values: {}", "values: priority: \"invalid\"", 1)
+		g.Expect(os.WriteFile(invalidBundlePath, []byte(invalidBundle), 0o644)).To(Succeed())
+		stdout, _, err = executeCommandWithOutErr(fmt.Sprintf("bundle build --update --local-index %s -f %s", indexPath, invalidBundlePath))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(stdout).To(BeEmpty())
+		g.Expect(readFile(invalidBundlePath)).To(Equal(invalidBundle))
 	})
+}
+
+ 
+func TestWriteBundleFilesRejectsConcurrentChange(t *testing.T) {
+	g := NewWithT(t)
+	file := filepath.Join(t.TempDir(), "bundle.cue")
+	original := []byte("before")
+	g.Expect(os.WriteFile(file, []byte("changed"), 0o644)).To(Succeed())
+
+	err := writeBundleFiles([]string{file}, map[string][]byte{file: original}, map[string][]byte{file: []byte("after")})
+	g.Expect(err).To(MatchError(ContainSubstring("changed on disk")))
+	data, err := os.ReadFile(file)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(data).To(Equal([]byte("changed")))
 }
 
 func Test_BundleUpdateLocalOCI(t *testing.T) {
@@ -362,4 +392,84 @@ func Test_BundleUpdateLocalOCI(t *testing.T) {
 
 	_, err = executeCommand(fmt.Sprintf("bundle build -f %s", bundlePath))
 	g.Expect(err).ToNot(HaveOccurred())
+
+	atomicBundlePath := filepath.Join(t.TempDir(), "bundle.cue")
+	g.Expect(os.WriteFile(atomicBundlePath, []byte(bundle), 0o644)).To(Succeed())
+	stdout, _, err := executeCommandWithOutErr(fmt.Sprintf("bundle build --update --oci %s -f %s", mapping, atomicBundlePath))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(stdout).To(HavePrefix("---\n"))
+	g.Expect(stdout).To(ContainSubstring("app.kubernetes.io/version: 1.1.0"))
+	atomicUpdated, err := os.ReadFile(atomicBundlePath)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(atomicUpdated)).To(ContainSubstring("url: \"file://" + archive + "\""))
+}
+
+func Test_BundleBuildUpdateMixedLocalSources(t *testing.T) {
+	g := NewWithT(t)
+	root := t.TempDir()
+	module := filepath.Join(root, "module")
+	g.Expect(os.CopyFS(module, os.DirFS("testdata/module"))).To(Succeed())
+	vendor := filepath.Join(module, "cue.mod/pkg/timoni.sh")
+	g.Expect(os.Remove(vendor)).To(Succeed())
+	g.Expect(os.MkdirAll(vendor, 0o755)).To(Succeed())
+	g.Expect(os.CopyFS(vendor, os.DirFS("../../schemas/timoni.sh"))).To(Succeed())
+
+	indexedDigest, err := engine.ModuleSourceDigest(module)
+	g.Expect(err).ToNot(HaveOccurred())
+	build, err := oci.BuildModuleImage(module, nil, map[string]string{
+		apiv1.VersionAnnotation: "1.1.0",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	archive := filepath.Join(root, "module.oci.tar")
+	g.Expect(oci.WriteImage(build.Image, archive, oci.FormatArchive, []string{"1.1.0"})).To(Succeed())
+	g.Expect(build.Close()).To(Succeed())
+
+	indexedRepository := "oci://registry.example/indexed/module"
+	artifactRepository := "oci://registry.example/artifact/module"
+	indexPath := filepath.Join(root, "module-index.cue")
+	index := fmt.Sprintf(`modules: {
+	"%s": versions: {
+		"1.0.0": {source: "file://%s", digest: "%s"}
+		"1.1.0": {source: "file://%s", digest: "%s"}
+	}
+}
+`, indexedRepository, module, indexedDigest, module, indexedDigest)
+	g.Expect(os.WriteFile(indexPath, []byte(index), 0o644)).To(Succeed())
+
+	bundlePath := filepath.Join(root, "bundle.cue")
+	bundle := fmt.Sprintf(`bundle: {
+	apiVersion: "v1alpha1"
+	name: "test"
+	instances: {
+		indexed: {
+			module: url: "file://%s"
+			module: version: "1.0.0" @timoni(update:semver:*)
+			module: digest: "%s"
+			namespace: "test"
+			values: priority: 10
+		}
+		artifact: {
+			module: url: "%s"
+			module: version: "1.0.0" @timoni(update:semver:*)
+			module: digest: "sha256:%s"
+			namespace: "test"
+			values: priority: 10
+		}
+	}
+}
+`, module, indexedDigest, artifactRepository, strings.Repeat("0", 64))
+	g.Expect(os.WriteFile(bundlePath, []byte(bundle), 0o644)).To(Succeed())
+
+	stdout, _, err := executeCommandWithOutErr(fmt.Sprintf(
+		"bundle build --update --local-index %s --oci %s=%s -f %s",
+		indexPath, artifactRepository, archive, bundlePath,
+	))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(stdout).To(HavePrefix("---\n"))
+	g.Expect(stdout).To(ContainSubstring("app.kubernetes.io/version: 1.1.0"))
+
+	updated, err := os.ReadFile(bundlePath)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(updated)).To(ContainSubstring("url: \"file://" + module + "\""))
+	g.Expect(string(updated)).To(ContainSubstring("url: \"file://" + archive + "\""))
 }

--- a/cmd/timoni/bundle_update_test.go
+++ b/cmd/timoni/bundle_update_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/engine"
 	"github.com/stefanprodan/timoni/internal/oci"
@@ -122,6 +124,40 @@ bundle: {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(output).To(ContainSubstring("all module references are up to date"))
 		g.Expect(readFile(bundlePath)).To(Equal(updated))
+	})
+
+	t.Run("vets staged updates before writing", func(t *testing.T) {
+		g := NewWithT(t)
+		bundlePath := writeBundle(bundleData)
+
+		output, err := executeCommand(fmt.Sprintf("bundle update --vet -f %s", bundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("pinned: oci://" + modURL + " 1.0.0@"))
+		g.Expect(readFile(bundlePath)).To(ContainSubstring(`version: "1.1.0" @timoni(update:semver:1.x)`))
+
+		output, err = executeCommand(fmt.Sprintf("bundle update --vet -f %s", bundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("all module references are up to date"))
+	})
+
+	t.Run("vets a dry-run without writing", func(t *testing.T) {
+		g := NewWithT(t)
+		bundlePath := writeBundle(bundleData)
+
+		output, err := executeCommand(fmt.Sprintf("bundle update --vet --dry-run -f %s", bundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("(dry run)"))
+		g.Expect(readFile(bundlePath)).To(Equal(bundleData))
+	})
+
+	t.Run("does not write when staged vet fails", func(t *testing.T) {
+		g := NewWithT(t)
+		invalid := strings.Replace(bundleData, "\t\t\tnamespace: \"test\"", "\t\t\tnamespace: \"\"", 1)
+		bundlePath := writeBundle(invalid)
+
+		_, err := executeCommand(fmt.Sprintf("bundle update --vet -f %s", bundlePath))
+		g.Expect(err).To(MatchError(ContainSubstring("failed to build bundle")))
+		g.Expect(readFile(bundlePath)).To(Equal(invalid))
 	})
 
 	t.Run("updates the unmarked references to the level", func(t *testing.T) {
@@ -238,7 +274,7 @@ bundle: {
 		g.Expect(output).To(ContainSubstring("1.0.0@" + digestOne + " -> 1.1.0@" + digestTwo))
 		g.Expect(readFile(bundlePath)).To(Equal(bundle))
 
-		_, err = executeCommand(fmt.Sprintf("bundle update --local-index %s -f %s", indexPath, bundlePath))
+		_, err = executeCommand(fmt.Sprintf("bundle update --local-index %s --vet -f %s", indexPath, bundlePath))
 		g.Expect(err).ToNot(HaveOccurred())
 		updated := readFile(bundlePath)
 		g.Expect(updated).To(ContainSubstring("file://" + moduleTwo))
@@ -324,7 +360,6 @@ bundle: {
 	})
 }
 
- 
 func TestWriteBundleFilesRejectsConcurrentChange(t *testing.T) {
 	g := NewWithT(t)
 	file := filepath.Join(t.TempDir(), "bundle.cue")
@@ -336,6 +371,43 @@ func TestWriteBundleFilesRejectsConcurrentChange(t *testing.T) {
 	data, err := os.ReadFile(file)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(data).To(Equal([]byte("changed")))
+}
+
+func TestRunBundleVetUsesStagedOverrides(t *testing.T) {
+	g := NewWithT(t)
+	bundlePath := filepath.Join(t.TempDir(), "bundle.cue")
+	original := `bundle: {
+	apiVersion: "v1alpha1"
+	name: "test"
+	instances: test: {
+		module: {
+			url: "oci://docker.io/test"
+			version: "latest"
+		}
+		namespace: ""
+		values: {}
+	}
+}
+`
+	staged := strings.Replace(original, `namespace: ""`, `namespace: "default"`, 1)
+	g.Expect(os.WriteFile(bundlePath, []byte(original), 0o644)).To(Succeed())
+
+	previousBundleArgs := bundleArgs
+	previousVetArgs := bundleVetArgs
+	t.Cleanup(func() {
+		bundleArgs = previousBundleArgs
+		bundleVetArgs = previousVetArgs
+	})
+	bundleArgs = bundleFlags{}
+	bundleVetArgs = bundleVetFlags{}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := runBundleVet(cmd, []string{bundlePath}, true, map[string][]byte{bundlePath: []byte(staged)})
+	g.Expect(err).ToNot(HaveOccurred())
+	data, err := os.ReadFile(bundlePath)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(data).To(Equal([]byte(original)))
 }
 
 func Test_BundleUpdateLocalOCI(t *testing.T) {
@@ -383,7 +455,7 @@ func Test_BundleUpdateLocalOCI(t *testing.T) {
 	g.Expect(output).To(ContainSubstring("1.0.0@sha256:" + strings.Repeat("0", 64) + " -> 1.1.0@" + digest))
 	g.Expect(readBundle()).To(Equal(bundle))
 
-	_, err = executeCommand(fmt.Sprintf("bundle update --oci %s -f %s", mapping, bundlePath))
+	_, err = executeCommand(fmt.Sprintf("bundle update --oci %s --vet -f %s", mapping, bundlePath))
 	g.Expect(err).ToNot(HaveOccurred())
 	updated := readBundle()
 	g.Expect(updated).To(ContainSubstring("url: \"file://" + archive + "\""))

--- a/cmd/timoni/bundle_update_test.go
+++ b/cmd/timoni/bundle_update_test.go
@@ -25,6 +25,9 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	. "github.com/onsi/gomega"
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/oci"
 )
 
 func Test_BundleUpdate(t *testing.T) {
@@ -81,6 +84,7 @@ bundle: {
 		}
 	}
 }
+
 `, modURL, digestOf("1.0.0"))
 
 	t.Run("prints the updates without modifying the files", func(t *testing.T) {
@@ -190,4 +194,172 @@ bundle: {
 		g.Expect(err).To(MatchError(ContainSubstring("instances unmarked: listing versions of")))
 		g.Expect(readFile(bundlePath)).To(Equal(unreachable))
 	})
+
+	t.Run("updates an indexed local module in dry-run and apply modes", func(t *testing.T) {
+		g := NewWithT(t)
+		root := t.TempDir()
+		moduleOne := filepath.Join(root, "module-1.0.0")
+		moduleTwo := filepath.Join(root, "module-1.1.0")
+		for _, module := range []string{moduleOne, moduleTwo} {
+			g.Expect(os.MkdirAll(module, 0o755)).To(Succeed())
+			g.Expect(os.WriteFile(filepath.Join(module, "marker"), []byte(module), 0o644)).To(Succeed())
+		}
+		digestOne, err := engine.ModuleSourceDigest(moduleOne)
+		g.Expect(err).ToNot(HaveOccurred())
+		digestTwo, err := engine.ModuleSourceDigest(moduleTwo)
+		g.Expect(err).ToNot(HaveOccurred())
+		indexPath := filepath.Join(root, "module-index.cue")
+		index := fmt.Sprintf(`modules: {
+	"oci://registry.example/test/module": versions: {
+		"1.0.0": {source: "file://%s", digest: "%s"}
+		"1.1.0": {source: "file://%s", digest: "%s"}
+	}
+}
+`, moduleOne, digestOne, moduleTwo, digestTwo)
+		g.Expect(os.WriteFile(indexPath, []byte(index), 0o644)).To(Succeed())
+		bundlePath := filepath.Join(root, "bundle.cue")
+		bundle := fmt.Sprintf(`bundle: {
+	apiVersion: "v1alpha1"
+	name: "test"
+	instances: app: {
+		module: url: "file://%s"
+		module: version: "1.0.0" @timoni(update:semver:*)
+		module: digest: "%s"
+		namespace: "test"
+		values: {}
+	}
+}
+`, moduleOne, digestOne)
+		g.Expect(os.WriteFile(bundlePath, []byte(bundle), 0o644)).To(Succeed())
+
+		output, err := executeCommand(fmt.Sprintf("bundle update --local-index %s -f %s --dry-run", indexPath, bundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("file://" + moduleOne + " -> file://" + moduleTwo))
+		g.Expect(output).To(ContainSubstring("1.0.0@" + digestOne + " -> 1.1.0@" + digestTwo))
+		g.Expect(readFile(bundlePath)).To(Equal(bundle))
+
+		_, err = executeCommand(fmt.Sprintf("bundle update --local-index %s -f %s", indexPath, bundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		updated := readFile(bundlePath)
+		g.Expect(updated).To(ContainSubstring("file://" + moduleTwo))
+		g.Expect(updated).To(ContainSubstring(`version: "1.1.0" @timoni(update:semver:*)`))
+		g.Expect(updated).To(ContainSubstring(`digest: "` + digestTwo + `"`))
+	})
+
+	t.Run("switches a matching OCI module to an indexed source", func(t *testing.T) {
+		g := NewWithT(t)
+		root := t.TempDir()
+		moduleOne := filepath.Join(root, "module-1.0.0")
+		moduleTwo := filepath.Join(root, "module-1.1.0")
+		for _, module := range []string{moduleOne, moduleTwo} {
+			g.Expect(os.MkdirAll(module, 0o755)).To(Succeed())
+			g.Expect(os.CopyFS(module, os.DirFS("testdata/module"))).To(Succeed())
+			g.Expect(os.MkdirAll(filepath.Join(module, "cue.mod/pkg"), 0o755)).To(Succeed())
+			schemas, err := filepath.Abs("../../schemas/timoni.sh")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(os.Remove(filepath.Join(module, "cue.mod/pkg/timoni.sh"))).To(Succeed())
+			g.Expect(os.Symlink(schemas, filepath.Join(module, "cue.mod/pkg/timoni.sh"))).To(Succeed())
+		}
+		digestOne, err := engine.ModuleSourceDigest(moduleOne)
+		g.Expect(err).ToNot(HaveOccurred())
+		digestTwo, err := engine.ModuleSourceDigest(moduleTwo)
+		g.Expect(err).ToNot(HaveOccurred())
+		moduleURL := "oci://registry.example/test/module"
+		indexPath := filepath.Join(root, "module-index.cue")
+		index := fmt.Sprintf(`modules: {
+	"%s": versions: {
+		"1.0.0": {source: "file://%s", digest: "%s"}
+		"1.1.0": {source: "file://%s", digest: "%s"}
+	}
+}
+`, moduleURL, moduleOne, digestOne, moduleTwo, digestTwo)
+		g.Expect(os.WriteFile(indexPath, []byte(index), 0o644)).To(Succeed())
+		bundlePath := filepath.Join(root, "bundle.cue")
+		bundle := fmt.Sprintf(`bundle: {
+	apiVersion: "v1alpha1"
+	name: "test"
+	instances: app: {
+		module: url: "%s"
+		module: version: "1.0.0" @timoni(update:semver:*)
+		module: digest: "%s"
+		namespace: "test"
+		values: {}
+	}
+}
+`, moduleURL, digestOne)
+		g.Expect(os.WriteFile(bundlePath, []byte(bundle), 0o644)).To(Succeed())
+
+		output, err := executeCommand(fmt.Sprintf("bundle update --local-index %s -f %s --dry-run", indexPath, bundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring(moduleURL + " -> file://" + moduleTwo))
+		g.Expect(readFile(bundlePath)).To(Equal(bundle))
+
+		_, err = executeCommand(fmt.Sprintf("bundle update --local-index %s -f %s", indexPath, bundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		updated := readFile(bundlePath)
+		g.Expect(updated).To(ContainSubstring("file://" + moduleTwo))
+		g.Expect(updated).To(ContainSubstring(`version: "1.1.0" @timoni(update:semver:*)`))
+		g.Expect(updated).To(ContainSubstring(`digest: "` + digestTwo + `"`))
+
+		output, err = executeCommand(fmt.Sprintf("bundle build -f %s", bundlePath))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("kind: ConfigMap"))
+		g.Expect(output).To(ContainSubstring("app.kubernetes.io/version: 1.1.0"))
+	})
+}
+
+func Test_BundleUpdateLocalOCI(t *testing.T) {
+	g := NewWithT(t)
+	module := filepath.Join(t.TempDir(), "module")
+	g.Expect(os.CopyFS(module, os.DirFS("testdata/module"))).To(Succeed())
+	vendor := filepath.Join(module, "cue.mod/pkg/timoni.sh")
+	g.Expect(os.Remove(vendor)).To(Succeed())
+	g.Expect(os.MkdirAll(vendor, 0o755)).To(Succeed())
+	g.Expect(os.CopyFS(vendor, os.DirFS("../../schemas/timoni.sh"))).To(Succeed())
+	build, err := oci.BuildModuleImage(module, nil, map[string]string{
+		apiv1.VersionAnnotation: "1.1.0",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	archive := filepath.Join(t.TempDir(), "module.oci.tar")
+	g.Expect(oci.WriteImage(build.Image, archive, oci.FormatArchive, []string{"1.1.0"})).To(Succeed())
+	digest := build.Digest.String()
+	g.Expect(build.Close()).To(Succeed())
+
+	repository := "oci://registry.example/team/module"
+	bundlePath := filepath.Join(t.TempDir(), "bundle.cue")
+	bundle := fmt.Sprintf(`bundle: {
+	apiVersion: "v1alpha1"
+	name: "test"
+	instances: app: {
+		module: url: "%s"
+		module: version: "1.0.0" @timoni(update:semver:*)
+		module: digest: "sha256:%s"
+		namespace: "test"
+		values: priority: 10
+	}
+}
+`, repository, strings.Repeat("0", 64))
+	g.Expect(os.WriteFile(bundlePath, []byte(bundle), 0o644)).To(Succeed())
+	readBundle := func() string {
+		data, err := os.ReadFile(bundlePath)
+		g.Expect(err).ToNot(HaveOccurred())
+		return string(data)
+	}
+	mapping := repository + "=" + archive
+
+	output, err := executeCommand(fmt.Sprintf("bundle update --oci %s -f %s --dry-run", mapping, bundlePath))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("source " + repository + " -> file://" + archive))
+	g.Expect(output).To(ContainSubstring("1.0.0@sha256:" + strings.Repeat("0", 64) + " -> 1.1.0@" + digest))
+	g.Expect(readBundle()).To(Equal(bundle))
+
+	_, err = executeCommand(fmt.Sprintf("bundle update --oci %s -f %s", mapping, bundlePath))
+	g.Expect(err).ToNot(HaveOccurred())
+	updated := readBundle()
+	g.Expect(updated).To(ContainSubstring("url: \"file://" + archive + "\""))
+	g.Expect(updated).To(ContainSubstring(`version: "1.1.0" @timoni(update:semver:*)`))
+	g.Expect(updated).To(ContainSubstring(`digest: "` + digest + `"`))
+
+	_, err = executeCommand(fmt.Sprintf("bundle build -f %s", bundlePath))
+	g.Expect(err).ToNot(HaveOccurred())
 }

--- a/cmd/timoni/bundle_vet.go
+++ b/cmd/timoni/bundle_vet.go
@@ -98,8 +98,11 @@ func init() {
 
 // runBundleVetCmd validates a bundle definition with runtime values from the environment or clusters.
 func runBundleVetCmd(cmd *cobra.Command, args []string) error {
+	return runBundleVet(cmd, bundleVetArgs.files, bundleVetArgs.offline, nil)
+}
+
+func runBundleVet(cmd *cobra.Command, files []string, offline bool, overrides map[string][]byte) error {
 	log := LoggerFrom(cmd.Context())
-	files := bundleVetArgs.files
 	if len(files) == 0 {
 		return fmt.Errorf("no bundle provided with -f")
 	}
@@ -126,10 +129,11 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 	cuectx := cuecontext.New()
 	bm := engine.NewBundleBuilder(cuectx, files)
 	bm.SetWorkdir(workdir)
+	bm.SetFileOverrides(overrides)
 
 	runtimeValues := make(map[string]string)
 
-	if bundleArgs.runtimeFromEnv || bundleVetArgs.offline {
+	if bundleArgs.runtimeFromEnv || offline {
 		maps.Copy(runtimeValues, engine.GetEnv())
 	}
 
@@ -138,7 +142,7 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if bundleVetArgs.offline {
+	if offline {
 		for _, ref := range rt.Refs {
 			for key := range ref.Expressions {
 				if _, found := runtimeValues[key]; !found {
@@ -165,7 +169,7 @@ func runBundleVetCmd(cmd *cobra.Command, args []string) error {
 		maps.Copy(clusterValues, runtimeValues)
 
 		// add values from cluster
-		if len(rt.Refs) > 0 && !bundleVetArgs.offline {
+		if len(rt.Refs) > 0 && !offline {
 			rm, err := runtime.NewResourceManager(kubeconfigArgs)
 			if err != nil {
 				return err

--- a/cmd/timoni/main_test.go
+++ b/cmd/timoni/main_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/stefanprodan/timoni/internal/engine"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -205,7 +206,7 @@ func resetCmdArgs() {
 	bundleVetArgs = bundleVetFlags{}
 	bundleUpdateArgs = bundleUpdateFlags{level: engine.UpdateLevelNone}
 	bundleDelArgs = bundleDelFlags{}
-	bundleBuildArgs = bundleBuildFlags{validate: true}
+	bundleBuildArgs = bundleBuildFlags{level: engine.UpdateLevelNone, validate: true}
 	vendorCrdArgs = vendorCrdFlags{}
 	vendorK8sArgs = vendorK8sFlags{}
 	pushArtifactArgs = pushArtifactFlags{
@@ -221,6 +222,16 @@ func resetCmdArgs() {
 	digestArtifactArgs = digestArtifactFlags{}
 	runtimeBuildArgs = runtimeBuildFlags{}
 	versionArgs = versionFlags{output: "yaml"}
+	resetFlagChanges(rootCmd)
+}
+
+func resetFlagChanges(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		flag.Changed = false
+	})
+	for _, child := range cmd.Commands() {
+		resetFlagChanges(child)
+	}
 }
 
 func rnd(prefix string) string {

--- a/docs/bundle-update.mdx
+++ b/docs/bundle-update.mdx
@@ -84,14 +84,12 @@ modules: {
 Sources are explicit: relative paths resolve from the index file, and no
 registry identity is inferred from a filesystem path. Each source must be a
 directory. Regular files and symlink target strings are hashed; other special
-files are rejected. The client verifies each digest with this deterministic
+files are rejected. The client verifies each digest using this deterministic
 tree hash before planning and fetching:
 
 ```shell
-timoni bundle update --local-index module-index.cue \
-  --dry-run -f bundle.cue
-timoni bundle update --local-index module-index.cue \
-  -f bundle.cue
+timoni bundle update --local-index module-index.cue -f bundle.cue --dry-run
+timoni bundle update --local-index module-index.cue -f bundle.cue
 ```
 
 With `--local-index`, a matching OCI reference may also switch to its indexed
@@ -117,10 +115,8 @@ artifact contains its module version and manifest digest, but not the registry
 repository name:
 
 ```shell
-timoni bundle update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar \
-  --dry-run -f bundle.cue
-timoni bundle update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar \
-  -f bundle.cue
+timoni bundle update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar -f bundle.cue --dry-run
+timoni bundle update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar -f bundle.cue
 ```
 
 Path-only inputs are rejected; Timoni never infers an OCI identity from a

--- a/docs/bundle-update.mdx
+++ b/docs/bundle-update.mdx
@@ -60,6 +60,76 @@ files untouched.
 To print the available updates without modifying the files,
 use the `--dry-run` flag.
 
+## Updating indexed local modules
+
+Local `file://` modules are skipped unless an explicit local index is supplied.
+The index is a CUE file that maps each module identity and semantic version to
+a local module directory and its source-tree digest:
+
+```cue
+modules: {
+	"oci://registry.example/team/app": versions: {
+		"1.0.0": {
+			source: "file://modules/app-1.0.0"
+			digest: "sha256:<64-hex-digest>"
+		}
+		"1.1.0": {
+			source: "file://modules/app-1.1.0"
+			digest: "sha256:<64-hex-digest>"
+		}
+	}
+}
+```
+
+Sources are explicit: relative paths resolve from the index file, and no
+registry identity is inferred from a filesystem path. Each source must be a
+directory. Regular files and symlink target strings are hashed; other special
+files are rejected. The client verifies each digest with this deterministic
+tree hash before planning and fetching:
+
+```shell
+timoni bundle update --local-index module-index.cue \
+  --dry-run -f bundle.cue
+timoni bundle update --local-index module-index.cue \
+  -f bundle.cue
+```
+
+With `--local-index`, a matching OCI reference may also switch to its indexed
+`file://` source. OCI references absent from the index keep the registry
+fallback. The update rewrites the module URL, version, and pinned digest
+together. The digest in this local-source path is a source-tree digest; an OCI
+reference continues to use its artifact digest. Timoni verifies the indexed
+source before planning and the shared bundle fetcher verifies it again before
+rendering, so stale, missing, or mismatched sources fail before any bundle file
+is written. `--dry-run` leaves bundle files byte-for-byte unchanged. Validate
+and render the updated bundle after writing:
+
+```shell
+timoni bundle vet -f bundle.cue
+timoni bundle build -f bundle.cue --mask-secrets
+```
+
+## Updating local OCI artifacts
+
+Use the repeatable `--oci oci://repository=path` flag for a local OCI archive
+or image layout directory. The repository mapping is required because a local
+artifact contains its module version and manifest digest, but not the registry
+repository name:
+
+```shell
+timoni bundle update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar \
+  --dry-run -f bundle.cue
+timoni bundle update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar \
+  -f bundle.cue
+```
+
+Path-only inputs are rejected; Timoni never infers an OCI identity from a
+filename or argument order. The client verifies the artifact manifest version
+and digest before planning and again while fetching it for `bundle build`, then
+rewrites the module URL to a canonical `file://` path. Local OCI mappings are
+independent of `--local-index`, and a bundle may mix remote OCI references,
+local OCI artifacts, and ordinary mutable `file://` modules.
+
 ## Update policies
 
 The `@timoni(update:...)` attribute accepts one of the following policies:
@@ -164,7 +234,7 @@ declare the same update policy, otherwise the command fails.
 The command updates only the module references defined by string literals
 in CUE files, and reports the instances it skips along with the reason:
 
-- the module URL is not an OCI URL, e.g. a `file://` local module
+- the module URL is a local `file://` reference and no `--local-index` was supplied
 - the module URL, version, or digest is set from a runtime value
 - the version is not a string literal, e.g. an interpolation or an expression
 - the version is defined in a YAML or JSON file, or in a file outside the CUE module

--- a/docs/bundle-update.mdx
+++ b/docs/bundle-update.mdx
@@ -253,6 +253,18 @@ timoni bundle vet -f bundle.cue
 timoni bundle build -f bundle.cue
 ```
 
+To validate the staged update before writing it, combine `--vet` with the
+update command:
+
+```shell
+timoni bundle update --vet -f bundle.cue
+```
+
+This validates the bundle definition, then writes updates only if vet succeeds.
+Add `--dry-run` to validate without writing. It does not render
+module instances; use `timoni bundle build --update` for the stronger atomic
+update, vet, and render workflow.
+
 ## Continuous updates with GitHub Actions
 
 To open a pull request with the updates on a schedule, run the update

--- a/docs/bundle.mdx
+++ b/docs/bundle.mdx
@@ -484,6 +484,23 @@ timoni bundle build -f bundle.cue --mask-secrets
 To write the generated manifests to disk as a directory tree instead of printing them
 to stdout, see [Export manifests to directory](#export-manifests-to-directory).
 
+To update module references and render the updated bundle in one transaction, use
+`--update` with an explicit local source authority:
+
+```shell
+timoni bundle build --update --local-index module-index.cue -f bundle.cue \
+  --runtime-from-env --mask-secrets
+timoni bundle build --update \
+  --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar \
+  -f bundle.cue --runtime-from-env --mask-secrets
+```
+
+The command plans and verifies the selected sources, then runs vet and build
+against the same in-memory inputs. It writes the bundle files and exposes
+rendered stdout only after both succeed. `--local-index` and repeatable `--oci`
+mappings may be combined; ordinary `bundle build` and `bundle update` remain
+separate workflows. `--update` cannot be used with `-f -` or `--output-dir`.
+
 ### Use values from JSON and YAML files
 
 A bundle can be defined in multiple files of different formats:
@@ -686,6 +703,20 @@ indexed local source, while an OCI identity absent from the index keeps the
 registry fallback. The updater verifies both the current and selected trees
 before rewriting the module URL, version, and digest. Without this explicit
 flag, local module references are skipped.
+
+The same authorities can be used directly by the build transaction:
+
+```shell
+timoni bundle build --update --local-index module-index.cue -f bundle.cue
+timoni bundle build --update \
+  --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar \
+  -f bundle.cue
+```
+
+The repeatable `--oci` mapping names the repository explicitly because a local
+archive or image layout does not carry its destination repository. A path-only
+mapping is rejected. The selected local artifact is verified before the staged
+bundle is rendered.
 
 ### Export manifests to directory
 

--- a/docs/bundle.mdx
+++ b/docs/bundle.mdx
@@ -671,10 +671,21 @@ bundle: {
 When using local paths, the `url` field must be in the format `file://path/to/module`
 and the module path is computed relatively to the path of the bundle file location.
 
-Note that when using local modules, the module's version and digest are ignored, as these
-are only relevant when pulling modules from a container registry.
-All instances created from modules referenced with local paths have
-the module version set to `0.0.0-devel`.
+For an ordinary local module, the version and digest are ignored because the
+source is read directly from disk, and the instance version is
+`0.0.0-devel`. An indexed local update is the reproducible exception: it
+rewrites and verifies the source-tree digest and carries the indexed semantic
+version through bundle rendering.
+
+For reproducible local updates, pass `--local-index <index.cue>` to
+`timoni bundle update`. The CUE index maps exact OCI module identities and
+semantic versions to `file://` source trees with pinned `sha256:<64 hex>`
+source-tree digests; regular files and symlink target strings are hashed while
+other special files are rejected. A matching OCI reference may switch to the
+indexed local source, while an OCI identity absent from the index keeps the
+registry fallback. The updater verifies both the current and selected trees
+before rewriting the module URL, version, and digest. Without this explicit
+flag, local module references are skipped.
 
 ### Export manifests to directory
 

--- a/docs/bundle.mdx
+++ b/docs/bundle.mdx
@@ -488,11 +488,8 @@ To update module references and render the updated bundle in one transaction, us
 `--update` with an explicit local source authority:
 
 ```shell
-timoni bundle build --update --local-index module-index.cue -f bundle.cue \
-  --runtime-from-env --mask-secrets
-timoni bundle build --update \
-  --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar \
-  -f bundle.cue --runtime-from-env --mask-secrets
+timoni bundle build --update --local-index module-index.cue -f bundle.cue --runtime-from-env --mask-secrets
+timoni bundle build --update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar -f bundle.cue --runtime-from-env --mask-secrets
 ```
 
 The command plans and verifies the selected sources, then runs vet and build
@@ -704,13 +701,11 @@ registry fallback. The updater verifies both the current and selected trees
 before rewriting the module URL, version, and digest. Without this explicit
 flag, local module references are skipped.
 
-The same authorities can be used directly by the build transaction:
+The same source mappings can be used directly by the build transaction:
 
 ```shell
 timoni bundle build --update --local-index module-index.cue -f bundle.cue
-timoni bundle build --update \
-  --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar \
-  -f bundle.cue
+timoni bundle build --update --oci oci://registry.example/team/app=.local/artifacts/app.oci.tar -f bundle.cue
 ```
 
 The repeatable `--oci` mapping names the repository explicitly because a local

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/sirupsen/logrus v1.10.1
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	golang.org/x/sync v0.22.0
 	k8s.io/api v0.36.4
 	k8s.io/apiextensions-apiserver v0.36.4
@@ -133,7 +134,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/internal/engine/bundle_builder.go
+++ b/internal/engine/bundle_builder.go
@@ -37,6 +37,7 @@ import (
 type BundleBuilder struct {
 	ctx               *cue.Context
 	files             []string
+	fileOverrides     map[string][]byte
 	root              string
 	workdir           string
 	workspacesFiles   map[string][]string
@@ -76,6 +77,31 @@ func (b *BundleBuilder) SetWorkdir(dir string) {
 	b.workdir = dir
 }
 
+// SetFileOverrides supplies in-memory contents for bundle and imported package
+// files. The overrides are used for the build only and are never written to
+// disk.
+func (b *BundleBuilder) SetFileOverrides(overrides map[string][]byte) {
+	b.fileOverrides = make(map[string][]byte, len(overrides)*2)
+	for path, data := range overrides {
+		b.fileOverrides[path] = data
+		if abs, err := filepath.Abs(path); err == nil {
+			b.fileOverrides[abs] = data
+		}
+	}
+}
+
+func (b *BundleBuilder) fileContent(file string) ([]byte, error) {
+	if data, ok := b.fileOverrides[file]; ok {
+		return data, nil
+	}
+	if abs, err := filepath.Abs(file); err == nil {
+		if data, ok := b.fileOverrides[abs]; ok {
+			return data, nil
+		}
+	}
+	return os.ReadFile(file)
+}
+
 // InitWorkspace loads the bundle definitions into the in-memory workspace
 // identified by the given name, sets the bundle schema, and then it injects
 // the runtime values based on @timoni() attributes. Nothing is written to
@@ -87,7 +113,7 @@ func (b *BundleBuilder) InitWorkspace(workspace string, runtimeValues map[string
 	workspaceDir := b.WorkspaceDir(workspace)
 	for i, file := range b.files {
 		_, fn := filepath.Split(file)
-		content, err := os.ReadFile(file)
+		content, err := b.fileContent(file)
 		if err != nil {
 			return fmt.Errorf("failed to read %s: %w", fn, err)
 		}
@@ -141,7 +167,10 @@ func (b *BundleBuilder) InitWorkspace(workspace string, runtimeValues map[string
 // A workspace must be initialised with InitWorkspace before calling this function.
 func (b *BundleBuilder) Build(workspace string) (cue.Value, error) {
 	var value cue.Value
-	overlay := make(map[string]load.Source, len(b.workspacesSources[workspace]))
+	overlay := make(map[string]load.Source, len(b.workspacesSources[workspace])+len(b.fileOverrides))
+	for file, data := range b.fileOverrides {
+		overlay[file] = load.FromBytes(data)
+	}
 	for f, data := range b.workspacesSources[workspace] {
 		overlay[f] = load.FromBytes(data)
 	}

--- a/internal/engine/bundle_builder_test.go
+++ b/internal/engine/bundle_builder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -110,6 +111,24 @@ bundle: {
 			s, _ := v.String()
 			return s
 		}, Equal("from-runtime")))
+	})
+
+	t.Run("builds from file overrides without writing them", func(t *testing.T) {
+		g := NewWithT(t)
+		overridden := bytes.Replace([]byte(bundleData), []byte(`version: "1.0.0"`), []byte(`version: "2.0.0"`), 1)
+		overriddenBuilder := NewBundleBuilder(ctx, []string{bundleFile})
+		overriddenBuilder.SetFileOverrides(map[string][]byte{bundleFile: overridden})
+		g.Expect(overriddenBuilder.InitWorkspace("overridden", map[string]string{"TEST_WORKSPACE_MSG": "from-runtime"})).To(Succeed())
+
+		v, err := overriddenBuilder.Build("overridden")
+		g.Expect(err).ToNot(HaveOccurred())
+		bundle, err := overriddenBuilder.GetBundle(v)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(bundle.Instances[0].Module.Version).To(Equal("2.0.0"))
+
+		disk, err := os.ReadFile(bundleFile)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(disk).To(Equal([]byte(bundleData)))
 	})
 
 	t.Run("resolves relative file URLs against the origin", func(t *testing.T) {

--- a/internal/engine/bundle_updater.go
+++ b/internal/engine/bundle_updater.go
@@ -111,6 +111,8 @@ type UpdatePolicy struct {
 type UpdateChange struct {
 	Instances   []string
 	Repository  string
+	FromSource  string
+	ToSource    string
 	FromVersion string
 	ToVersion   string
 	FromDigest  string
@@ -120,6 +122,7 @@ type UpdateChange struct {
 	Files []string
 
 	versionLit *bundleLiteral
+	sourceLits []*bundleLiteral
 	digestLits []*bundleLiteral
 }
 
@@ -167,8 +170,11 @@ type bundleFile struct {
 type updateTarget struct {
 	instance   string
 	repository string
+	source     string
 	version    string
 	digest     string
+	sourceLit  *bundleLiteral
+	indexed    bool
 	policies   []UpdatePolicy
 	versionLit *bundleLiteral
 	digestLit  *bundleLiteral
@@ -185,6 +191,7 @@ type updateTarget struct {
 type updateGroup struct {
 	targets    []*updateTarget
 	policies   []UpdatePolicy
+	sourceLits []*bundleLiteral
 	digestLits []*bundleLiteral
 }
 
@@ -208,6 +215,8 @@ type BundleUpdater struct {
 	workspaceFiles []string
 	packageFiles   []string
 	value          cue.Value
+	localIndex     *LocalModuleIndexLister
+	localArtifacts *LocalModuleArtifactLister
 }
 
 // NewBundleUpdater creates a BundleUpdater for the given bundle files.
@@ -225,6 +234,18 @@ func NewBundleUpdater(ctx *cue.Context, files []string) *BundleUpdater {
 // cue.mod module root, enabling imports in the bundle definitions.
 func (u *BundleUpdater) SetWorkdir(dir string) {
 	u.workdir = dir
+}
+
+// SetLocalIndex enables bundle updates for local modules through an explicit
+// index. Without an index, file:// module references remain excluded.
+func (u *BundleUpdater) SetLocalIndex(index *LocalModuleIndexLister) {
+	u.localIndex = index
+}
+
+// SetLocalArtifacts enables bundle updates from explicitly mapped local OCI
+// archives and image layouts.
+func (u *BundleUpdater) SetLocalArtifacts(artifacts *LocalModuleArtifactLister) {
+	u.localArtifacts = artifacts
 }
 
 // SetLevel sets the update level applied to the module references
@@ -528,6 +549,73 @@ func policiesOf(v cue.Value, lit *bundleLiteral) ([]UpdatePolicy, error) {
 	return policies, nil
 }
 
+// resolveTargetSource resolves the module source of a bundle instance and
+// reports whether the target can be considered for updating.
+func (u *BundleUpdater) resolveTargetSource(t *updateTarget, vURL cue.Value) (bool, error) {
+	if strings.HasPrefix(t.repository, apiv1.LocalPrefix) {
+		if u.localIndex == nil && u.localArtifacts == nil {
+			t.skip = "module is not an OCI artifact"
+			return false, nil
+		}
+		baseDir := filepath.Dir(vURL.Pos().Filename())
+		if t.sourceLit != nil {
+			baseDir = filepath.Dir(t.sourceLit.file.origin)
+		}
+		var identity string
+		var ok bool
+		var resolveErr error
+		if u.localIndex != nil {
+			identity, ok, resolveErr = u.localIndex.ResolveIdentity(t.repository, baseDir)
+		}
+		if u.localArtifacts != nil {
+			artifactIdentity, artifactOK, artifactErr := u.localArtifacts.ResolveIdentity(t.repository, baseDir)
+			if artifactErr != nil {
+				return false, fmt.Errorf("instance %s: %w", t.instance, artifactErr)
+			}
+			if ok && artifactOK && identity != artifactIdentity {
+				return false, fmt.Errorf("instance %s: local source maps to conflicting module identities %s and %s", t.instance, identity, artifactIdentity)
+			}
+			if artifactOK {
+				identity, ok = artifactIdentity, true
+			}
+		}
+		if resolveErr != nil {
+			return false, fmt.Errorf("instance %s: %w", t.instance, resolveErr)
+		}
+		if !ok {
+			t.skip = "module source is not in the local index"
+			return false, nil
+		}
+		t.repository = identity
+		t.indexed = true
+		if t.sourceLit == nil {
+			t.skip = "module url is not a rewritable CUE literal"
+			return false, nil
+		}
+		return true, nil
+	}
+	if !strings.HasPrefix(t.repository, apiv1.ArtifactPrefix) {
+		t.skip = "module is not an OCI artifact"
+		return false, nil
+	}
+	if u.localIndex == nil && u.localArtifacts == nil {
+		return true, nil
+	}
+	indexOK := false
+	if u.localIndex != nil {
+		_, indexOK = u.localIndex.entries[t.repository]
+	}
+	artifactOK := u.localArtifacts != nil && u.localArtifacts.HasRepository(t.repository)
+	if indexOK || artifactOK {
+		t.indexed = true
+		if t.sourceLit == nil {
+			t.skip = "module url is not a rewritable CUE literal"
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 // targets resolves the module reference of each bundle instance
 // to the literals defining its version and digest.
 func (u *BundleUpdater) targets() ([]*updateTarget, error) {
@@ -557,8 +645,13 @@ func (u *BundleUpdater) targets() ([]*updateTarget, error) {
 			t.skip = "module url is not concrete"
 			continue
 		}
-		if !strings.HasPrefix(t.repository, apiv1.ArtifactPrefix) {
-			t.skip = "module is not an OCI artifact"
+		t.source = t.repository
+		t.sourceLit = u.lookupLiteral(vURL)
+		canUpdateSource, err := u.resolveTargetSource(t, vURL)
+		if err != nil {
+			return nil, err
+		}
+		if !canUpdateSource {
 			continue
 		}
 
@@ -608,6 +701,10 @@ func (u *BundleUpdater) targets() ([]*updateTarget, error) {
 				}
 			}
 		}
+		if t.indexed && t.digestLit == nil {
+			t.skip = "indexed module requires a digest literal"
+			continue
+		}
 
 		if t.versionLit == nil {
 			if _, isField := vVersion.Source().(*ast.Field); isField {
@@ -655,6 +752,9 @@ func groupTargets(targets []*updateTarget) ([]*updateGroup, error) {
 				g.targets[0].instance, t.instance, g.targets[0].repository, t.repository)
 		}
 		g.targets = append(g.targets, t)
+		if t.sourceLit != nil && !slices.Contains(g.sourceLits, t.sourceLit) {
+			g.sourceLits = append(g.sourceLits, t.sourceLit)
+		}
 		for _, p := range t.policies {
 			if !slices.Contains(g.policies, p) {
 				g.policies = append(g.policies, p)
@@ -736,6 +836,45 @@ func (g *updateGroup) policy(level string) (UpdatePolicy, string, error) {
 	}
 }
 
+func verifyIndexedSource(ctx context.Context, resolver ModuleSourceLister, first *updateTarget, names []string, version string) error {
+	if !first.indexed || resolver == nil {
+		return nil
+	}
+	expectedSource, err := resolver.ResolveSource(ctx, first.repository, version)
+	if err != nil {
+		return fmt.Errorf("instances %s: verifying local source for %s version %s failed: %w", strings.Join(names, ", "), first.repository, version, err)
+	}
+	if !strings.HasPrefix(first.source, apiv1.LocalPrefix) {
+		return nil
+	}
+	currentSource, resolveErr := canonicalLocalSource(first.source, filepath.Dir(first.sourceLit.file.origin))
+	if resolveErr != nil || currentSource != expectedSource {
+		return fmt.Errorf("instances %s: local source does not match the indexed %s version %s", strings.Join(names, ", "), first.repository, version)
+	}
+	return nil
+}
+
+func resolveIndexedSource(ctx context.Context, resolver ModuleSourceLister, first *updateTarget, version string) (string, error) {
+	if !first.indexed || resolver == nil {
+		return "", nil
+	}
+	source, err := resolver.ResolveSource(ctx, first.repository, version)
+	if err != nil {
+		return "", fmt.Errorf("resolving local source for %s version %s failed: %w", first.repository, version, err)
+	}
+	if strings.HasPrefix(first.source, apiv1.LocalPrefix) {
+		baseDir := filepath.Dir(first.sourceLit.file.origin)
+		currentSource, resolveErr := canonicalLocalSource(first.source, baseDir)
+		if resolveErr == nil && currentSource == source {
+			return "", nil
+		}
+		if source == "" {
+			return first.repository, nil
+		}
+	}
+	return source, nil
+}
+
 // Plan computes the module reference changes for the bundle instances
 // by listing the module versions with the given lister and selecting
 // the version according to the update policy of each instance. The digest
@@ -804,6 +943,11 @@ func (u *BundleUpdater) Plan(ctx context.Context, lister ModuleVersionLister) (*
 		}
 
 		current, digestDrift := g.current()
+		resolver, _ := lister.(ModuleSourceLister)
+		if err := verifyIndexedSource(ctx, resolver, first, names, current.Version); err != nil {
+			errs = append(errs, err)
+			continue
+		}
 		next, err := selectVersion(policy, current, list)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("instances %s: %w", strings.Join(names, ", "), err))
@@ -821,7 +965,12 @@ func (u *BundleUpdater) Plan(ctx context.Context, lister ModuleVersionLister) (*
 				digestDrift = true
 			}
 		}
-		if next.Version == current.Version && !digestDrift {
+		toSource, err := resolveIndexedSource(ctx, resolver, first, next.Version)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("instances %s: %w", strings.Join(names, ", "), err))
+			continue
+		}
+		if next.Version == current.Version && !digestDrift && toSource == "" {
 			skip("up to date")
 			continue
 		}
@@ -829,13 +978,19 @@ func (u *BundleUpdater) Plan(ctx context.Context, lister ModuleVersionLister) (*
 		change := &UpdateChange{
 			Instances:   names,
 			Repository:  first.repository,
+			FromSource:  first.source,
+			ToSource:    toSource,
 			FromVersion: current.Version,
 			ToVersion:   next.Version,
 			versionLit:  first.versionLit,
+			sourceLits:  g.sourceLits,
 			digestLits:  g.digestLits,
 		}
 		if first.versionLit != nil {
 			change.Files = append(change.Files, first.versionLit.file.origin)
+		}
+		if first.sourceLit != nil && toSource != "" && !slices.Contains(change.Files, first.sourceLit.file.origin) {
+			change.Files = append(change.Files, first.sourceLit.file.origin)
 		}
 		for _, lit := range g.digestLits {
 			if !slices.Contains(change.Files, lit.file.origin) {
@@ -856,6 +1011,11 @@ func (u *BundleUpdater) Plan(ctx context.Context, lister ModuleVersionLister) (*
 // and rebuilds the bundle to verify that the result is a valid bundle.
 func (u *BundleUpdater) Apply(plan *UpdatePlan) error {
 	for _, change := range plan.Changes {
+		if change.ToSource != "" {
+			for _, lit := range change.sourceLits {
+				lit.lit.Value = literal.String.Quote(change.ToSource)
+			}
+		}
 		if change.versionLit != nil {
 			change.versionLit.lit.Value = literal.String.Quote(change.ToVersion)
 		}

--- a/internal/engine/fetcher/fetcher.go
+++ b/internal/engine/fetcher/fetcher.go
@@ -19,6 +19,8 @@ package fetcher
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
@@ -34,6 +36,9 @@ type Options struct {
 	Source string
 	// Version is the version of the module to fetch.
 	Version string
+	// Digest is the expected content digest for a pinned local module source.
+	// An empty digest preserves the ordinary mutable local-module behavior.
+	Digest string
 	// Destination is the location to store the fetched module.
 	Destination string
 	// CacheDir is the location to store the fetched module.
@@ -54,11 +59,32 @@ func New(ctx context.Context, opts Options) (Fetcher, error) {
 	case strings.HasPrefix(opts.Source, apiv1.ArtifactPrefix):
 		return NewOCI(ctx, opts.Source, opts.Version, opts.Destination, opts.CacheDir, opts.Creds, opts.Insecure), nil
 	case strings.HasPrefix(opts.Source, apiv1.LocalPrefix):
+		if isLocalArtifact(strings.TrimPrefix(opts.Source, apiv1.LocalPrefix)) {
+			return NewLocalArtifact(opts.Source, opts.Version, opts.Digest, opts.Destination), nil
+		}
+		if opts.Digest != "" {
+			return NewLocalReference(opts.Source, opts.Version, opts.Digest), nil
+		}
 		return NewLocal(opts.Source), nil
 	default:
 		if opts.DefaultLocal {
+			if opts.Digest != "" {
+				return NewLocalReference(opts.Source, opts.Version, opts.Digest), nil
+			}
 			return NewLocal(opts.Source), nil
 		}
 		return nil, fmt.Errorf("unsupported module source %s", opts.Source)
 	}
+}
+
+func isLocalArtifact(source string) bool {
+	info, err := os.Stat(source)
+	if err != nil {
+		return false
+	}
+	if !info.IsDir() {
+		return true
+	}
+	_, err = os.Stat(filepath.Join(source, "oci-layout"))
+	return err == nil
 }

--- a/internal/engine/fetcher/local.go
+++ b/internal/engine/fetcher/local.go
@@ -25,6 +25,7 @@ import (
 
 	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
 	"github.com/stefanprodan/timoni/internal/engine"
+	"github.com/stefanprodan/timoni/internal/oci"
 )
 
 type Local struct {
@@ -32,12 +33,24 @@ type Local struct {
 	root          string
 	rootErr       error
 	requiredFiles []string
+	version       string
+	digest        string
 }
 
 // NewLocal creates a local Fetcher for the given module source directory.
 // The source is resolved to an absolute path at construction time, so a
 // later working directory change does not alter which module is fetched.
 func NewLocal(src string) *Local {
+	return newLocal(src, "", "")
+}
+
+// NewLocalReference creates a fetcher for a digest-pinned local module source.
+// Fetch verifies that the source still matches the expected digest.
+func NewLocalReference(src, version, digest string) *Local {
+	return newLocal(src, version, digest)
+}
+
+func newLocal(src, version, digest string) *Local {
 	src = strings.TrimPrefix(src, apiv1.LocalPrefix)
 	root, rootErr := filepath.Abs(src)
 	if rootErr != nil {
@@ -53,7 +66,57 @@ func NewLocal(src string) *Local {
 		root:          root,
 		rootErr:       rootErr,
 		requiredFiles: requiredFiles,
+		version:       version,
+		digest:        digest,
 	}
+}
+
+// LocalArtifact fetches a local OCI module artifact and extracts it into the
+// requested destination before the CUE loader reads it.
+type LocalArtifact struct {
+	src     string
+	root    string
+	version string
+	digest  string
+}
+
+// NewLocalArtifact creates a fetcher for a local OCI archive or image layout.
+func NewLocalArtifact(src, version, digest, destination string) *LocalArtifact {
+	src = strings.TrimPrefix(src, apiv1.LocalPrefix)
+	return &LocalArtifact{
+		src:     src,
+		root:    filepath.Join(destination, "module"),
+		version: version,
+		digest:  digest,
+	}
+}
+
+// GetModuleRoot returns the extraction directory of the local OCI artifact.
+func (f *LocalArtifact) GetModuleRoot() string { return f.root }
+
+// Fetch verifies and extracts the local OCI artifact.
+func (f *LocalArtifact) Fetch() (*apiv1.ModuleReference, error) {
+	if f.src == "" {
+		return nil, fmt.Errorf("module artifact not found at path %s", f.src)
+	}
+	if f.root == "module" {
+		return nil, fmt.Errorf("destination is required for local OCI artifact %s", f.src)
+	}
+	if err := os.MkdirAll(f.root, 0o755); err != nil {
+		return nil, fmt.Errorf("creating module destination failed: %w", err)
+	}
+	mod, err := oci.PullLocalModule(f.src, f.root)
+	if err != nil {
+		return nil, err
+	}
+	if f.version != "" && f.version != apiv1.LatestVersion && f.version != "@"+mod.Digest && f.version != mod.Version {
+		return nil, fmt.Errorf("module artifact %s version mismatch: expected %s, got %s", f.src, f.version, mod.Version)
+	}
+	if f.digest != "" && f.digest != mod.Digest {
+		return nil, fmt.Errorf("module artifact %s digest mismatch: expected %s, got %s", f.src, f.digest, mod.Digest)
+	}
+	mod.Repository = apiv1.LocalPrefix + f.src
+	return mod, nil
 }
 
 // GetModuleRoot returns the absolute path of the module source directory.
@@ -86,11 +149,21 @@ func (f *Local) Fetch() (*apiv1.ModuleReference, error) {
 		}
 	}
 
-	mr := apiv1.ModuleReference{
-		Repository: f.src,
-		Version:    engine.DefaultDevelVersion,
-		Digest:     "unknown",
+	version := engine.DefaultDevelVersion
+	digest := "unknown"
+	if f.digest != "" {
+		actual, err := engine.ModuleSourceDigest(f.root)
+		if err != nil {
+			return nil, fmt.Errorf("failed to verify module source %s: %w", f.src, err)
+		}
+		if actual != f.digest {
+			return nil, fmt.Errorf("module source %s digest mismatch: expected %s, got %s", f.src, f.digest, actual)
+		}
+		version = f.version
+		digest = f.digest
 	}
+
+	mr := apiv1.ModuleReference{Repository: f.src, Version: version, Digest: digest}
 
 	return &mr, nil
 }

--- a/internal/engine/fetcher/local_artifact_test.go
+++ b/internal/engine/fetcher/local_artifact_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fetcher
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/oci"
+)
+
+func TestLocalArtifactFetch(t *testing.T) {
+	g := NewWithT(t)
+	build, err := oci.BuildModuleImage("../../oci/testdata/module", nil, map[string]string{
+		apiv1.VersionAnnotation: "1.1.0",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	archive := filepath.Join(t.TempDir(), "module.oci.tar")
+	g.Expect(oci.WriteImage(build.Image, archive, oci.FormatArchive, []string{"1.1.0"})).To(Succeed())
+	layout := filepath.Join(t.TempDir(), "module-layout")
+	g.Expect(oci.WriteImage(build.Image, layout, oci.FormatLayout, []string{"1.1.0"})).To(Succeed())
+	digest := build.Digest.String()
+	g.Expect(build.Close()).To(Succeed())
+
+	for _, source := range []string{archive, layout} {
+		t.Run(filepath.Base(source), func(t *testing.T) {
+			g := NewWithT(t)
+			f, err := New(context.Background(), Options{
+				Source:      "file://" + source,
+				Version:     "1.1.0",
+				Digest:      digest,
+				Destination: t.TempDir(),
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+			mod, err := f.Fetch()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(mod.Repository).To(Equal("file://" + source))
+			g.Expect(mod.Version).To(Equal("1.1.0"))
+			g.Expect(mod.Digest).To(Equal(digest))
+			g.Expect(filepath.Join(f.GetModuleRoot(), "cue.mod", "module.cue")).To(BeAnExistingFile())
+		})
+	}
+}

--- a/internal/engine/fetcher/local_test.go
+++ b/internal/engine/fetcher/local_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stefanprodan/timoni/internal/engine"
 	. "github.com/stefanprodan/timoni/internal/testutils"
 )
 
@@ -107,4 +108,29 @@ func TestLocalFetch(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("module not found at path"))
 	})
+}
+
+func TestLocalFetchIndexedReference(t *testing.T) {
+	g := NewWithT(t)
+	src := t.TempDir()
+	g.Expect(os.MkdirAll(filepath.Join(src, "cue.mod"), 0o755)).To(Succeed())
+	for name, content := range map[string]string{
+		"cue.mod/module.cue": "module: \"example.com/test/module\"\n",
+		"timoni.cue":         "timoni: {}\n",
+		"values.cue":         "values: {}\n",
+	} {
+		g.Expect(os.WriteFile(filepath.Join(src, name), []byte(content), 0o644)).To(Succeed())
+	}
+	digest, err := engine.ModuleSourceDigest(src)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	lf := NewLocalReference("file://"+src, "1.2.3", digest)
+	ref, err := lf.Fetch()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ref.Version).To(Equal("1.2.3"))
+	g.Expect(ref.Digest).To(Equal(digest))
+
+	g.Expect(os.WriteFile(filepath.Join(src, "values.cue"), []byte("values: {changed: true}\n"), 0o644)).To(Succeed())
+	_, err = lf.Fetch()
+	g.Expect(err).To(MatchError(ContainSubstring("digest mismatch")))
 }

--- a/internal/engine/local_artifact.go
+++ b/internal/engine/local_artifact.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/oci"
+)
+
+type localArtifactEntry struct {
+	source string
+	digest string
+}
+
+// LocalModuleArtifactLister adds explicitly mapped local OCI artifacts to
+// module version lookup and delegates unmapped versions to its fallback provider.
+type LocalModuleArtifactLister struct {
+	entries  map[string]map[string]localArtifactEntry
+	aliases  map[string]string
+	fallback ModuleVersionLister
+}
+
+// NewLocalModuleArtifactLister loads mappings of the form
+// "oci://registry.example/team/module=/path/to/module.oci.tar". The mapping
+// is explicit because local OCI metadata does not contain the repository name.
+func NewLocalModuleArtifactLister(mappings []string, fallback ModuleVersionLister) (*LocalModuleArtifactLister, error) {
+	lister := &LocalModuleArtifactLister{
+		entries:  make(map[string]map[string]localArtifactEntry),
+		aliases:  make(map[string]string),
+		fallback: fallback,
+	}
+	for _, mapping := range mappings {
+		repository, source, ok := strings.Cut(mapping, "=")
+		if !ok || repository == apiv1.ArtifactPrefix || !strings.HasPrefix(repository, apiv1.ArtifactPrefix) || source == "" {
+			return nil, fmt.Errorf("invalid local OCI mapping %q, expected oci://repository=path", mapping)
+		}
+		source = strings.TrimPrefix(source, apiv1.LocalPrefix)
+		abs, err := filepath.Abs(source)
+		if err != nil {
+			return nil, fmt.Errorf("resolving local OCI artifact %s failed: %w", source, err)
+		}
+		version, digest, err := oci.LocalModuleMetadata(abs)
+		if err != nil {
+			return nil, fmt.Errorf("reading local OCI artifact %s failed: %w", abs, err)
+		}
+		if _, err := semver.StrictNewVersion(version); err != nil {
+			return nil, fmt.Errorf("local OCI artifact %s has invalid semantic version %q", abs, version)
+		}
+		canonical := apiv1.LocalPrefix + filepath.Clean(abs)
+		if previous, exists := lister.aliases[canonical]; exists && previous != repository {
+			return nil, fmt.Errorf("local OCI artifact %s is assigned to both %s and %s", canonical, previous, repository)
+		}
+		if previous, exists := lister.entries[repository][version]; exists {
+			if previous.digest != digest || previous.source != canonical {
+				return nil, fmt.Errorf("local OCI artifact %s version %s conflicts with another artifact", repository, version)
+			}
+		}
+		if lister.entries[repository] == nil {
+			lister.entries[repository] = make(map[string]localArtifactEntry)
+		}
+		lister.entries[repository][version] = localArtifactEntry{source: canonical, digest: digest}
+		lister.aliases[canonical] = repository
+	}
+	return lister, nil
+}
+
+// HasRepository reports whether a local artifact is mapped to the repository.
+func (l *LocalModuleArtifactLister) HasRepository(repository string) bool {
+	_, ok := l.entries[repository]
+	return ok
+}
+
+// ResolveIdentity maps a local artifact source to its explicit OCI repository.
+func (l *LocalModuleArtifactLister) ResolveIdentity(repository, baseDir string) (string, bool, error) {
+	if !strings.HasPrefix(repository, apiv1.LocalPrefix) {
+		_, ok := l.entries[repository]
+		return repository, ok, nil
+	}
+	canonical, err := canonicalLocalSource(repository, baseDir)
+	if err != nil {
+		return "", false, err
+	}
+	identity, ok := l.aliases[canonical]
+	return identity, ok, nil
+}
+
+// ListVersions returns the union of local artifact versions and fallback
+// versions, sorted newest first.
+func (l *LocalModuleArtifactLister) ListVersions(ctx context.Context, repository string) ([]string, error) {
+	versions := make(map[string]struct{})
+	for version := range l.entries[repository] {
+		versions[version] = struct{}{}
+	}
+	if l.fallback != nil {
+		fallback, err := l.fallback.ListVersions(ctx, repository)
+		if err != nil && len(versions) == 0 {
+			return nil, err
+		}
+		for _, version := range fallback {
+			versions[version] = struct{}{}
+		}
+	}
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("module %s is not in the local OCI inputs", repository)
+	}
+	result := make([]string, 0, len(versions))
+	for version := range versions {
+		result = append(result, version)
+	}
+	slices.SortFunc(result, func(a, b string) int {
+		av, _ := semver.StrictNewVersion(a)
+		bv, _ := semver.StrictNewVersion(b)
+		if av.GreaterThan(bv) {
+			return -1
+		}
+		if av.LessThan(bv) {
+			return 1
+		}
+		return 0
+	})
+	return result, nil
+}
+
+// ResolveDigest returns the verified digest of a local artifact or delegates
+// to the fallback provider for a version that is not mapped locally.
+func (l *LocalModuleArtifactLister) ResolveDigest(ctx context.Context, repository, version string) (string, error) {
+	if entry, ok := l.entries[repository][version]; ok {
+		if err := l.verify(entry, repository, version); err != nil {
+			return "", err
+		}
+		return entry.digest, nil
+	}
+	if l.fallback == nil {
+		return "", fmt.Errorf("version %s is not in the local OCI inputs for %s", version, repository)
+	}
+	return l.fallback.ResolveDigest(ctx, repository, version)
+}
+
+// ResolveSource returns the verified local artifact source for a mapped
+// version, or delegates to the fallback provider.
+func (l *LocalModuleArtifactLister) ResolveSource(ctx context.Context, repository, version string) (string, error) {
+	if entry, ok := l.entries[repository][version]; ok {
+		if err := l.verify(entry, repository, version); err != nil {
+			return "", err
+		}
+		return entry.source, nil
+	}
+	if resolver, ok := l.fallback.(ModuleSourceLister); ok {
+		return resolver.ResolveSource(ctx, repository, version)
+	}
+	return "", nil
+}
+
+func (l *LocalModuleArtifactLister) verify(entry localArtifactEntry, repository, version string) error {
+	actualVersion, digest, err := oci.LocalModuleMetadata(strings.TrimPrefix(entry.source, apiv1.LocalPrefix))
+	if err != nil {
+		return fmt.Errorf("verify local OCI artifact %s version %s failed: %w", repository, version, err)
+	}
+	if actualVersion != version {
+		return fmt.Errorf("local OCI artifact %s version mismatch: input has %s, artifact has %s", repository, version, actualVersion)
+	}
+	if digest != entry.digest {
+		return fmt.Errorf("local OCI artifact %s version %s digest mismatch: input has %s, artifact has %s", repository, version, entry.digest, digest)
+	}
+	return nil
+}

--- a/internal/engine/local_artifact_test.go
+++ b/internal/engine/local_artifact_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+	"github.com/stefanprodan/timoni/internal/oci"
+)
+
+type localArtifactFallback struct{}
+
+func (localArtifactFallback) ListVersions(_ context.Context, _ string) ([]string, error) {
+	return []string{"1.0.0"}, nil
+}
+
+func (localArtifactFallback) ResolveDigest(_ context.Context, _, _ string) (string, error) {
+	return "sha256:" + strings.Repeat("a", 64), nil
+}
+
+type remoteVersionFallback struct{}
+
+func (remoteVersionFallback) ListVersions(_ context.Context, _ string) ([]string, error) {
+	return []string{"1.2.0"}, nil
+}
+
+func (remoteVersionFallback) ResolveDigest(_ context.Context, _, _ string) (string, error) {
+	return "sha256:" + strings.Repeat("b", 64), nil
+}
+
+func TestLocalModuleArtifactLister(t *testing.T) {
+	g := NewWithT(t)
+	root := t.TempDir()
+	build, err := oci.BuildModuleImage("../oci/testdata/module", nil, map[string]string{
+		apiv1.VersionAnnotation: "1.1.0",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	archive := filepath.Join(root, "module.oci.tar")
+	g.Expect(oci.WriteImage(build.Image, archive, oci.FormatArchive, []string{"1.1.0"})).To(Succeed())
+	g.Expect(build.Close()).To(Succeed())
+
+	repository := "oci://registry.example/team/module"
+	_, err = NewLocalModuleArtifactLister([]string{archive}, nil)
+	g.Expect(err).To(MatchError(ContainSubstring("expected oci://repository=path")))
+	_, err = NewLocalModuleArtifactLister([]string{"oci://=" + archive}, nil)
+	g.Expect(err).To(MatchError(ContainSubstring("expected oci://repository=path")))
+
+	lister, err := NewLocalModuleArtifactLister([]string{repository + "=" + archive}, localArtifactFallback{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(lister.ListVersions(context.Background(), repository)).To(Equal([]string{"1.1.0", "1.0.0"}))
+	digest, err := lister.ResolveDigest(context.Background(), repository, "1.1.0")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(digest).To(HavePrefix("sha256:"))
+	source, err := lister.ResolveSource(context.Background(), repository, "1.1.0")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(source).To(Equal("file://" + archive))
+	identity, ok, err := lister.ResolveIdentity(source, root)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ok).To(BeTrue())
+	g.Expect(identity).To(Equal(repository))
+
+	remoteLister, err := NewLocalModuleArtifactLister([]string{repository + "=" + archive}, remoteVersionFallback{})
+	g.Expect(err).ToNot(HaveOccurred())
+	toRemote, err := resolveIndexedSource(context.Background(), remoteLister, &updateTarget{
+		repository: repository,
+		source:     source,
+		indexed:    true,
+		sourceLit:  &bundleLiteral{file: &bundleFile{origin: filepath.Join(root, "bundle.cue")}},
+	}, "1.2.0")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(toRemote).To(Equal(repository))
+
+	replacement, err := oci.BuildModuleImage("../oci/testdata/module", nil, map[string]string{
+		apiv1.VersionAnnotation: "1.2.0",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	replacementArchive := filepath.Join(root, "replacement.oci.tar")
+	g.Expect(oci.WriteImage(replacement.Image, replacementArchive, oci.FormatArchive, []string{"1.2.0"})).To(Succeed())
+	g.Expect(replacement.Close()).To(Succeed())
+	g.Expect(os.Rename(replacementArchive, archive)).To(Succeed())
+	_, err = lister.ResolveDigest(context.Background(), repository, "1.1.0")
+	g.Expect(err).To(MatchError(ContainSubstring("version mismatch")))
+}

--- a/internal/engine/local_index.go
+++ b/internal/engine/local_index.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/parser"
+	"github.com/Masterminds/semver/v3"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+// ModuleSourceLister extends module version lookup with verified local source
+// resolution.
+type ModuleSourceLister interface {
+	ModuleVersionLister
+	ResolveSource(ctx context.Context, repository, version string) (string, error)
+}
+
+type localIndexEntry struct {
+	source string
+	digest string
+}
+
+// LocalModuleIndexLister reads an explicit CUE index of local modules and falls
+// back to another version provider for identities not present in the index.
+// The index never derives a registry identity from a filesystem path.
+type LocalModuleIndexLister struct {
+	indexDir string
+	entries  map[string]map[string]localIndexEntry
+	aliases  map[string]string
+	fallback ModuleVersionLister
+}
+
+// NewLocalModuleIndexLister loads a CUE index whose shape is:
+//
+//	modules: {
+//	  "oci://registry.example/team/module": versions: {
+//	    "1.2.3": {source: "file://modules/module-1.2.3", digest: "sha256:..."}
+//	  }
+//	}
+//
+// Relative sources are resolved relative to the index file.
+func NewLocalModuleIndexLister(indexPath string, fallback ModuleVersionLister) (*LocalModuleIndexLister, error) {
+	content, err := os.ReadFile(indexPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read local module index %s: %w", indexPath, err)
+	}
+	indexPath, err = filepath.Abs(indexPath)
+	if err != nil {
+		return nil, err
+	}
+	file, err := parser.ParseFile(indexPath, content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse local module index: %w", err)
+	}
+	value := cuecontext.New().BuildFile(file)
+	if err := value.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid local module index: %w", err)
+	}
+
+	lister := &LocalModuleIndexLister{
+		indexDir: filepath.Dir(indexPath),
+		entries:  make(map[string]map[string]localIndexEntry),
+		aliases:  make(map[string]string),
+		fallback: fallback,
+	}
+	modules := value.LookupPath(cue.ParsePath("modules"))
+	iter, err := modules.Fields()
+	if err != nil {
+		return nil, fmt.Errorf("local module index modules must be a struct: %w", err)
+	}
+	for iter.Next() {
+		identity := iter.Selector().Unquoted()
+		if identity == "" || !strings.HasPrefix(identity, apiv1.ArtifactPrefix) {
+			return nil, fmt.Errorf("local module index identity %q must use oci://", identity)
+		}
+		versions := iter.Value().LookupPath(cue.ParsePath("versions"))
+		versionIter, err := versions.Fields()
+		if err != nil {
+			return nil, fmt.Errorf("local module index %s versions must be a struct: %w", identity, err)
+		}
+		if _, exists := lister.entries[identity]; exists {
+			return nil, fmt.Errorf("duplicate local module index identity %s", identity)
+		}
+		lister.entries[identity] = make(map[string]localIndexEntry)
+		for versionIter.Next() {
+			version := versionIter.Selector().Unquoted()
+			if _, err := semver.StrictNewVersion(version); err != nil {
+				return nil, fmt.Errorf("local module index %s has invalid semantic version %q", identity, version)
+			}
+			entryValue := versionIter.Value()
+			source, err := entryValue.LookupPath(cue.ParsePath("source")).String()
+			if err != nil || source == "" {
+				return nil, fmt.Errorf("local module index %s version %s has no source", identity, version)
+			}
+			digest, err := entryValue.LookupPath(cue.ParsePath("digest")).String()
+			if err != nil || !validSHA256Digest(digest) {
+				return nil, fmt.Errorf("local module index %s version %s has invalid SHA-256 digest", identity, version)
+			}
+			canonical, err := canonicalLocalSource(source, lister.indexDir)
+			if err != nil {
+				return nil, fmt.Errorf("local module index %s version %s: %w", identity, version, err)
+			}
+			if previous, exists := lister.aliases[canonical]; exists && previous != identity {
+				return nil, fmt.Errorf("local module source %s is assigned to both %s and %s", canonical, previous, identity)
+			}
+			lister.aliases[canonical] = identity
+			lister.entries[identity][version] = localIndexEntry{source: canonical, digest: digest}
+		}
+	}
+	return lister, nil
+}
+
+// ResolveIdentity maps a bundle repository to an indexed module identity.
+// Local source URLs are resolved relative to the bundle file that declared
+// them; OCI identities are matched exactly.
+func (l *LocalModuleIndexLister) ResolveIdentity(repository, baseDir string) (string, bool, error) {
+	if strings.HasPrefix(repository, apiv1.LocalPrefix) {
+		canonical, err := canonicalLocalSource(repository, baseDir)
+		if err != nil {
+			return "", false, err
+		}
+		identity, ok := l.aliases[canonical]
+		return identity, ok, nil
+	}
+	_, ok := l.entries[repository]
+	return repository, ok, nil
+}
+
+// ListVersions lists indexed semantic versions or delegates to the fallback.
+func (l *LocalModuleIndexLister) ListVersions(ctx context.Context, repository string) ([]string, error) {
+	entries, ok := l.entries[repository]
+	if !ok {
+		if l.fallback == nil {
+			return nil, fmt.Errorf("module %s is not in the local index", repository)
+		}
+		return l.fallback.ListVersions(ctx, repository)
+	}
+	versions := make([]string, 0, len(entries))
+	for version := range entries {
+		versions = append(versions, version)
+	}
+	slices.SortFunc(versions, func(a, b string) int {
+		av, _ := semver.StrictNewVersion(a)
+		bv, _ := semver.StrictNewVersion(b)
+		if av.GreaterThan(bv) {
+			return -1
+		}
+		if av.LessThan(bv) {
+			return 1
+		}
+		return 0
+	})
+	return versions, nil
+}
+
+// ResolveDigest returns the digest recorded for an indexed version.
+func (l *LocalModuleIndexLister) ResolveDigest(ctx context.Context, repository, version string) (string, error) {
+	entries, ok := l.entries[repository]
+	if !ok {
+		if l.fallback == nil {
+			return "", fmt.Errorf("module %s is not in the local index", repository)
+		}
+		return l.fallback.ResolveDigest(ctx, repository, version)
+	}
+	entry, ok := entries[version]
+	if !ok {
+		return "", fmt.Errorf("version %s is not in the local index for %s", version, repository)
+	}
+	return entry.digest, nil
+}
+
+// ResolveSource verifies and returns the local source recorded for an indexed
+// version.
+func (l *LocalModuleIndexLister) ResolveSource(_ context.Context, repository, version string) (string, error) {
+	entries, ok := l.entries[repository]
+	if !ok {
+		return "", nil
+	}
+	entry, ok := entries[version]
+	if !ok {
+		return "", fmt.Errorf("version %s is not in the local index for %s", version, repository)
+	}
+	actual, err := ModuleSourceDigest(strings.TrimPrefix(entry.source, apiv1.LocalPrefix))
+	if err != nil {
+		return "", fmt.Errorf("verify local module %s version %s: %w", repository, version, err)
+	}
+	if actual != entry.digest {
+		return "", fmt.Errorf("local module %s version %s digest mismatch: index has %s, source has %s", repository, version, entry.digest, actual)
+	}
+	return entry.source, nil
+}
+
+func canonicalLocalSource(source, baseDir string) (string, error) {
+	if !strings.HasPrefix(source, apiv1.LocalPrefix) {
+		return "", fmt.Errorf("source %q must use file://", source)
+	}
+	pathValue := strings.TrimPrefix(source, apiv1.LocalPrefix)
+	if pathValue == "" {
+		return "", fmt.Errorf("source is empty")
+	}
+	if !filepath.IsAbs(pathValue) {
+		pathValue = filepath.Join(baseDir, pathValue)
+	}
+	abs, err := filepath.Abs(pathValue)
+	if err != nil {
+		return "", err
+	}
+	return apiv1.LocalPrefix + filepath.Clean(abs), nil
+}

--- a/internal/engine/local_index_test.go
+++ b/internal/engine/local_index_test.go
@@ -104,7 +104,7 @@ func TestLocalModuleIndexLister_UpdateAndVerifySource(t *testing.T) {
 	g.Expect(string(formatted)).To(ContainSubstring("file://" + moduleTwo))
 	g.Expect(string(formatted)).To(ContainSubstring(digestTwo))
 
-	// Reject a source mutation before applying any bundle literal.
+	// Reject a changed source before applying any bundle updates.
 	g.Expect(os.WriteFile(filepath.Join(moduleTwo, "marker.cue"), []byte("marker: \"changed\"\n"), 0o644)).To(Succeed())
 	updater = NewBundleUpdater(cuecontext.New(), []string{bundlePath})
 	updater.SetLocalIndex(lister)

--- a/internal/engine/local_index_test.go
+++ b/internal/engine/local_index_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	. "github.com/onsi/gomega"
+)
+
+func writeIndexedModule(t *testing.T, root, marker string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "cue.mod"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"cue.mod/module.cue": "module: \"example.com/test/module\"\n",
+		"timoni.cue":         "timoni: {}\n",
+		"values.cue":         "values: {}\n",
+		"marker.cue":         "marker: \"" + marker + "\"\n",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestLocalModuleIndexLister_UpdateAndVerifySource(t *testing.T) {
+	g := NewWithT(t)
+	root := t.TempDir()
+	moduleOne := writeIndexedModule(t, filepath.Join(root, "module-1.0.0"), "one")
+	moduleTwo := writeIndexedModule(t, filepath.Join(root, "module-2.0.0"), "two")
+	digestOne, err := ModuleSourceDigest(moduleOne)
+	g.Expect(err).ToNot(HaveOccurred())
+	digestTwo, err := ModuleSourceDigest(moduleTwo)
+	g.Expect(err).ToNot(HaveOccurred())
+	indexPath := filepath.Join(root, "module-index.cue")
+	index := fmt.Sprintf(`modules: {
+	"oci://registry.example/test/module": versions: {
+		"1.0.0": {source: "file://%s", digest: "%s"}
+		"2.0.0": {source: "file://%s", digest: "%s"}
+	}
+}
+`, moduleOne, digestOne, moduleTwo, digestTwo)
+	g.Expect(os.WriteFile(indexPath, []byte(index), 0o644)).To(Succeed())
+
+	lister, err := NewLocalModuleIndexLister(indexPath, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	identity, ok, err := lister.ResolveIdentity("oci://registry.example/test/module", root)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ok).To(BeTrue())
+	g.Expect(identity).To(Equal("oci://registry.example/test/module"))
+	source, err := lister.ResolveSource(context.Background(), identity, "2.0.0")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(source).To(Equal("file://" + moduleTwo))
+	bundlePath := filepath.Join(root, "bundle.cue")
+	bundle := fmt.Sprintf(`bundle: {
+	apiVersion: "v1alpha1"
+	name: "test"
+	instances: app: {
+		module: url: "file://%s"
+		module: version: "1.0.0" @timoni(update:semver:*)
+		module: digest: "%s"
+		namespace: "test"
+		values: {}
+	}
+}
+`, moduleOne, digestOne)
+	g.Expect(os.WriteFile(bundlePath, []byte(bundle), 0o644)).To(Succeed())
+
+	updater := NewBundleUpdater(cuecontext.New(), []string{bundlePath})
+	updater.SetLocalIndex(lister)
+	g.Expect(updater.Load()).To(Succeed())
+	plan, err := updater.Plan(context.Background(), lister)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(plan.Changes).To(HaveLen(1))
+	change := plan.Changes[0]
+	g.Expect(change.ToVersion).To(Equal("2.0.0"))
+	g.Expect(change.ToDigest).To(Equal(digestTwo))
+	g.Expect(change.ToSource).To(Equal("file://" + moduleTwo))
+	g.Expect(updater.Apply(plan)).To(Succeed())
+	formatted, err := updater.Format(bundlePath)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(formatted)).To(ContainSubstring("file://" + moduleTwo))
+	g.Expect(string(formatted)).To(ContainSubstring(digestTwo))
+
+	// Reject a source mutation before applying any bundle literal.
+	g.Expect(os.WriteFile(filepath.Join(moduleTwo, "marker.cue"), []byte("marker: \"changed\"\n"), 0o644)).To(Succeed())
+	updater = NewBundleUpdater(cuecontext.New(), []string{bundlePath})
+	updater.SetLocalIndex(lister)
+	g.Expect(updater.Load()).To(Succeed())
+	_, err = updater.Plan(context.Background(), lister)
+	g.Expect(err).To(MatchError(ContainSubstring("digest mismatch")))
+}
+
+func TestModuleSourceDigest_ChangesWithSymlinkTarget(t *testing.T) {
+	g := NewWithT(t)
+	root := t.TempDir()
+	targetOne := filepath.Join(root, "target-one")
+	targetTwo := filepath.Join(root, "target-two")
+	g.Expect(os.WriteFile(targetOne, []byte("one"), 0o644)).To(Succeed())
+	g.Expect(os.WriteFile(targetTwo, []byte("two"), 0o644)).To(Succeed())
+	module := filepath.Join(root, "module")
+	g.Expect(os.Mkdir(module, 0o755)).To(Succeed())
+	link := filepath.Join(module, "link")
+	g.Expect(os.Symlink(targetOne, link)).To(Succeed())
+	digestOne, err := ModuleSourceDigest(module)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(os.Remove(link)).To(Succeed())
+	g.Expect(os.Symlink(targetTwo, link)).To(Succeed())
+	digestTwo, err := ModuleSourceDigest(module)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(digestTwo).ToNot(Equal(digestOne))
+}

--- a/internal/engine/source_digest.go
+++ b/internal/engine/source_digest.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ModuleSourceDigest returns the SHA-256 digest of a module directory.
+// The digest includes sorted relative paths and file contents; symlink target
+// strings are included without following links, which keeps the digest deterministic.
+func ModuleSourceDigest(root string) (string, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Lstat(root)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("module source %s is not a directory", root)
+	}
+
+	type sourceEntry struct {
+		path       string
+		linkTarget string
+	}
+	var files []sourceEntry
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			files = append(files, sourceEntry{path: path, linkTarget: target})
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("module source contains non-regular file %s", path)
+		}
+		files = append(files, sourceEntry{path: path})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].path < files[j].path })
+
+	h := sha256.New()
+	for _, file := range files {
+		rel, err := filepath.Rel(root, file.path)
+		if err != nil {
+			return "", err
+		}
+		rel = filepath.ToSlash(rel)
+		if _, err := io.WriteString(h, fmt.Sprintf("%d:%s\x00", len(rel), rel)); err != nil {
+			return "", err
+		}
+		if file.linkTarget != "" {
+			if _, err := io.WriteString(h, "link:"+file.linkTarget+"\x00"); err != nil {
+				return "", err
+			}
+			continue
+		}
+		f, err := os.Open(file.path)
+		if err != nil {
+			return "", err
+		}
+		_, copyErr := io.Copy(h, f)
+		closeErr := f.Close()
+		if copyErr != nil {
+			return "", copyErr
+		}
+		if closeErr != nil {
+			return "", closeErr
+		}
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func validSHA256Digest(value string) bool {
+	if !strings.HasPrefix(value, "sha256:") || len(value) != len("sha256:")+sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(strings.TrimPrefix(value, "sha256:"))
+	return err == nil
+}

--- a/internal/oci/extract.go
+++ b/internal/oci/extract.go
@@ -28,3 +28,11 @@ func extractLayer(r io.Reader, dstPath string) error {
 		tar.WithMaxUntarSize(tar.DefaultMaxUntarSize),
 		tar.WithSkipSymlinks())
 }
+
+// extractUncompressedLayer extracts an uncompressed OCI layer.
+func extractUncompressedLayer(r io.Reader, dstPath string) error {
+	return tar.Untar(r, dstPath,
+		tar.WithMaxUntarSize(tar.DefaultMaxUntarSize),
+		tar.WithSkipGzip(),
+		tar.WithSkipSymlinks())
+}

--- a/internal/oci/local_module.go
+++ b/internal/oci/local_module.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/fluxcd/pkg/tar"
+	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+
+	apiv1 "github.com/stefanprodan/timoni/api/v1alpha1"
+)
+
+// LocalModuleMetadata returns the semantic version and manifest digest of a
+// local Timoni module archive or OCI image layout.
+func LocalModuleMetadata(source string) (string, string, error) {
+	_, cleanup, _, version, digest, err := localModule(source)
+	if err != nil {
+		return "", "", err
+	}
+	if err := cleanup(); err != nil {
+		return "", "", err
+	}
+	return version, digest, nil
+}
+
+// PullLocalModule extracts a local Timoni module archive or OCI image layout
+// into dstPath and returns its manifest metadata.
+func PullLocalModule(source, dstPath string) (*apiv1.ModuleReference, error) {
+	image, cleanup, manifest, version, digest, err := localModule(source)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cleanup() }()
+
+	layers, err := image.Layers()
+	if err != nil {
+		return nil, fmt.Errorf("reading module layers failed: %w", err)
+	}
+	for i, descriptor := range manifest.Layers {
+		if descriptor.MediaType != apiv1.ContentMediaType {
+			continue
+		}
+		reader, err := layers[i].Uncompressed()
+		if err != nil {
+			return nil, fmt.Errorf("reading module layer %d failed: %w", i, err)
+		}
+		extractErr := extractUncompressedLayer(reader, dstPath)
+		closeErr := reader.Close()
+		if extractErr != nil {
+			return nil, fmt.Errorf("extracting module layer %d failed: %w", i, extractErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("closing module layer %d failed: %w", i, closeErr)
+		}
+	}
+
+	return &apiv1.ModuleReference{
+		Version:     version,
+		Digest:      digest,
+		Annotations: manifest.Annotations,
+	}, nil
+}
+
+func localModule(source string) (gcrv1.Image, func() error, *gcrv1.Manifest, string, string, error) {
+	image, cleanup, err := imageFromLocalArtifact(source)
+	if err != nil {
+		return nil, nil, nil, "", "", err
+	}
+	fail := func(err error) (gcrv1.Image, func() error, *gcrv1.Manifest, string, string, error) {
+		_ = cleanup()
+		return nil, nil, nil, "", "", err
+	}
+	manifest, err := image.Manifest()
+	if err != nil {
+		return fail(fmt.Errorf("reading artifact manifest failed: %w", err))
+	}
+	version := manifest.Annotations[apiv1.VersionAnnotation]
+	if err := validateModuleManifest(manifest, version); err != nil {
+		return fail(err)
+	}
+	digest, err := image.Digest()
+	if err != nil {
+		return fail(fmt.Errorf("calculating artifact digest failed: %w", err))
+	}
+	return image, cleanup, manifest, version, digest.String(), nil
+}
+
+// imageFromLocalArtifact loads the first image from an OCI archive or layout.
+func imageFromLocalArtifact(source string) (gcrv1.Image, func() error, error) {
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil, nil, fmt.Errorf("module artifact not found at path %s", source)
+	}
+	if info.IsDir() {
+		return imageFromLayoutPath(source)
+	}
+
+	tmpDir, err := os.MkdirTemp("", apiv1.FieldManager)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := func() error { return os.RemoveAll(tmpDir) }
+	archive, err := os.Open(source)
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("opening OCI archive failed: %w", err)
+	}
+	defer archive.Close()
+	if err := untarLocalArchive(archive, tmpDir); err != nil {
+		_ = cleanup()
+		return nil, nil, err
+	}
+	image, _, err := imageFromLayoutPath(tmpDir)
+	if err != nil {
+		_ = cleanup()
+		return nil, nil, err
+	}
+	return image, cleanup, nil
+}
+
+func untarLocalArchive(r io.Reader, dst string) error {
+	if err := tar.Untar(r, dst, tar.WithSkipGzip(), tar.WithSkipSymlinks()); err != nil {
+		return fmt.Errorf("extracting OCI archive failed: %w", err)
+	}
+	return nil
+}
+
+func imageFromLayoutPath(source string) (gcrv1.Image, func() error, error) {
+	layoutPath, err := layout.FromPath(source)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening OCI layout failed: %w", err)
+	}
+	index, err := layoutPath.ImageIndex()
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading OCI layout failed: %w", err)
+	}
+	manifest, err := index.IndexManifest()
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading OCI layout failed: %w", err)
+	}
+	if len(manifest.Manifests) == 0 {
+		return nil, nil, fmt.Errorf("no image found in OCI layout")
+	}
+	image, err := index.Image(manifest.Manifests[0].Digest)
+	if err != nil {
+		return nil, nil, err
+	}
+	return image, func() error { return nil }, nil
+}

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author: Stefan Prodan
   homepage: https://timoni.sh
   source: https://github.com/stefanprodan/timoni
-  version: "0.4.0"
+  version: "0.5.0"
 ---
 
 # Timoni
@@ -72,6 +72,7 @@ below.
 | Apply | `timoni bundle apply -f bundle.cue [-f bundle_secrets.cue]` |
 | Render to files | `timoni bundle build -f bundle.cue --output-dir ./manifests` |
 | Render to stdout without Secret values | `timoni bundle build -f bundle.cue --mask-secrets` |
+| Update references and render atomically | `timoni bundle build --update -f bundle.cue [--local-index index.cue] [--oci oci://<repo>=<path>]` |
 | Status | `timoni bundle status -f bundle.cue` or `timoni bundle status <name>` |
 | Delete | `timoni bundle delete -f bundle.cue` or `timoni bundle delete <name>` |
 | Update module versions per policy | `timoni bundle update -f bundle.cue [--level patch\|minor\|major]` |
@@ -189,6 +190,12 @@ bundle: {
   artifact digest before planning and fetching, then rewrites the selected
   source to `file://`. `--oci` works independently of `--local-index`, and
   bundles may mix remote OCI, local OCI, and mutable local sources.
+- To update and render in one transaction, use `timoni bundle build --update`
+  with `--local-index` and/or repeatable `--oci` mappings. Timoni plans and
+  verifies the selected sources, then vets and builds from the same in-memory
+  inputs. It writes the bundle files and exposes rendered stdout only after both
+  succeed. Ordinary `bundle build` and `bundle update` remain unchanged. The
+  combined command rejects `-f -` and `--output-dir`.
 - Split a bundle across files and merge with repeated `-f` (for example a
   `bundle_secrets.cue` kept out of git or piped from stdin with `-f -`).
   SOPS-encrypted YAML/JSON partials:
@@ -206,8 +213,9 @@ bundle: {
   `--oci oci://repository=path` for local OCI artifacts; each is an explicit
   source authority, and the selected source is verified again when the bundle
   is built.
-  Run `timoni bundle vet` and `timoni bundle build` afterwards. The update
-  does not validate values against the new module schema.
+  For update-only workflows, run `timoni bundle vet` and `timoni bundle build`
+  afterwards. The update command does not validate values against the new module
+  schema.
 
 ## Runtimes and multi-cluster
 

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author: Stefan Prodan
   homepage: https://timoni.sh
   source: https://github.com/stefanprodan/timoni
-  version: "0.5.0"
+  version: "0.6.0"
 ---
 
 # Timoni
@@ -75,7 +75,7 @@ below.
 | Update references and render atomically | `timoni bundle build --update -f bundle.cue [--local-index index.cue] [--oci oci://<repo>=<path>]` |
 | Status | `timoni bundle status -f bundle.cue` or `timoni bundle status <name>` |
 | Delete | `timoni bundle delete -f bundle.cue` or `timoni bundle delete <name>` |
-| Update module versions per policy | `timoni bundle update -f bundle.cue [--level patch\|minor\|major]` |
+| Update module versions per policy | `timoni bundle update -f bundle.cue [--level patch\|minor\|major] [--vet]` |
 | Preview module updates | `timoni bundle update -f bundle.cue --dry-run` (prints `old -> new` per instance, writes nothing) |
 | With a runtime | add `-r runtime.cue`; select with `--runtime-cluster <name>` / `--runtime-group <group>` |
 | Runtime values from CI env vars | add `--runtime-from-env` |
@@ -213,9 +213,10 @@ bundle: {
   `--oci oci://repository=path` for local OCI artifacts; each is an explicit
   source authority, and the selected source is verified again when the bundle
   is built.
-  For update-only workflows, run `timoni bundle vet` and `timoni bundle build`
-  afterwards. The update command does not validate values against the new module
-  schema.
+  Add `--vet` to validate the staged bundle before writing updates; combine it
+  with `--dry-run` to validate without writing. This checks the
+  bundle definition but not module values against the new module schema.
+  For full update, vet, and render atomicity, use `timoni bundle build --update`.
 
 ## Runtimes and multi-cluster
 

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -72,7 +72,7 @@ below.
 | Apply | `timoni bundle apply -f bundle.cue [-f bundle_secrets.cue]` |
 | Render to files | `timoni bundle build -f bundle.cue --output-dir ./manifests` |
 | Render to stdout without Secret values | `timoni bundle build -f bundle.cue --mask-secrets` |
-| Update references and render atomically | `timoni bundle build --update -f bundle.cue [--local-index index.cue] [--oci oci://<repo>=<path>]` |
+| Update references and render in one transaction | `timoni bundle build --update -f bundle.cue [--local-index index.cue] [--oci oci://<repo>=<path>]` |
 | Status | `timoni bundle status -f bundle.cue` or `timoni bundle status <name>` |
 | Delete | `timoni bundle delete -f bundle.cue` or `timoni bundle delete <name>` |
 | Update module versions per policy | `timoni bundle update -f bundle.cue [--level patch\|minor\|major] [--vet]` |
@@ -216,7 +216,7 @@ bundle: {
   Add `--vet` to validate the staged bundle before writing updates; combine it
   with `--dry-run` to validate without writing. This checks the
   bundle definition but not module values against the new module schema.
-  For full update, vet, and render atomicity, use `timoni bundle build --update`.
+  For the full staged update, vet, and render workflow, use `timoni bundle build --update`.
 
 ## Runtimes and multi-cluster
 

--- a/skills/timoni/SKILL.md
+++ b/skills/timoni/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author: Stefan Prodan
   homepage: https://timoni.sh
   source: https://github.com/stefanprodan/timoni
-  version: "0.3.0"
+  version: "0.4.0"
 ---
 
 # Timoni
@@ -170,8 +170,25 @@ bundle: {
   deterministic retrieval.
 - Local modules in a bundle use `module: url: "file://../modules/app"`,
   relative to the bundle file, or an absolute path as
-  `file:///abs/path/to/module`; `version`/`digest` are ignored and the
-  instance gets version `0.0.0-devel`.
+  `file:///abs/path/to/module`; ordinary local references ignore `version` and
+  `digest` and the instance gets version `0.0.0-devel`. Indexed local updates
+  are the reproducible exception: they carry the indexed version and verify
+  the source-tree digest during rendering.
+- `timoni bundle update` can update extracted local modules with
+  `--local-index <index.cue>`. The index maps exact `oci://` identities and
+  semantic versions to `file://` sources pinned by a `sha256:<64 hex>` digest;
+  the client hashes regular files and symlink target strings, and rejects
+  other special files. A matching OCI reference may switch to its indexed local
+  source; other OCI references keep the registry fallback. The digest is a
+  source-tree digest for indexed local modules and an artifact digest for OCI
+  modules. The updater verifies the current and selected sources before
+  rewriting `url`, `version`, and `digest`.
+- For a local OCI archive or image layout, use repeatable
+  `--oci oci://repository=path` mappings. The repository must be explicit;
+  path-only inputs are rejected. Timoni verifies the manifest version and
+  artifact digest before planning and fetching, then rewrites the selected
+  source to `file://`. `--oci` works independently of `--local-index`, and
+  bundles may mix remote OCI, local OCI, and mutable local sources.
 - Split a bundle across files and merge with repeated `-f` (for example a
   `bundle_secrets.cue` kept out of git or piped from stdin with `-f -`).
   SOPS-encrypted YAML/JSON partials:
@@ -185,8 +202,12 @@ bundle: {
   digests according to the `@timoni(update:semver:<constraint>|digest|none)`
   attribute on the `version` field; `--level patch|minor|major` updates the
   references without an attribute, and `--dry-run` only prints the changes.
-  Run `timoni bundle vet` and `timoni bundle build` afterwards, the update
-  does not validate the values against the new module schema.
+  Add `--local-index <index.cue>` for extracted local modules or
+  `--oci oci://repository=path` for local OCI artifacts; each is an explicit
+  source authority, and the selected source is verified again when the bundle
+  is built.
+  Run `timoni bundle vet` and `timoni bundle build` afterwards. The update
+  does not validate values against the new module schema.
 
 ## Runtimes and multi-cluster
 


### PR DESCRIPTION
## What

Add two independent local-source modes to `timoni bundle update`, plus an opt-in atomic update-and-render workflow:

1. `--local-index` maps exact OCI module identities and semantic versions to extracted `file://` sources with pinned SHA-256 source-tree digests. The updater verifies the selected source before planning, rewrites the source, version, and digest together, and passes the digest through bundle apply so local fetches are verified again before rendering.
2. Repeatable `--oci oci://repository=path` mappings select local OCI archives or image layouts. Timoni verifies the manifest version and artifact digest before planning and fetching, then rewrites the selected source to a canonical `file://` path.
3. `bundle build --update` stages the selected changes in memory, vets and builds those staged inputs, buffers rendered stdout, and writes bundle files only after validation succeeds. Ordinary `bundle build` and `bundle update` behavior remains unchanged; the atomic mode rejects `-f -` and `--output-dir`.

The local-source modes work independently and may be combined intentionally. A bundle may mix remote OCI references, local OCI artifacts, and ordinary mutable local modules. With `--local-index`, a matching OCI reference may switch to its indexed local source; an unindexed OCI reference keeps the registry fallback.

## Why

Local modules were skipped because a filesystem path does not prove which published module and version it represents. The explicit index supplies that authority while deterministic hashing detects stale or tampered sources. Regular files and symlink target strings are hashed; other special files are rejected. Local OCI mappings supply the missing repository identity explicitly because an archive or image layout contains its version and artifact digest, but not the registry repository name.

## Minimal reproductions

### 1. Update an extracted local module with `--local-index`

Before this change, a `file://` reference was skipped because it did not carry a published OCI identity:

```cue
module: url: "file://../modules/app"
```

```console
$ timoni bundle update -f bundle.cue --dry-run
file:// instance -> skipped: module is not an OCI artifact
```

The workaround was to replace the checkout with the desired extracted archive:

```console
$ tar -xf app.tar -C ../modules/app
$ timoni mod vet ../modules/app --name app --namespace app
$ timoni bundle vet --runtime-from-env -f bundle.cue
$ timoni bundle build --runtime-from-env --mask-secrets -f bundle.cue > render.yaml
$ less render.yaml
```

Use an explicit index beside the extracted module sources; this branch intentionally does not generate it.

```cue
modules: {
	"oci://registry.io/app": versions: {
		"1.1.0": {
			source: "file://../modules/app-1.1.0"
			digest: "sha256:<64-hex-digest>"
		}
	}
}
```

Replace `<64-hex-digest>` with the source-tree digest, then run the update first as a dry run and apply it:

```console
$ timoni bundle update --local-index module-index.cue -f bundle.cue --dry-run
# reports the source, version, and digest transition without writing
$ timoni bundle update --local-index module-index.cue -f bundle.cue
```

The index supplies the OCI identity, semantic version, source path, and source-tree digest. The updater selects and rewrites all three bundle literals together, and the shared fetcher verifies the selected source again before rendering. Run the normal `bundle vet` and `bundle build` commands afterward, or use the atomic workflow below.

Relative sources resolve from the index file; filesystem paths never determine the OCI identity. A source mutation, missing source, invalid special file, or digest mismatch causes the update to fail before the bundle changes. The required invariant is:

```text
indexed version/digest -> selected source -> rendered selected module
```

### 2. Update directly from a local OCI artifact with `--oci`

Use the artifact itself as the source and map it explicitly to its repository:

```console
$ timoni bundle update --oci oci://registry.io/app=app.oci.tar -f bundle.cue --dry-run
# verifies the local artifact and reports the available update without writing
$ timoni bundle update --oci oci://registry.io/app=app.oci.tar -f bundle.cue
```

The `--oci` mapping also accepts an OCI image-layout directory and is repeatable for multiple repositories. Path-only inputs are rejected because Timoni never infers an OCI identity from a filename or argument order. The manifest version and artifact digest are checked before planning and again when the selected artifact is fetched for rendering. This mode works without `--local-index`, just as the indexed-source mode works without `--oci`; use the normal vet/build steps afterward or the atomic workflow below.

### 3. Update and render atomically with `bundle build --update`

The update-only workflow still leaves validation and rendering as separate commands:

```console
$ timoni bundle update --local-index module-index.cue -f bundle.cue
$ timoni bundle vet -f bundle.cue
$ timoni bundle build -f bundle.cue --mask-secrets
```

When the build is the desired target, the opt-in transaction combines those steps while consuming the same staged source selection:

```console
$ timoni bundle build --update --local-index module-index.cue -f bundle.cue --runtime-from-env --mask-secrets
$ timoni bundle build --update --oci oci://registry.io/app=app.oci.tar -f bundle.cue --runtime-from-env --mask-secrets
```

The command loads only explicitly authorized local sources, plans and verifies the selected versions, stages the updated CUE files in memory, runs vet and build against those staged inputs, and buffers rendered stdout. It writes the changed bundle files and exposes the render output only after every step succeeds. If planning, source verification, vet, build, render, or the final multi-file write fails, the original bundle files remain byte-for-byte unchanged. The workflow does not apply anything to a cluster or publish to a registry.

## Verification

```shell
go test ./internal/engine/... ./internal/oci -count=1
go test ./cmd/timoni -run '^(Test_BundleUpdate|Test_BundleUpdateLocalOCI|Test_BundleBuildUpdateMixedLocalSources)$' -count=1
go test ./... -count=1
```

The focused and black-box suites cover indexed version selection, digest verification, cache-hit revalidation, symlink target changes, imported CUE package files, dry-run behavior, OCI-to-local substitution, local rendering, mixed local-source updates, CLI validation, and the existing OCI path.